### PR TITLE
Isolate Codex homes per agent

### DIFF
--- a/scripts/rollback_codex_home.py
+++ b/scripts/rollback_codex_home.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Move cwd-matched rollouts from an isolated Codex home back to shared."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from pinky_daemon.codex_home import (
+    per_agent_codex_home_enabled,
+    rollback_agent_rollouts,
+)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Move one working directory's Codex rollouts back to the shared "
+            "user-level session store after disabling per-agent homes."
+        )
+    )
+    parser.add_argument("working_dir", type=Path)
+    parser.add_argument(
+        "--agent-home",
+        type=Path,
+        help="isolated CODEX_HOME (default: <working_dir>/.codex)",
+    )
+    parser.add_argument(
+        "--shared-home",
+        type=Path,
+        help="shared CODEX_HOME (default: CODEX_HOME or ~/.codex)",
+    )
+    args = parser.parse_args()
+
+    if per_agent_codex_home_enabled():
+        parser.error(
+            "disable PINKY_CODEX_PER_AGENT_HOME before moving rollouts back"
+        )
+
+    working_dir = args.working_dir.expanduser().resolve()
+    agent_home = (
+        args.agent_home.expanduser().resolve()
+        if args.agent_home is not None
+        else working_dir / ".codex"
+    )
+    moved = rollback_agent_rollouts(
+        working_dir,
+        agent_home,
+        shared_home=args.shared_home,
+        log=print,
+    )
+    print(f"moved={moved}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -496,6 +496,7 @@ class Agent:
     provider_key: str = ""   # API key override, empty = use ANTHROPIC_API_KEY env var
     provider_model: str = ""  # model name override (e.g. "llama3.2"), empty = use agent.model
     provider_ref: str = ""   # ID of a global provider from the providers table
+    codex_home: str = ""  # Explicit per-agent CODEX_HOME override (flag-gated)
     thinking_effort: str = "medium"  # low, medium, high, xhigh, max, ultracode — default thinking depth
     # ``ultracode`` (#151): xhigh reasoning + standing workflow orchestration.
     # Resolves to xhigh for the actual effort knob (the CLI flag rejects the
@@ -576,6 +577,7 @@ class Agent:
             "provider_key_set": bool(self.provider_key),
             "provider_model": self.provider_model,
             "provider_ref": self.provider_ref,
+            "codex_home": self.codex_home,
             "thinking_effort": self.thinking_effort,
             "strict_effort_enforcement": self.strict_effort_enforcement,
             "dedicated_config_dir": self.dedicated_config_dir,
@@ -1827,6 +1829,8 @@ class AgentRegistry:
             # Operator-supplied container image for isolation_mode="container".
             # Empty for other modes; bring-your-own (Pinky never builds it).
             ("container_image", "TEXT NOT NULL DEFAULT ''"),
+            # Explicit per-agent CODEX_HOME. Inert unless the isolation flag is on.
+            ("codex_home", "TEXT NOT NULL DEFAULT ''"),
         ]
         for col, typedef in migrations:
             if col not in existing:
@@ -2649,6 +2653,7 @@ except Exception as exc:
                     "dream_enabled", "dream_schedule", "dream_timezone", "dream_model", "dream_notify",
                     "librarian_enabled", "librarian_schedule",
                     "runtime", "transport", "provider_url", "provider_model", "provider_ref",
+                    "codex_home",
                     "thinking_effort", "strict_effort_enforcement",
                     "dedicated_config_dir", "isolated",
                     "isolation_mode", "container_image"):
@@ -2783,6 +2788,7 @@ except Exception as exc:
                 provider_key=kwargs.get("provider_key", ""),
                 provider_model=kwargs.get("provider_model", ""),
                 provider_ref=kwargs.get("provider_ref", ""),
+                codex_home=kwargs.get("codex_home", ""),
                 thinking_effort=kwargs.get("thinking_effort", "medium"),
                 strict_effort_enforcement=kwargs.get("strict_effort_enforcement", False),
                 dedicated_config_dir=kwargs.get("dedicated_config_dir", False),
@@ -2802,10 +2808,11 @@ except Exception as exc:
                     dream_enabled, dream_schedule, dream_timezone, dream_model, dream_notify,
                     librarian_enabled, librarian_schedule,
                     runtime, transport, provider_url, provider_key, provider_model, provider_ref,
+                    codex_home,
                     thinking_effort, strict_effort_enforcement, dedicated_config_dir,
                     watchdog_config,
                     created_at, updated_at)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (agent.name, agent.display_name, agent.model, agent.soul,
                  agent.users, agent.boundaries,
                  agent.system_prompt, agent.working_dir, agent.permission_mode,
@@ -2822,6 +2829,7 @@ except Exception as exc:
                  int(agent.librarian_enabled), agent.librarian_schedule,
                  agent.runtime, agent.transport, agent.provider_url, agent.provider_key,
                  agent.provider_model, agent.provider_ref,
+                 agent.codex_home,
                  agent.thinking_effort, int(agent.strict_effort_enforcement),
                  int(agent.dedicated_config_dir),
                  json.dumps(agent.watchdog_config),
@@ -2862,7 +2870,7 @@ except Exception as exc:
         "runtime, transport, provider_url, provider_key, provider_model, provider_ref, "
         "disallowed_tools, thinking_effort, watchdog_config, last_seen_at, "
         "strict_effort_enforcement, context_nudge_threshold_pct, isolated, "
-        "isolation_mode, container_image, dedicated_config_dir"
+        "isolation_mode, container_image, dedicated_config_dir, codex_home"
     )
 
     def get(self, name: str) -> Agent | None:
@@ -7040,6 +7048,7 @@ except Exception as exc:
             isolation_mode=row[52] if len(row) > 52 and row[52] else "local",
             container_image=row[53] if len(row) > 53 and row[53] else "",
             dedicated_config_dir=bool(row[54]) if len(row) > 54 else False,
+            codex_home=row[55] if len(row) > 55 and row[55] else "",
         )
 
     # ── Cost Tracking ──────────────────────────────────────

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -126,6 +126,7 @@ from pinky_daemon.auth import (
 )
 from pinky_daemon.autonomy import AgentEvent, AutonomyEngine, EventType
 from pinky_daemon.broker import BrokerMessage, MessageBroker
+from pinky_daemon.codex_home import codex_home_for
 from pinky_daemon.context_window import resolve_context_window
 from pinky_daemon.conversation_store import ConversationStore
 from pinky_daemon.dream_runner import DreamRunner
@@ -3803,6 +3804,7 @@ def create_api(
             subagents=subagents,
             provider_url=resolved_provider_url,
             provider_key=resolved_provider_key,
+            codex_home=getattr(agent, "codex_home", "") or "",
             thinking_effort=agent.thinking_effort or "medium",
             strict_effort_enforcement=bool(
                 getattr(agent, "strict_effort_enforcement", False)
@@ -6364,6 +6366,7 @@ npm run build</pre>
             provider_key=req.provider_key,
             provider_model=req.provider_model,
             provider_ref=req.provider_ref,
+            codex_home=req.codex_home,
             thinking_effort=req.thinking_effort,
             strict_effort_enforcement=req.strict_effort_enforcement,
             dedicated_config_dir=req.dedicated_config_dir,
@@ -6810,12 +6813,7 @@ npm run build</pre>
         allowed_roots = [(Path.home() / ".claude" / "projects").resolve()]
         # #215: codex tmux agents tail rollouts under the codex session store
         # (``$CODEX_HOME/sessions`` or ``~/.codex/sessions``), not ~/.claude.
-        _codex_home = os.environ.get("CODEX_HOME", "").strip()
-        allowed_roots.append(
-            (Path(_codex_home) / "sessions").resolve()
-            if _codex_home
-            else (Path.home() / ".codex" / "sessions").resolve()
-        )
+        allowed_roots.append((codex_home_for(agent) / "sessions").resolve())
         if getattr(agent, "isolation_mode", "local") == "container":
             wd = (agent.working_dir or "").strip()
             if wd and Path(wd).is_absolute():

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -9339,32 +9339,29 @@ npm run build</pre>
                 pass
 
             try:
-                # Arm fresh-launch intent BEFORE disconnect.  If a
-                # broker/watchdog wake races the teardown's transient DEAD
-                # state, its launch must inherit the force-fresh contract
-                # rather than resume the old transcript.
-                _refresh_streaming_launch_config(name, ss)
-                ss._config.wake_context = _build_streaming_wake_context(
-                    name, commit=False
-                )
-                ss._config.resume_handle = ""
-                ss._config.restart_reason = "context_restart"
-                # PR for #543: explicit launch-behavior contract — the next
-                # transport spawn must NOT resume the prior conversation.
-                ss._config.force_fresh_context_once = True
-                ss.resume_handle = ""
-                # Codex sessions track thread_id separately on the session.
-                if hasattr(ss, "codex_session_id"):
-                    if ss.codex_session_id:
-                        _log(
-                            f"api: clearing stale codex thread "
-                            f"{ss.codex_session_id[:12]} for {name}"
-                        )
-                    ss.codex_session_id = ""
+                def _configure_context_restart() -> None:
+                    # This callback runs inside restart_transport only after its
+                    # replacement preflight succeeds, but before teardown. A
+                    # racing wake therefore inherits force-fresh intent without
+                    # a refusal corrupting the still-live transport.
+                    _refresh_streaming_launch_config(name, ss)
+                    ss._config.wake_context = _build_streaming_wake_context(
+                        name, commit=False
+                    )
+                    ss._config.resume_handle = ""
+                    ss._config.restart_reason = "context_restart"
+                    ss._config.force_fresh_context_once = True
+                    ss.resume_handle = ""
+                    if hasattr(ss, "codex_session_id"):
+                        if ss.codex_session_id:
+                            _log(
+                                f"api: clearing stale codex thread "
+                                f"{ss.codex_session_id[:12]} for {name}"
+                            )
+                        ss.codex_session_id = ""
+                    agents.set_streaming_session_id(name, "", label="main")
 
-                await ss.disconnect()
-                agents.set_streaming_session_id(name, "", label="main")
-                await ss.connect()
+                await ss.restart_transport(configure=_configure_context_restart)
                 _log(f"api: streaming session restarted for {name}")
                 activity.log(
                     name, "context_restart", f"{name} context restarted"
@@ -9514,10 +9511,6 @@ npm run build</pre>
             if not guard["restart_safe"]:
                 raise HTTPException(409, _guard_message("restart", guard))
 
-            # Persist only once the restart is actually going ahead, so a 409
-            # above leaves the DB matching the still-running session.
-            agents.register(name, model=req.model)
-
             # Ask agent to save state
             try:
                 await ss._client.query(
@@ -9530,21 +9523,27 @@ npm run build</pre>
             # Restart streaming session
             old_resume_handle = ss.resume_handle
             old_turns = ss._stats["turns"]
-            await ss.disconnect()
-            agents.set_streaming_session_id(name, "", label="main")
-            ss._config.resume_handle = ""
-            ss.resume_handle = ""
-            if hasattr(ss, "codex_session_id"):
-                if ss.codex_session_id:
-                    _log(f"api: clearing stale codex thread {ss.codex_session_id[:12]} for {name}")
-                ss.codex_session_id = ""
-            # This is a retained-object rebuild, so refresh every durable
-            # launch setting (not just the newly-persisted model). Provider,
-            # effort, and Codex's transport-level caches may have changed in
-            # the registry since the object was constructed.
-            _refresh_streaming_launch_config(name, ss)
+
+            def _configure_model_restart() -> None:
+                # Persist and mutate the retained object only after the common
+                # replacement preflight has protected the live transport.
+                agents.register(name, model=req.model)
+                agents.set_streaming_session_id(name, "", label="main")
+                ss._config.resume_handle = ""
+                ss.resume_handle = ""
+                if hasattr(ss, "codex_session_id"):
+                    if ss.codex_session_id:
+                        _log(
+                            f"api: clearing stale codex thread "
+                            f"{ss.codex_session_id[:12]} for {name}"
+                        )
+                    ss.codex_session_id = ""
+                # Refresh every durable launch setting, including provider,
+                # effort, and backend-specific transport caches.
+                _refresh_streaming_launch_config(name, ss)
+
             try:
-                await ss.connect()
+                await ss.restart_transport(configure=_configure_model_restart)
                 _log(f"api: restarted {name} with model {req.model}")
             except Exception as e:
                 broker.unregister_streaming(name)
@@ -9621,19 +9620,24 @@ npm run build</pre>
         old_resume_handle = ss.resume_handle
         old_turns = ss._stats["turns"]
 
-        await ss.disconnect()
-        agents.set_streaming_session_id(name, "", label="main")
+        def _configure_archive_restart() -> None:
+            agents.set_streaming_session_id(name, "", label="main")
+            ss._config.wake_context = _build_streaming_wake_context(
+                name, commit=False
+            )
+            _refresh_streaming_launch_config(name, ss)
+            ss._config.resume_handle = ""
+            ss.resume_handle = ""
+            if hasattr(ss, "codex_session_id"):
+                if ss.codex_session_id:
+                    _log(
+                        f"api: clearing stale codex thread "
+                        f"{ss.codex_session_id[:12]} for {name}"
+                    )
+                ss.codex_session_id = ""
 
-        ss._config.wake_context = _build_streaming_wake_context(name, commit=False)
-        _refresh_streaming_launch_config(name, ss)
-        ss._config.resume_handle = ""
-        ss.resume_handle = ""
-        if hasattr(ss, "codex_session_id"):
-            if ss.codex_session_id:
-                _log(f"api: clearing stale codex thread {ss.codex_session_id[:12]} for {name}")
-            ss.codex_session_id = ""
         try:
-            await ss.connect()
+            await ss.restart_transport(configure=_configure_archive_restart)
             _log(f"api: archived and restarted session for {name}")
         except Exception as e:
             broker.unregister_streaming(name)
@@ -11166,14 +11170,19 @@ npm run build</pre>
             sessions = broker._streaming.get(agent_name, {})
             ss = sessions.get(label)
             if ss:
-                try:
-                    await ss.disconnect()
-                except Exception:
-                    pass
-                agents.set_streaming_session_id(agent_name, "", label=label)
-                broker.unregister_streaming(agent_name, label=label)
-            await asyncio.sleep(2)
-            await _ensure_streaming_session(agent_name, label=label)
+                async def _rebuild_watchdog_transport() -> None:
+                    agents.set_streaming_session_id(agent_name, "", label=label)
+                    broker.unregister_streaming(agent_name, label=label)
+                    await asyncio.sleep(2)
+                    await _ensure_streaming_session(agent_name, label=label)
+
+                await ss.restart_transport(
+                    bring_up=_rebuild_watchdog_transport,
+                    suppress_teardown_errors=True,
+                )
+            else:
+                await asyncio.sleep(2)
+                await _ensure_streaming_session(agent_name, label=label)
             _log(f"watchdog: {agent_name}/{label} recovered successfully")
         except Exception as exc:
             _log(f"watchdog: recovery failed for {agent_name}/{label}: {exc}")
@@ -11441,32 +11450,38 @@ npm run build</pre>
             title=f"Watchdog MCP-recover ({label}): {reason}",
             metadata=audit_meta,
         )
-        try:
-            await ss.disconnect()
-        except Exception:
-            pass
-        agents.set_streaming_session_id(agent_name, "", label=label)
-        # The agent couldn't refresh save_my_context (its MCP was dead) — bump
-        # so any context-staleness gate is satisfied; preserve saved state.
-        try:
-            agents.bump_context_updated_at(agent_name)
-        except Exception:
-            pass
-        ss._config.wake_context = _build_streaming_wake_context(agent_name, commit=False)
-        _refresh_streaming_launch_config(agent_name, ss)
-        ss._config.resume_handle = ""
-        ss._config.restart_reason = "mcp_epoch_unbound"
-        ss._config.force_fresh_context_once = True
-        ss.resume_handle = ""
-        if hasattr(ss, "codex_session_id"):
-            ss.codex_session_id = ""
-        try:
+
+        def _configure_mcp_recovery() -> None:
+            agents.set_streaming_session_id(agent_name, "", label=label)
+            # The agent couldn't refresh save_my_context (its MCP was dead) —
+            # bump so any context-staleness gate is satisfied; preserve state.
+            try:
+                agents.bump_context_updated_at(agent_name)
+            except Exception:
+                pass
+            ss._config.wake_context = _build_streaming_wake_context(
+                agent_name, commit=False
+            )
+            _refresh_streaming_launch_config(agent_name, ss)
+            ss._config.resume_handle = ""
+            ss._config.restart_reason = "mcp_epoch_unbound"
+            ss._config.force_fresh_context_once = True
+            ss.resume_handle = ""
+            if hasattr(ss, "codex_session_id"):
+                ss.codex_session_id = ""
+
+        async def _connect_mcp_recovery(connect) -> None:
             # #202: a force-fresh MCP recovery boots a brand-new `claude`, so
-            # serialize it behind the cold-start gate too — it's globally
-            # rate-limited, but can still overlap a daemon cold boot / manual
-            # cold start and race the shared single-use OAuth refresh token.
+            # serialize it behind the cold-start gate too.
             async with _coldstart_gate(agent_name, label):
-                await ss.connect()
+                await connect()
+
+        try:
+            await ss.restart_transport(
+                configure=_configure_mcp_recovery,
+                connect_wrapper=_connect_mcp_recovery,
+                suppress_teardown_errors=True,
+            )
             session_event_store.log(
                 session_id=ss.id,
                 agent_name=agent_name,
@@ -12601,22 +12616,23 @@ npm run build</pre>
         old_resume_handle = ss.resume_handle
         old_turns = ss._stats["turns"]
 
-        await ss.disconnect()
-        agents.set_streaming_session_id(name, "", label="main")
-
-        ss._config.wake_context = _build_streaming_wake_context(name, commit=False)
-        _refresh_streaming_launch_config(name, ss)
-        ss._config.resume_handle = ""
-        ss._config.restart_reason = "force_restart"
-        ss._config.force_fresh_context_once = True
-        ss.resume_handle = ""
-        if hasattr(ss, "codex_session_id"):
-            if ss.codex_session_id:
-                _log(
-                    f"api: clearing stale codex thread {ss.codex_session_id[:12]} "
-                    f"for {name} (force-restart)"
-                )
-            ss.codex_session_id = ""
+        def _configure_forced_restart() -> None:
+            agents.set_streaming_session_id(name, "", label="main")
+            ss._config.wake_context = _build_streaming_wake_context(
+                name, commit=False
+            )
+            _refresh_streaming_launch_config(name, ss)
+            ss._config.resume_handle = ""
+            ss._config.restart_reason = "force_restart"
+            ss._config.force_fresh_context_once = True
+            ss.resume_handle = ""
+            if hasattr(ss, "codex_session_id"):
+                if ss.codex_session_id:
+                    _log(
+                        f"api: clearing stale codex thread "
+                        f"{ss.codex_session_id[:12]} for {name} (force-restart)"
+                    )
+                ss.codex_session_id = ""
 
         audit_meta = {
             "label": "main",
@@ -12628,7 +12644,7 @@ npm run build</pre>
             "source": "force_restart_endpoint",
         }
         try:
-            await ss.connect()
+            await ss.restart_transport(configure=_configure_forced_restart)
             _log(
                 f"api: FORCE-restarted streaming session for {name} "
                 f"(heartbeat_age={heartbeat_age_sec}s, "

--- a/src/pinky_daemon/api_models.py
+++ b/src/pinky_daemon/api_models.py
@@ -342,6 +342,7 @@ class RegisterAgentRequest(BaseModel):
     provider_key: str = ""  # ANTHROPIC_API_KEY override
     provider_model: str = ""  # Model name override for this provider
     provider_ref: str = ""  # ID of a global provider from the providers table
+    codex_home: str = ""  # Explicit per-agent CODEX_HOME override (flag-gated)
     thinking_effort: str = "medium"  # low/medium/high/xhigh/max/ultracode
     strict_effort_enforcement: bool = False  # PR #429 — block tool calls when effort drifts
     # #550/Picard — opt-in: a LOCAL agent runs its own Claude account via a
@@ -426,6 +427,7 @@ class UpdateAgentRequest(BaseModel):
     provider_key: str | None = None  # ANTHROPIC_API_KEY override
     provider_model: str | None = None  # Model name override for this provider
     provider_ref: str | None = None  # ID of a global provider from the providers table
+    codex_home: str | None = None  # Explicit per-agent CODEX_HOME override
     thinking_effort: str | None = None  # low/medium/high/xhigh/max/ultracode
     strict_effort_enforcement: bool | None = None  # PR #429 — block tool calls when effort drifts
     # #550/Picard — opt-in dedicated CLAUDE_CONFIG_DIR for a LOCAL agent;

--- a/src/pinky_daemon/codex_app_server_tmux.py
+++ b/src/pinky_daemon/codex_app_server_tmux.py
@@ -46,6 +46,10 @@ from pinky_daemon.codex_app_server import (
     NotificationHandler,
     ServerRequestHandler,
 )
+from pinky_daemon.codex_home import (
+    per_agent_codex_home_enabled,
+    prepare_agent_codex_home,
+)
 from pinky_daemon.command_runner import LocalCommandRunner
 from pinky_daemon.streaming_session import _log
 from pinky_daemon.tmux_session import _TmuxControl
@@ -102,11 +106,13 @@ class CodexAppServerSupervisor:
         *,
         working_dir: str,
         openai_api_key: str = "",
+        agent_config: object | None = None,
         log: Callable[[str], None] = _log,
     ) -> None:
         self.agent_name = agent_name
         self._log = log
         self._openai_api_key = openai_api_key
+        self._agent_config = agent_config
         self._sock_dir, self._sock_dir_is_tmp = self._resolve_sock_dir(agent_name, working_dir)
         self.sock_path = os.path.join(self._sock_dir, "app.sock")
         self._tmux = _TmuxControl(self.session_name, command_runner=LocalCommandRunner())
@@ -149,6 +155,7 @@ class CodexAppServerSupervisor:
         client plus its process adapter. Raises on tmux failure or readiness
         timeout. The caller (CodexSession) performs the single ``initialize``."""
         self._kill_requested = False
+        env = self._build_env()
 
         # Idempotent pre-start cleanup: a crashed predecessor can leave a live
         # tmux session and/or a stale socket; either would wedge a fresh start.
@@ -162,7 +169,7 @@ class CodexAppServerSupervisor:
             for p in [sys.executable, "-m", "pinky_daemon.codex_app_server_shim", self.sock_path]
         )
         result = await self._tmux.new_session(
-            cwd=self._sock_dir, command=command, env=self._build_env()
+            cwd=self._sock_dir, command=command, env=env
         )
         if not result.ok:
             raise RuntimeError(
@@ -219,6 +226,14 @@ class CodexAppServerSupervisor:
             env[key] = value
         if self._openai_api_key:
             env["OPENAI_API_KEY"] = self._openai_api_key
+        if per_agent_codex_home_enabled():
+            if self._agent_config is None:
+                raise RuntimeError(
+                    "per-agent Codex home requires app-server agent config"
+                )
+            env["CODEX_HOME"] = str(
+                prepare_agent_codex_home(self._agent_config, log=self._log)
+            )
         return env
 
     async def _await_accept(self) -> tuple[asyncio.StreamReader, asyncio.StreamWriter]:

--- a/src/pinky_daemon/codex_home.py
+++ b/src/pinky_daemon/codex_home.py
@@ -34,6 +34,7 @@ _MIGRATION_LOCK_ASIDE_PREFIX = ".pinkybot-rollout-lock-aside-"
 _PRESERVATION_RESERVATION_SUFFIX = ".reserve"
 _PRESERVATION_RESERVATION_STALE_SECONDS = 60 * 60
 _CLAIM_DESCRIPTOR_SCAN_TIMEOUT_SECONDS = 2.0
+_CRASH_FROZEN_CLAIM_MODE = stat.S_IRUSR | stat.S_IWUSR
 _DEFAULT_MIGRATION_LOCK_TIMEOUT_SECONDS = 10.0
 _MIGRATION_LOCK_RETRY_SECONDS = 0.05
 
@@ -293,17 +294,21 @@ def _reserve_exclusive_destination(
             reservation_fd = os.open(reservation, flags, 0o600)
         except FileExistsError:
             continue
-        os.close(reservation_fd)
-        if _path_entry_exists(destination):
-            reservation.unlink()
-            continue
         try:
-            yield destination
-        finally:
-            try:
+            fcntl.flock(reservation_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            if _path_entry_exists(destination):
                 reservation.unlink()
-            except FileNotFoundError:
-                pass
+                continue
+            try:
+                yield destination
+            finally:
+                try:
+                    reservation.unlink()
+                except FileNotFoundError:
+                    pass
+        finally:
+            fcntl.flock(reservation_fd, fcntl.LOCK_UN)
+            os.close(reservation_fd)
         return
 
 
@@ -447,7 +452,7 @@ def _sweep_migration_temps(destination_sessions: Path, log: LogFn) -> None:
 
 
 def _sweep_stale_reservations(root: Path, log: LogFn) -> None:
-    """Remove only old, empty, singly-linked migration reservation sidecars."""
+    """Remove unlocked crash or stale migration reservation sidecars."""
     if not root.exists():
         return
     stale_before = time.time() - _PRESERVATION_RESERVATION_STALE_SECONDS
@@ -462,29 +467,63 @@ def _sweep_stale_reservations(root: Path, log: LogFn) -> None:
             not stat.S_ISREG(reservation_stat.st_mode)
             or reservation_stat.st_nlink != 1
             or reservation_stat.st_size != 0
-            or reservation_stat.st_mtime > stale_before
         ):
             continue
-        try:
-            reservation.unlink()
-            log(f"codex-home: removed stale migration reservation {reservation}")
-        except FileNotFoundError:
+        destination = reservation.with_name(
+            reservation.name[1 : -len(_PRESERVATION_RESERVATION_SUFFIX)]
+        )
+        if _path_entry_exists(destination) and reservation_stat.st_mtime > stale_before:
             continue
+        nofollow = getattr(os, "O_NOFOLLOW", 0)
+        try:
+            reservation_fd = os.open(
+                reservation,
+                os.O_RDWR | nofollow | getattr(os, "O_CLOEXEC", 0),
+            )
+        except OSError:
+            continue
+        try:
+            opened_stat = os.fstat(reservation_fd)
+            if (opened_stat.st_dev, opened_stat.st_ino) != (
+                reservation_stat.st_dev,
+                reservation_stat.st_ino,
+            ):
+                continue
+            try:
+                fcntl.flock(
+                    reservation_fd,
+                    fcntl.LOCK_EX | fcntl.LOCK_NB,
+                )
+            except OSError as exc:
+                if exc.errno in (errno.EACCES, errno.EAGAIN):
+                    continue
+                raise
+            try:
+                reservation.unlink()
+            except FileNotFoundError:
+                continue
+            kind = (
+                "stale"
+                if reservation_stat.st_mtime <= stale_before
+                else "orphaned"
+            )
+            log(
+                f"codex-home: removed {kind} migration reservation {reservation}"
+            )
+        finally:
+            os.close(reservation_fd)
 
 
 def _claim_has_open_descriptors(claim: Path, log: LogFn) -> bool | None:
-    """Return holder state from lsof, retaining the claim on scan uncertainty."""
+    """Return whether any descriptor holds a claim path.
+
+    This path scan is used only to distinguish a crashed mode-000 freeze from a
+    live retirement. It deliberately includes this process: another retirer in
+    the same process is still a live holder and must keep the freeze intact.
+    """
     try:
         scan = subprocess.run(
-            [
-                "lsof",
-                "-Fn",
-                "-a",
-                "-p",
-                f"^{os.getpid()}",
-                "--",
-                os.fspath(claim),
-            ],
+            ["lsof", "-Fn", "--", os.fspath(claim)],
             stdin=subprocess.DEVNULL,
             capture_output=True,
             text=True,
@@ -530,12 +569,7 @@ def _inode_has_open_descriptors(
     claim: Path,
     log: LogFn,
 ) -> bool | None:
-    """Re-scan an unlinked claim by device and inode.
-
-    A full field scan avoids depending on a pathname after unlink. The exact
-    descriptor owned by this retirement is excluded; any other descriptor,
-    including one in this process, retains the bytes through a recovery claim.
-    """
+    """Scan a frozen claim by device and inode, excluding only this handle."""
     try:
         scan = subprocess.run(
             ["lsof", "-F", "pfDi"],
@@ -548,7 +582,7 @@ def _inode_has_open_descriptors(
     except (OSError, subprocess.SubprocessError) as exc:
         log(
             f"codex-home: claim retirement boundary-condition check for {claim} "
-            f"could not re-scan the inode: {exc}"
+            f"descriptor scan unavailable for frozen inode: {exc}"
         )
         return None
 
@@ -557,13 +591,13 @@ def _inode_has_open_descriptors(
     if stderr:
         log(
             f"codex-home: claim retirement boundary-condition check for {claim} "
-            f"could not re-scan the inode: {stderr}"
+            f"descriptor scan failed for frozen inode: {stderr}"
         )
         return None
     if scan.returncode != 0 or not stdout:
         log(
             f"codex-home: claim retirement boundary-condition check for {claim} "
-            f"received unexpected re-scan status {scan.returncode}"
+            f"received unexpected inode-scan status {scan.returncode}"
         )
         return None
 
@@ -604,8 +638,16 @@ def _inode_has_open_descriptors(
     target_identity = (claim_stat.st_dev, claim_stat.st_ino)
     own_identity = (os.getpid(), claim_handle.fileno())
     found_own_descriptor = False
+    uncertain_target_record = False
     for process_id, descriptor, device, inode in records:
-        if (device, inode) != target_identity:
+        exact_target = (device, inode) == target_identity
+        partial_target = (
+            (inode == target_identity[1] and device is None)
+            or (device == target_identity[0] and inode is None)
+        )
+        if partial_target:
+            uncertain_target_record = True
+        if not exact_target:
             continue
         descriptor_number = ""
         for character in descriptor:
@@ -620,6 +662,12 @@ def _inode_has_open_descriptors(
             continue
         return True
 
+    if uncertain_target_record:
+        log(
+            f"codex-home: retained rollout claim {claim}; frozen inode scan "
+            "could not parse a device or inode field for a potential holder"
+        )
+        return None
     if found_own_descriptor:
         return False
     log(
@@ -629,12 +677,98 @@ def _inode_has_open_descriptors(
     return None
 
 
-def _recover_unlinked_rollout_claim(
+def _restore_rollout_claim_mode(
     claim: Path,
     claim_handle: BinaryIO,
+    original_mode: int,
+    log: LogFn,
+) -> bool:
+    """Restore a frozen named claim through its already-open descriptor."""
+    try:
+        os.fchmod(claim_handle.fileno(), original_mode)
+        os.fsync(claim_handle.fileno())
+    except OSError as exc:
+        log(
+            f"codex-home: retained rollout claim {claim}; could not restore "
+            f"mode after retirement freeze: {exc}"
+        )
+        return False
+    return True
+
+
+def _repair_frozen_rollout_claim(claim: Path, log: LogFn) -> bool:
+    """Repair a mode-000 claim left by a crashed retirement.
+
+    A live retirement always holds an open descriptor. Seeing any holder, or
+    being unable to prove holder absence, is therefore a transient retain and
+    must never thaw another retireer's stable boundary.
+    """
+    try:
+        frozen_stat = claim.lstat()
+    except FileNotFoundError:
+        return True
+    if (
+        not stat.S_ISREG(frozen_stat.st_mode)
+        or stat.S_IMODE(frozen_stat.st_mode) != 0
+    ):
+        return True
+
+    holders = _claim_has_open_descriptors(claim, log)
+    if holders is not False:
+        detail = (
+            "another retirement still holds the frozen claim"
+            if holders
+            else "live-retirement status could not be verified"
+        )
+        log(
+            f"codex-home: transiently retained mode-000 rollout claim {claim}; "
+            f"{detail}"
+        )
+        return False
+
+    try:
+        os.chmod(
+            claim,
+            _CRASH_FROZEN_CLAIM_MODE,
+            follow_symlinks=False,
+        )
+        repaired_stat = claim.lstat()
+    except (OSError, NotImplementedError) as exc:
+        log(
+            f"codex-home: retained crashed mode-000 rollout claim {claim}; "
+            f"pathname mode repair failed: {exc}"
+        )
+        return False
+    if (
+        not stat.S_ISREG(repaired_stat.st_mode)
+        or (repaired_stat.st_dev, repaired_stat.st_ino)
+        != (frozen_stat.st_dev, frozen_stat.st_ino)
+    ):
+        log(
+            f"codex-home: retained rollout claim {claim}; identity changed "
+            "during crashed-freeze repair"
+        )
+        return False
+    try:
+        _fsync_directory(claim.parent)
+    except OSError as exc:
+        log(
+            f"codex-home: repaired crashed mode-000 rollout claim {claim}, "
+            f"but its directory sync failed: {exc}"
+        )
+        return False
+    log(f"codex-home: repaired crashed mode-000 rollout claim {claim}")
+    return True
+
+
+def _publish_frozen_rollout_recovery(
+    claim: Path,
+    claim_handle: BinaryIO,
+    target_cwd: str,
+    expected_signature: tuple[int, str],
     log: LogFn,
 ) -> Path:
-    """Copy current unlinked bytes into a complete, discoverable claim."""
+    """Publish and verify a durable recovery claim before unlinking the old one."""
     canonical = _claim_original_path(claim)
     if canonical is None:
         raise RuntimeError(f"cannot recover malformed rollout claim name: {claim}")
@@ -645,6 +779,7 @@ def _recover_unlinked_rollout_claim(
         suffix=_MIGRATION_TEMP_SUFFIX,
     )
     temp_path = Path(temp_name)
+    recovery: Path | None = None
     try:
         claim_handle.seek(0)
         with os.fdopen(temp_fd, "wb") as temp_handle:
@@ -659,14 +794,31 @@ def _recover_unlinked_rollout_claim(
                 lambda recovery_id: claim.with_name(
                     f"{_MIGRATION_CLAIM_PREFIX}{recovery_id}-{canonical.name}"
                 ),
-            ) as recovery:
+            ) as candidate:
                 try:
-                    os.link(temp_path, recovery, follow_symlinks=False)
+                    os.link(temp_path, candidate, follow_symlinks=False)
                 except FileExistsError:
                     continue
+                recovery = candidate
             break
         temp_path.unlink()
         _fsync_directory(claim.parent)
+        if recovery is None or not _rollout_is_valid(
+            recovery,
+            target_cwd,
+            expected_signature=expected_signature,
+        ):
+            raise RuntimeError(
+                f"published rollout recovery claim failed verification: {recovery}"
+            )
+    except Exception:
+        if recovery is not None:
+            try:
+                recovery.unlink()
+                _fsync_directory(claim.parent)
+            except FileNotFoundError:
+                pass
+        raise
     finally:
         if temp_fd >= 0:
             os.close(temp_fd)
@@ -674,10 +826,8 @@ def _recover_unlinked_rollout_claim(
             temp_path.unlink()
         except FileNotFoundError:
             pass
-    log(
-        "codex-home: WARNING claim retirement boundary-condition check "
-        f"preserved current bytes as recovery claim {recovery}"
-    )
+    assert recovery is not None
+    log(f"codex-home: published verified rollout recovery claim {recovery}")
     return recovery
 
 
@@ -688,15 +838,23 @@ def _retire_rollout_claim(
     *,
     log: LogFn,
 ) -> bool:
-    """Retire a verified tombstone with post-unlink recovery verification."""
+    """Retire a claim only after reaching a stable, recoverable byte boundary."""
     nofollow = getattr(os, "O_NOFOLLOW", None)
     if nofollow is None:
         raise RuntimeError("rollout claim path resolution requires O_NOFOLLOW")
+    if not _repair_frozen_rollout_claim(claim, log):
+        return False
     flags = os.O_RDONLY | nofollow | getattr(os, "O_CLOEXEC", 0)
     try:
         claim_fd = os.open(claim, flags)
     except FileNotFoundError:
         return True
+    except PermissionError as exc:
+        log(
+            f"codex-home: transiently retained rollout claim {claim}; "
+            f"pathname open was denied during a concurrent freeze: {exc}"
+        )
+        return False
     with os.fdopen(claim_fd, "rb", buffering=0) as claim_handle:
         opened_stat = os.fstat(claim_handle.fileno())
         try:
@@ -715,26 +873,66 @@ def _retire_rollout_claim(
             )
             return False
 
-        holders = _claim_has_open_descriptors(claim, log)
+        original_mode = stat.S_IMODE(opened_stat.st_mode)
+        try:
+            os.fchmod(claim_handle.fileno(), 0)
+            os.fsync(claim_handle.fileno())
+        except OSError as exc:
+            log(
+                f"codex-home: retained rollout claim {claim}; "
+                f"could not establish retirement freeze: {exc}"
+            )
+            _restore_rollout_claim_mode(
+                claim,
+                claim_handle,
+                original_mode,
+                log,
+            )
+            return False
+
+        holders = _inode_has_open_descriptors(claim_handle, claim, log)
         if holders is not False:
             if holders:
                 log(
                     f"codex-home: retained rollout claim {claim}; "
-                    "open descriptor holder(s) remain"
+                    "open descriptor holder(s) remain at the frozen boundary"
                 )
+            _restore_rollout_claim_mode(
+                claim,
+                claim_handle,
+                original_mode,
+                log,
+            )
             return False
 
         claim_signature = _file_signature_from_handle(claim_handle)
-        if not _rollout_is_valid(
+        destination_matches = _rollout_is_valid(
             destination,
             target_cwd,
             expected_signature=claim_signature,
-        ):
-            log(
-                f"codex-home: retained rollout claim {claim}; "
-                "installed destination is not byte-identical at retirement"
-            )
-            return False
+        )
+        recovery: Path | None = None
+        if not destination_matches:
+            try:
+                recovery = _publish_frozen_rollout_recovery(
+                    claim,
+                    claim_handle,
+                    target_cwd,
+                    claim_signature,
+                    log,
+                )
+            except Exception as exc:
+                log(
+                    f"codex-home: retained rollout claim {claim}; recovery "
+                    f"publication failed before unlink: {exc}"
+                )
+                _restore_rollout_claim_mode(
+                    claim,
+                    claim_handle,
+                    original_mode,
+                    log,
+                )
+                return False
 
         try:
             current_stat = claim.lstat()
@@ -748,29 +946,44 @@ def _retire_rollout_claim(
                 f"codex-home: retained rollout claim {claim}; "
                 "claim identity changed before unlink"
             )
+            _restore_rollout_claim_mode(
+                claim,
+                claim_handle,
+                original_mode,
+                log,
+            )
             return False
         if current_stat is not None:
             try:
                 claim.unlink()
             except FileNotFoundError:
                 pass
+            except OSError as exc:
+                log(
+                    f"codex-home: retained rollout claim {claim}; "
+                    f"unlink failed at the stable boundary: {exc}"
+                )
+                _restore_rollout_claim_mode(
+                    claim,
+                    claim_handle,
+                    original_mode,
+                    log,
+                )
+                return False
+        try:
             _fsync_directory(claim.parent)
-
-        post_unlink_holders = _inode_has_open_descriptors(
-            claim_handle,
-            claim,
-            log,
-        )
-        current_signature = _file_signature_from_handle(claim_handle)
-        current_destination_matches = _rollout_is_valid(
-            destination,
-            target_cwd,
-            expected_signature=current_signature,
-        )
-        if post_unlink_holders is not False or not current_destination_matches:
-            _recover_unlinked_rollout_claim(claim, claim_handle, log)
+        except OSError as exc:
+            log(
+                f"codex-home: claim retirement directory sync failed for "
+                f"{claim}: {exc}"
+            )
             return False
 
+    if recovery is not None:
+        log(
+            f"codex-home: retained differing bytes as recovery claim {recovery}"
+        )
+        return False
     log(f"codex-home: retired verified rollout claim {claim}")
     return True
 
@@ -803,6 +1016,8 @@ def _install_rollout(
     never removes and a later prepare can migrate independently.
     """
     destination.parent.mkdir(parents=True, exist_ok=True)
+    if not _repair_frozen_rollout_claim(claim, log):
+        return False
 
     if _path_entry_exists(destination):
         try:
@@ -815,6 +1030,12 @@ def _install_rollout(
                 )
                 return True
             raise
+        except PermissionError as exc:
+            log(
+                f"codex-home: transiently retained rollout claim {claim}; "
+                f"claim pathname access was denied during a concurrent freeze: {exc}"
+            )
+            return False
         if _rollout_is_valid(
             destination,
             target_cwd,
@@ -881,6 +1102,12 @@ def _install_rollout(
             )
             return True
         raise
+    except PermissionError as exc:
+        log(
+            f"codex-home: transiently retained rollout claim {claim}; "
+            f"claim pathname access was denied during a concurrent freeze: {exc}"
+        )
+        return False
     finally:
         if temp_fd >= 0:
             os.close(temp_fd)
@@ -1006,6 +1233,7 @@ def move_matching_rollouts(
         # works across daemon processes. The kernel releases flock on crash,
         # after which the successor sweeps the abandoned private temp.
         _sweep_migration_temps(destination_sessions, log)
+        _sweep_migration_temps(source_sessions, log)
         _sweep_stale_reservations(source_sessions, log)
         _sweep_stale_reservations(destination_sessions, log)
         return _move_rollout_candidates(
@@ -1033,8 +1261,24 @@ def _move_rollout_candidates(
         relative = source.relative_to(source_sessions)
         destination = destination_sessions / relative
         inspection_path = candidate.claim or source
+        if candidate.claim is not None and not _repair_frozen_rollout_claim(
+            candidate.claim,
+            log,
+        ):
+            continue
         rollout_cwd = _rollout_cwd(inspection_path)
         if not rollout_cwd:
+            if candidate.claim is not None:
+                try:
+                    claim_mode = stat.S_IMODE(candidate.claim.lstat().st_mode)
+                except FileNotFoundError:
+                    claim_mode = None
+                if claim_mode == 0:
+                    log(
+                        "codex-home: transiently retained rollout claim "
+                        f"{candidate.claim}; claim pathname is frozen by a "
+                        "concurrent retirement"
+                    )
             if not _path_entry_exists(inspection_path) and _rollout_is_valid(
                 destination, target_cwd
             ):

--- a/src/pinky_daemon/codex_home.py
+++ b/src/pinky_daemon/codex_home.py
@@ -1,0 +1,224 @@
+"""Flag-gated per-agent Codex home preparation and rollout migration."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+from collections.abc import Callable
+from pathlib import Path
+
+PER_AGENT_CODEX_HOME_ENV = "PINKY_CODEX_PER_AGENT_HOME"
+MANAGED_CONFIG_SENTINEL = "# pinkybot-managed-codex-home-v1"
+
+LogFn = Callable[[str], None]
+
+
+def per_agent_codex_home_enabled() -> bool:
+    """Return whether per-agent Codex homes are explicitly enabled."""
+    return os.environ.get(PER_AGENT_CODEX_HOME_ENV, "").strip() == "1"
+
+
+def shared_codex_home() -> Path:
+    """Return the user-level Codex home used when isolation is disabled."""
+    return Path(os.environ.get("CODEX_HOME") or (Path.home() / ".codex"))
+
+
+def _agent_working_dir(agent: object | None) -> Path:
+    raw = (getattr(agent, "working_dir", "") or "").strip()
+    if not raw:
+        raise RuntimeError("per-agent Codex home requires an agent working directory")
+    return Path(raw).expanduser().resolve()
+
+
+def codex_home_for(agent: object | None = None) -> Path:
+    """Resolve the Codex home shared by every reader for an agent scope.
+
+    The feature is a strict production no-op while disabled: the daemon-level
+    ``CODEX_HOME`` (or Codex's normal user-home fallback) is returned exactly as
+    before. When enabled, an explicit agent override wins; otherwise the home
+    lives inside the resolved agent working directory.
+    """
+    if not per_agent_codex_home_enabled():
+        return shared_codex_home()
+
+    override = (getattr(agent, "codex_home", "") or "").strip()
+    if override:
+        return Path(override).expanduser().resolve()
+    return _agent_working_dir(agent) / ".codex"
+
+
+def _managed_config(working_dir: Path) -> str:
+    project_key = json.dumps(str(working_dir))
+    return (
+        f"{MANAGED_CONFIG_SENTINEL}\n"
+        "# Generated for an isolated agent session.\n\n"
+        "[features]\n"
+        "apps = false\n"
+        "plugins = false\n\n"
+        f"[projects.{project_key}]\n"
+        'trust_level = "trusted"\n'
+    )
+
+
+def _write_managed_config(codex_home: Path, working_dir: Path, log: LogFn) -> None:
+    config_path = codex_home / "config.toml"
+    expected = _managed_config(working_dir)
+    if config_path.exists():
+        if config_path.is_symlink() or config_path.stat().st_nlink > 1:
+            log(
+                f"codex-home: preserving linked config at {config_path}; "
+                "per-agent safety settings were not rewritten"
+            )
+            return
+        existing = config_path.read_text(encoding="utf-8")
+        if not existing.startswith(MANAGED_CONFIG_SENTINEL):
+            log(
+                f"codex-home: preserving unmanaged config at {config_path}; "
+                "per-agent safety settings were not rewritten"
+            )
+            return
+        if existing == expected:
+            return
+    config_path.write_text(expected, encoding="utf-8")
+    config_path.chmod(0o600)
+
+
+def _ensure_auth_link(codex_home: Path, auth_source: Path) -> None:
+    auth_path = codex_home / "auth.json"
+    if auth_path.is_symlink():
+        try:
+            if auth_path.resolve(strict=True) == auth_source.resolve(strict=True):
+                return
+        except OSError:
+            pass
+        auth_path.unlink()
+    elif auth_path.exists():
+        raise RuntimeError(
+            f"refusing Codex spawn: {auth_path} is not the managed auth symlink"
+        )
+    auth_path.symlink_to(auth_source.resolve(strict=True))
+
+
+def _rollout_cwd(path: Path) -> str:
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            for line in handle:
+                try:
+                    entry = json.loads(line)
+                except (json.JSONDecodeError, TypeError):
+                    continue
+                if entry.get("type") != "session_meta":
+                    continue
+                payload = entry.get("payload") or {}
+                cwd = payload.get("cwd")
+                return cwd if isinstance(cwd, str) else ""
+    except OSError:
+        return ""
+    return ""
+
+
+def move_matching_rollouts(
+    source_home: Path,
+    destination_home: Path,
+    working_dir: str | Path,
+    *,
+    log: LogFn,
+) -> int:
+    """Move rollouts for one resolved working directory between Codex homes."""
+    source_sessions = source_home / "sessions"
+    destination_sessions = destination_home / "sessions"
+    target_cwd = os.path.realpath(str(working_dir))
+    if not source_sessions.exists():
+        return 0
+
+    moved = 0
+    for source in source_sessions.glob("**/rollout-*.jsonl"):
+        rollout_cwd = _rollout_cwd(source)
+        if not rollout_cwd or os.path.realpath(rollout_cwd) != target_cwd:
+            continue
+        relative = source.relative_to(source_sessions)
+        destination = destination_sessions / relative
+        if destination.exists():
+            log(
+                f"codex-home: rollout migration collision at {destination}; "
+                f"leaving {source} in place"
+            )
+            continue
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.move(str(source), str(destination))
+        moved += 1
+    return moved
+
+
+def prepare_agent_codex_home(agent: object, *, log: LogFn) -> Path:
+    """Prepare the isolated home before a Codex process is spawned.
+
+    With the flag disabled this function performs no filesystem work. With it
+    enabled, auth absence is a hard error before launch, config generation is
+    non-destructive, and cwd-matched rollouts move into the isolated store.
+    """
+    codex_home = codex_home_for(agent)
+    if not per_agent_codex_home_enabled():
+        return codex_home
+
+    working_dir = _agent_working_dir(agent)
+    shared_home = shared_codex_home().expanduser().resolve()
+    resolved_home = codex_home.expanduser().resolve()
+    if resolved_home == shared_home:
+        raise RuntimeError(
+            "refusing Codex spawn: per-agent CODEX_HOME resolves to the shared home"
+        )
+
+    auth_source = shared_home / "auth.json"
+    if not auth_source.is_file() or not os.access(auth_source, os.R_OK):
+        raise RuntimeError(
+            f"refusing Codex spawn: shared auth file is absent or unreadable: {auth_source}"
+        )
+
+    resolved_home.mkdir(parents=True, exist_ok=True)
+    resolved_home.chmod(0o700)
+    sessions = resolved_home / "sessions"
+    sessions.mkdir(parents=True, exist_ok=True)
+    sessions.chmod(0o700)
+    _write_managed_config(resolved_home, working_dir, log)
+    _ensure_auth_link(resolved_home, auth_source)
+
+    moved = move_matching_rollouts(
+        shared_home,
+        resolved_home,
+        working_dir,
+        log=log,
+    )
+    log(
+        f"codex-home: migrated {moved} cwd-matched rollout(s) into "
+        f"{resolved_home / 'sessions'}"
+    )
+    return resolved_home
+
+
+def rollback_agent_rollouts(
+    working_dir: str | Path,
+    agent_home: str | Path,
+    *,
+    shared_home: str | Path | None = None,
+    log: LogFn,
+) -> int:
+    """Move one agent's rollouts back to the user-level Codex store."""
+    source = Path(agent_home).expanduser().resolve()
+    destination = (
+        Path(shared_home).expanduser().resolve()
+        if shared_home is not None
+        else shared_codex_home().expanduser().resolve()
+    )
+    moved = move_matching_rollouts(
+        source,
+        destination,
+        working_dir,
+        log=log,
+    )
+    log(
+        f"codex-home: rolled back {moved} cwd-matched rollout(s) into "
+        f"{destination / 'sessions'}"
+    )
+    return moved

--- a/src/pinky_daemon/codex_home.py
+++ b/src/pinky_daemon/codex_home.py
@@ -14,6 +14,7 @@ import time
 import uuid
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import BinaryIO
@@ -25,13 +26,29 @@ MIGRATION_LOCK_TIMEOUT_ENV = "PINKY_CODEX_HOME_LOCK_TIMEOUT_SECONDS"
 
 _MIGRATION_TEMP_PREFIX = ".pinkybot-rollout-migration-"
 _MIGRATION_TEMP_SUFFIX = ".tmp"
+_MIGRATION_CLAIM_PREFIX = ".pinkybot-rollout-claim-"
 _MIGRATION_QUARANTINE_PREFIX = ".pinkybot-rollout-quarantine-"
 _MIGRATION_LOCK_NAME = ".pinkybot-rollout-migration.lock"
 _MIGRATION_LOCK_ASIDE_PREFIX = ".pinkybot-rollout-lock-aside-"
+_PRESERVATION_RESERVATION_SUFFIX = ".reserve"
 _DEFAULT_MIGRATION_LOCK_TIMEOUT_SECONDS = 10.0
 _MIGRATION_LOCK_RETRY_SECONDS = 0.05
 
 LogFn = Callable[[str], None]
+
+
+@dataclass(frozen=True)
+class _RolloutCandidate:
+    """A canonical rollout path and an optional crash-recovery claim."""
+
+    canonical: Path
+    claim: Path | None = None
+
+
+@dataclass(frozen=True)
+class _MoveResult:
+    moved: int
+    claimed_sources: frozenset[Path]
 
 
 def per_agent_codex_home_enabled() -> bool:
@@ -238,6 +255,47 @@ def _migration_lock_entry_kind(entry_stat: os.stat_result) -> str:
     return ""
 
 
+@contextmanager
+def _reserve_preservation_destination(
+    source: Path,
+    name_prefix: str,
+) -> Iterator[Path]:
+    """Reserve a collision-free preservation name without replacing data.
+
+    Every attempt gets a fresh UUID and an adjacent O_EXCL reservation.  A
+    pre-existing preservation artifact or reservation loses that attempt and
+    forces a new name.  The reservation serializes cooperating preservers while
+    ``os.rename`` moves the entry to a path proven unused; unlike ``os.replace``,
+    the move can never intentionally overwrite a retained artifact.
+    """
+    nofollow = getattr(os, "O_NOFOLLOW", 0)
+    cloexec = getattr(os, "O_CLOEXEC", 0)
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | nofollow | cloexec
+    while True:
+        destination = source.with_name(
+            f"{name_prefix}{source.name}-{uuid.uuid4().hex}"
+        )
+        reservation = destination.with_name(
+            f".{destination.name}{_PRESERVATION_RESERVATION_SUFFIX}"
+        )
+        try:
+            reservation_fd = os.open(reservation, flags, 0o600)
+        except FileExistsError:
+            continue
+        os.close(reservation_fd)
+        if _path_entry_exists(destination):
+            reservation.unlink()
+            continue
+        try:
+            yield destination
+        finally:
+            try:
+                reservation.unlink()
+            except FileNotFoundError:
+                pass
+        return
+
+
 def _rename_migration_lock_aside(
     lock_path: Path,
     entry_stat: os.stat_result,
@@ -254,10 +312,11 @@ def _rename_migration_lock_aside(
         entry_stat.st_ino,
     ):
         return False
-    aside = lock_path.with_name(
-        f"{_MIGRATION_LOCK_ASIDE_PREFIX}{lock_path.name}-{uuid.uuid4().hex}"
-    )
-    os.replace(lock_path, aside)
+    with _reserve_preservation_destination(
+        lock_path,
+        _MIGRATION_LOCK_ASIDE_PREFIX,
+    ) as aside:
+        os.rename(lock_path, aside)
     _fsync_directory(lock_path.parent)
     log(f"codex-home: renamed {kind} migration lock entry {lock_path} aside as {aside}")
     return True
@@ -364,17 +423,18 @@ def _sweep_migration_temps(destination_sessions: Path, log: LogFn) -> None:
 
 def _quarantine_rollout(destination: Path, log: LogFn) -> Path:
     """Atomically move an invalid final aside so it cannot shadow discovery."""
-    quarantine = destination.with_name(
-        f"{_MIGRATION_QUARANTINE_PREFIX}{destination.name}-{uuid.uuid4().hex}"
-    )
-    os.replace(destination, quarantine)
+    with _reserve_preservation_destination(
+        destination,
+        _MIGRATION_QUARANTINE_PREFIX,
+    ) as quarantine:
+        os.rename(destination, quarantine)
     _fsync_directory(destination.parent)
     log(f"codex-home: quarantined invalid rollout migration final {destination} as {quarantine}")
     return quarantine
 
 
 def _install_rollout(
-    source: Path,
+    claim: Path,
     destination: Path,
     target_cwd: str,
     *,
@@ -382,33 +442,33 @@ def _install_rollout(
 ) -> bool:
     """Install one rollout with crash recovery and concurrent convergence.
 
-    The source remains authoritative until an exact copy is fsynced, atomically
-    installed, and revalidated at the final path. ``True`` means this caller
-    either completed the move or observed another migrator's valid result.
+    ``claim`` is a private name established by atomically renaming the canonical
+    source before this function is entered.  All reads, verification, and
+    cleanup stay on that private name.  A writer arriving after the rename must
+    create a fresh canonical file, which this migration never removes and a
+    later prepare can migrate independently.
     """
     destination.parent.mkdir(parents=True, exist_ok=True)
 
     if _path_entry_exists(destination):
         try:
-            source_signature = _file_signature(source)
+            claim_signature = _file_signature(claim)
         except FileNotFoundError:
             if _rollout_is_valid(destination, target_cwd):
                 log(
                     f"codex-home: rollout migration converged at {destination}; "
-                    "source was already claimed"
+                    "private claim was already consumed"
                 )
                 return True
             raise
         if _rollout_is_valid(
             destination,
             target_cwd,
-            expected_signature=source_signature,
+            expected_signature=claim_signature,
         ):
             try:
-                if _file_signature(source) != source_signature:
-                    raise RuntimeError(f"rollout changed before source removal: {source}")
-                source.unlink()
-                _fsync_directory(source.parent)
+                claim.unlink()
+                _fsync_directory(claim.parent)
             except FileNotFoundError:
                 pass
             log(f"codex-home: rollout migration converged at {destination}")
@@ -424,7 +484,7 @@ def _install_rollout(
     try:
         copied_digest = hashlib.sha256()
         copied_size = 0
-        with source.open("rb") as source_handle, os.fdopen(temp_fd, "wb") as temp_handle:
+        with claim.open("rb") as source_handle, os.fdopen(temp_fd, "wb") as temp_handle:
             temp_fd = -1
             while chunk := source_handle.read(1024 * 1024):
                 temp_handle.write(chunk)
@@ -434,10 +494,11 @@ def _install_rollout(
             os.fsync(temp_handle.fileno())
         copied_signature = (copied_size, copied_digest.hexdigest())
 
-        # Detect an append/change racing the copy; never unlink a newer source
-        # than the snapshot we actually installed.
-        if _file_signature(source) != copied_signature:
-            raise RuntimeError(f"rollout changed during migration: {source}")
+        # A descriptor opened before the claim rename can still change the
+        # claimed inode.  Detect that shape before install and leave the claim
+        # intact for retry; name-based late writers use the fresh canonical path.
+        if _file_signature(claim) != copied_signature:
+            raise RuntimeError(f"rollout claim changed during migration: {claim}")
         if not _rollout_is_valid(
             temp_path,
             target_cwd,
@@ -455,32 +516,18 @@ def _install_rollout(
             _quarantine_rollout(destination, log)
             raise RuntimeError(f"rollout migration final failed validation: {destination}")
 
-        try:
-            if _file_signature(source) != copied_signature:
-                raise RuntimeError(f"rollout changed before source removal: {source}")
-            source.unlink()
-            _fsync_directory(source.parent)
-        except FileNotFoundError:
-            # A same-source migrator won the unlink race. Its destination is
-            # the same relative final; our validated atomic install converged.
-            if not _rollout_is_valid(
-                destination,
-                target_cwd,
-                expected_signature=copied_signature,
-            ):
-                raise
-            log(
-                f"codex-home: rollout migration converged at {destination}; "
-                "source was already claimed"
-            )
+        # Removal targets only the private claim.  There is deliberately no
+        # check-then-remove pair on the canonical writer path.
+        claim.unlink()
+        _fsync_directory(claim.parent)
         return True
     except FileNotFoundError:
-        # The source may disappear after glob/read when a concurrent migrator
-        # claims it. Count the valid final as convergence instead of raising.
+        # A crash-recovery claim may already have been consumed by a concurrent
+        # process. Count a valid final as convergence instead of raising.
         if _rollout_is_valid(destination, target_cwd):
             log(
                 f"codex-home: rollout migration converged at {destination}; "
-                "source was already claimed"
+                "private claim was already consumed"
             )
             return True
         raise
@@ -491,6 +538,86 @@ def _install_rollout(
             temp_path.unlink()
         except FileNotFoundError:
             pass
+
+
+def _claim_original_path(claim: Path) -> Path | None:
+    """Decode the canonical source path represented by a private claim."""
+    if not claim.name.startswith(_MIGRATION_CLAIM_PREFIX):
+        return None
+    encoded = claim.name[len(_MIGRATION_CLAIM_PREFIX) :]
+    claim_id, separator, original_name = encoded.partition("-")
+    if (
+        not separator
+        or len(claim_id) != 32
+        or any(character not in "0123456789abcdef" for character in claim_id)
+        or not original_name.startswith("rollout-")
+        or not original_name.endswith(".jsonl")
+    ):
+        return None
+    return claim.with_name(original_name)
+
+
+def _claim_rollout(source: Path) -> Path | None:
+    """Atomically remove the canonical writer target before migration reads."""
+    while True:
+        claim = source.with_name(
+            f"{_MIGRATION_CLAIM_PREFIX}{uuid.uuid4().hex}-{source.name}"
+        )
+        if _path_entry_exists(claim):
+            continue
+        try:
+            os.rename(source, claim)
+        except FileNotFoundError:
+            return None
+        _fsync_directory(source.parent)
+        return claim
+
+
+def _snapshot_rollout_candidates(source_sessions: Path) -> list[_RolloutCandidate]:
+    """Return recoverable claims first, then live canonical rollout names."""
+    claims: list[_RolloutCandidate] = []
+    claim_pattern = f"**/{_MIGRATION_CLAIM_PREFIX}*-rollout-*.jsonl"
+    for claim in sorted(source_sessions.glob(claim_pattern)):
+        canonical = _claim_original_path(claim)
+        if canonical is not None:
+            claims.append(_RolloutCandidate(canonical=canonical, claim=claim))
+    canonical = [
+        _RolloutCandidate(path)
+        for path in sorted(source_sessions.glob("**/rollout-*.jsonl"))
+    ]
+    return [*claims, *canonical]
+
+
+def _retry_rollout_candidates(
+    source_sessions: Path,
+    relative_sources: list[str],
+) -> list[_RolloutCandidate]:
+    """Resolve marker-pinned canonical paths and their private crash claims."""
+    candidates: list[_RolloutCandidate] = []
+    seen: set[tuple[Path, Path | None]] = set()
+    for raw_relative in relative_sources:
+        relative = Path(raw_relative)
+        if (
+            relative.is_absolute()
+            or ".." in relative.parts
+            or not relative.name.startswith("rollout-")
+            or not relative.name.endswith(".jsonl")
+        ):
+            continue
+        canonical = source_sessions / relative
+        claim_pattern = f"{_MIGRATION_CLAIM_PREFIX}*-{canonical.name}"
+        for claim in sorted(canonical.parent.glob(claim_pattern)):
+            if _claim_original_path(claim) == canonical:
+                key = (canonical, claim)
+                if key not in seen:
+                    candidates.append(_RolloutCandidate(canonical, claim))
+                    seen.add(key)
+        if _path_entry_exists(canonical):
+            key = (canonical, None)
+            if key not in seen:
+                candidates.append(_RolloutCandidate(canonical))
+                seen.add(key)
+    return candidates
 
 
 def move_matching_rollouts(
@@ -505,8 +632,9 @@ def move_matching_rollouts(
     destination_sessions = destination_home / "sessions"
     target_cwd = os.path.realpath(str(working_dir))
     # Snapshot before locking so a contender that saw the same source before
-    # the winner claimed it can still converge on the installed final.
-    candidates = list(source_sessions.glob("**/rollout-*.jsonl"))
+    # the winner claimed it can still converge on the installed final. Private
+    # crash claims lead the list so a newer canonical recreation wins last.
+    candidates = _snapshot_rollout_candidates(source_sessions)
     destination_sessions.mkdir(parents=True, exist_ok=True)
     lock_path = destination_sessions / _MIGRATION_LOCK_NAME
     with _acquire_migration_lock(lock_path, log):
@@ -520,25 +648,30 @@ def move_matching_rollouts(
             destination_sessions,
             target_cwd,
             log=log,
-        )
+        ).moved
 
 
 def _move_rollout_candidates(
-    candidates: list[Path],
+    candidates: list[_RolloutCandidate],
     source_sessions: Path,
     destination_sessions: Path,
     target_cwd: str,
     *,
     log: LogFn,
-) -> int:
+) -> _MoveResult:
     """Move a pre-lock snapshot while holding the destination writer lock."""
     moved = 0
-    for source in candidates:
+    claimed_sources: set[Path] = set()
+    for candidate in candidates:
+        source = candidate.canonical
         relative = source.relative_to(source_sessions)
         destination = destination_sessions / relative
-        rollout_cwd = _rollout_cwd(source)
+        inspection_path = candidate.claim or source
+        rollout_cwd = _rollout_cwd(inspection_path)
         if not rollout_cwd:
-            if not _path_entry_exists(source) and _rollout_is_valid(destination, target_cwd):
+            if not _path_entry_exists(inspection_path) and _rollout_is_valid(
+                destination, target_cwd
+            ):
                 log(
                     f"codex-home: rollout migration converged at {destination}; "
                     "source was already claimed"
@@ -547,17 +680,37 @@ def _move_rollout_candidates(
             continue
         if os.path.realpath(rollout_cwd) != target_cwd:
             continue
-        if _install_rollout(source, destination, target_cwd, log=log):
+        claim = candidate.claim or _claim_rollout(source)
+        if claim is None:
+            if _rollout_is_valid(destination, target_cwd):
+                log(
+                    f"codex-home: rollout migration converged at {destination}; "
+                    "source was already claimed"
+                )
+                moved += 1
+            continue
+        claimed_sources.add(source)
+        if _install_rollout(claim, destination, target_cwd, log=log):
             moved += 1
-    return moved
+    return _MoveResult(moved=moved, claimed_sources=frozenset(claimed_sources))
 
 
-def _write_migration_marker(codex_home: Path, moved: int) -> None:
+def _write_migration_marker(
+    codex_home: Path,
+    moved: int,
+    *,
+    retry_sources: list[str],
+) -> None:
     """Durably commit the one-time migration gate after a successful scan."""
     marker = codex_home / ROLLOUT_MIGRATION_MARKER
     payload = {
         "completed_at": datetime.now(timezone.utc).isoformat(),
         "moved_count": moved,
+        # Exact paths claimed during the one-time bridge remain eligible for a
+        # bounded retry. A writer recreating one of those canonical names after
+        # the atomic claim is therefore migrated on the next prepare without
+        # reopening the shared store to arbitrary late rollouts.
+        "retry_sources": retry_sources,
     }
     fd, temp_name = tempfile.mkstemp(
         dir=codex_home,
@@ -583,6 +736,23 @@ def _write_migration_marker(codex_home: Path, moved: int) -> None:
             pass
 
 
+def _read_marker_retry_sources(marker: Path) -> list[str]:
+    """Read retry paths from a managed marker; malformed markers fail closed."""
+    try:
+        marker_stat = marker.lstat()
+        if not stat.S_ISREG(marker_stat.st_mode) or marker_stat.st_nlink > 1:
+            return []
+        payload = json.loads(marker.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError):
+        return []
+    if not isinstance(payload, dict):
+        return []
+    raw_sources = payload.get("retry_sources")
+    if not isinstance(raw_sources, list):
+        return []
+    return [source for source in raw_sources if isinstance(source, str)]
+
+
 def _run_initial_rollout_migration(
     shared_home: Path,
     resolved_home: Path,
@@ -601,22 +771,53 @@ def _run_initial_rollout_migration(
     """
     marker = resolved_home / ROLLOUT_MIGRATION_MARKER
     if _path_entry_exists(marker):
-        log(f"codex-home: migration marker present at {marker}; shared rollout store not scanned")
-        return 0
+        retry_sources = _read_marker_retry_sources(marker)
+        if not retry_sources:
+            log(
+                f"codex-home: migration marker present at {marker}; "
+                "shared rollout store not scanned"
+            )
+            return 0
+        source_sessions = shared_home / "sessions"
+        destination_sessions = resolved_home / "sessions"
+        candidates = _retry_rollout_candidates(source_sessions, retry_sources)
+        if not candidates:
+            log(
+                f"codex-home: migration marker present at {marker}; "
+                "no claimed source path requires retry"
+            )
+            return 0
+        target_cwd = os.path.realpath(str(working_dir))
+        lock_path = destination_sessions / _MIGRATION_LOCK_NAME
+        with _acquire_migration_lock(lock_path, log):
+            _sweep_migration_temps(destination_sessions, log)
+            result = _move_rollout_candidates(
+                candidates,
+                source_sessions,
+                destination_sessions,
+                target_cwd,
+                log=log,
+            )
+        log(
+            f"codex-home: migration marker retry converged on "
+            f"{result.moved} rollout(s)"
+        )
+        return result.moved
 
     source_sessions = shared_home / "sessions"
     destination_sessions = resolved_home / "sessions"
-    candidates = list(source_sessions.glob("**/rollout-*.jsonl"))
+    candidates = _snapshot_rollout_candidates(source_sessions)
     target_cwd = os.path.realpath(str(working_dir))
     lock_path = destination_sessions / _MIGRATION_LOCK_NAME
     with _acquire_migration_lock(lock_path, log):
         if _path_entry_exists(marker):
             converged = sum(
                 _rollout_is_valid(
-                    destination_sessions / source.relative_to(source_sessions),
+                    destination_sessions
+                    / candidate.canonical.relative_to(source_sessions),
                     target_cwd,
                 )
-                for source in candidates
+                for candidate in candidates
             )
             log(
                 f"codex-home: concurrent rollout migration converged on "
@@ -624,15 +825,23 @@ def _run_initial_rollout_migration(
             )
             return converged
         _sweep_migration_temps(destination_sessions, log)
-        moved = _move_rollout_candidates(
+        result = _move_rollout_candidates(
             candidates,
             source_sessions,
             destination_sessions,
             target_cwd,
             log=log,
         )
-        _write_migration_marker(resolved_home, moved)
-        return moved
+        retry_sources = sorted(
+            str(source.relative_to(source_sessions))
+            for source in result.claimed_sources
+        )
+        _write_migration_marker(
+            resolved_home,
+            result.moved,
+            retry_sources=retry_sources,
+        )
+        return result.moved
 
 
 def prepare_agent_codex_home(agent: object, *, log: LogFn) -> Path:

--- a/src/pinky_daemon/codex_home.py
+++ b/src/pinky_daemon/codex_home.py
@@ -2,14 +2,25 @@
 
 from __future__ import annotations
 
+import fcntl
+import hashlib
 import json
 import os
-import shutil
+import stat
+import tempfile
+import uuid
 from collections.abc import Callable
+from datetime import datetime, timezone
 from pathlib import Path
 
 PER_AGENT_CODEX_HOME_ENV = "PINKY_CODEX_PER_AGENT_HOME"
 MANAGED_CONFIG_SENTINEL = "# pinkybot-managed-codex-home-v1"
+ROLLOUT_MIGRATION_MARKER = ".pinkybot-rollout-migration-v1.json"
+
+_MIGRATION_TEMP_PREFIX = ".pinkybot-rollout-migration-"
+_MIGRATION_TEMP_SUFFIX = ".tmp"
+_MIGRATION_QUARANTINE_PREFIX = ".pinkybot-rollout-quarantine-"
+_MIGRATION_LOCK_NAME = ".pinkybot-rollout-migration.lock"
 
 LogFn = Callable[[str], None]
 
@@ -64,10 +75,23 @@ def _managed_config(working_dir: Path) -> str:
 def _write_managed_config(codex_home: Path, working_dir: Path, log: LogFn) -> None:
     config_path = codex_home / "config.toml"
     expected = _managed_config(working_dir)
-    if config_path.exists():
-        if config_path.is_symlink() or config_path.stat().st_nlink > 1:
+    try:
+        config_stat = config_path.lstat()
+    except FileNotFoundError:
+        config_stat = None
+    if config_stat is not None:
+        # Check the directory entry itself before any target-following call.
+        # Path.exists() is false for a dangling symlink; checking it first
+        # would let write_text() follow the link and create/mutate its target.
+        if stat.S_ISLNK(config_stat.st_mode) or config_stat.st_nlink > 1:
             log(
                 f"codex-home: preserving linked config at {config_path}; "
+                "per-agent safety settings were not rewritten"
+            )
+            return
+        if not stat.S_ISREG(config_stat.st_mode):
+            log(
+                f"codex-home: preserving non-regular config at {config_path}; "
                 "per-agent safety settings were not rewritten"
             )
             return
@@ -86,18 +110,32 @@ def _write_managed_config(codex_home: Path, working_dir: Path, log: LogFn) -> No
 
 def _ensure_auth_link(codex_home: Path, auth_source: Path) -> None:
     auth_path = codex_home / "auth.json"
-    if auth_path.is_symlink():
+    auth_target = auth_source.resolve(strict=True)
+    for _attempt in range(3):
         try:
-            if auth_path.resolve(strict=True) == auth_source.resolve(strict=True):
+            auth_stat = auth_path.lstat()
+        except FileNotFoundError:
+            try:
+                auth_path.symlink_to(auth_target)
+                return
+            except FileExistsError:
+                # A concurrent prepare created the entry; classify it again.
+                continue
+        if not stat.S_ISLNK(auth_stat.st_mode):
+            raise RuntimeError(
+                f"refusing Codex spawn: {auth_path} is not the managed auth symlink"
+            )
+        try:
+            if auth_path.resolve(strict=True) == auth_target:
                 return
         except OSError:
             pass
-        auth_path.unlink()
-    elif auth_path.exists():
-        raise RuntimeError(
-            f"refusing Codex spawn: {auth_path} is not the managed auth symlink"
-        )
-    auth_path.symlink_to(auth_source.resolve(strict=True))
+        try:
+            auth_path.unlink()
+        except FileNotFoundError:
+            # A concurrent prepare already replaced the stale/dangling entry.
+            continue
+    raise RuntimeError(f"refusing Codex spawn: auth symlink at {auth_path} did not converge")
 
 
 def _rollout_cwd(path: Path) -> str:
@@ -108,14 +146,205 @@ def _rollout_cwd(path: Path) -> str:
                     entry = json.loads(line)
                 except (json.JSONDecodeError, TypeError):
                     continue
+                if not isinstance(entry, dict):
+                    continue
                 if entry.get("type") != "session_meta":
                     continue
                 payload = entry.get("payload") or {}
                 cwd = payload.get("cwd")
                 return cwd if isinstance(cwd, str) else ""
-    except OSError:
+    except (OSError, UnicodeError):
         return ""
     return ""
+
+
+def _path_entry_exists(path: Path) -> bool:
+    """Return whether a directory entry exists without following symlinks."""
+    try:
+        path.lstat()
+    except FileNotFoundError:
+        return False
+    return True
+
+
+def _file_signature(path: Path) -> tuple[int, str]:
+    """Return an exact size+digest signature for a regular rollout file."""
+    file_stat = path.lstat()
+    if not stat.S_ISREG(file_stat.st_mode):
+        raise OSError(f"rollout is not a regular file: {path}")
+    digest = hashlib.sha256()
+    size = 0
+    with path.open("rb") as handle:
+        while chunk := handle.read(1024 * 1024):
+            digest.update(chunk)
+            size += len(chunk)
+    return size, digest.hexdigest()
+
+
+def _rollout_is_valid(
+    path: Path,
+    target_cwd: str,
+    *,
+    expected_signature: tuple[int, str] | None = None,
+) -> bool:
+    """Validate a migration final without trusting its name alone."""
+    try:
+        rollout_cwd = _rollout_cwd(path)
+        if not rollout_cwd or os.path.realpath(rollout_cwd) != target_cwd:
+            return False
+        signature = _file_signature(path)
+    except OSError:
+        return False
+    return expected_signature is None or signature == expected_signature
+
+
+def _fsync_directory(path: Path) -> None:
+    """Persist directory-entry changes after replace/unlink operations."""
+    fd = os.open(path, os.O_RDONLY)
+    try:
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+
+
+def _sweep_migration_temps(destination_sessions: Path, log: LogFn) -> None:
+    """Remove private copy temps abandoned before an atomic install."""
+    if not destination_sessions.exists():
+        return
+    pattern = f"{_MIGRATION_TEMP_PREFIX}*{_MIGRATION_TEMP_SUFFIX}"
+    for abandoned in destination_sessions.glob(f"**/{pattern}"):
+        try:
+            abandoned.unlink()
+            log(f"codex-home: removed abandoned rollout migration temp {abandoned}")
+        except FileNotFoundError:
+            continue
+
+
+def _quarantine_rollout(destination: Path, log: LogFn) -> Path:
+    """Atomically move an invalid final aside so it cannot shadow discovery."""
+    quarantine = destination.with_name(
+        f"{_MIGRATION_QUARANTINE_PREFIX}{destination.name}-{uuid.uuid4().hex}"
+    )
+    os.replace(destination, quarantine)
+    _fsync_directory(destination.parent)
+    log(f"codex-home: quarantined invalid rollout migration final {destination} as {quarantine}")
+    return quarantine
+
+
+def _install_rollout(
+    source: Path,
+    destination: Path,
+    target_cwd: str,
+    *,
+    log: LogFn,
+) -> bool:
+    """Install one rollout with crash recovery and concurrent convergence.
+
+    The source remains authoritative until an exact copy is fsynced, atomically
+    installed, and revalidated at the final path. ``True`` means this caller
+    either completed the move or observed another migrator's valid result.
+    """
+    destination.parent.mkdir(parents=True, exist_ok=True)
+
+    if _path_entry_exists(destination):
+        try:
+            source_signature = _file_signature(source)
+        except FileNotFoundError:
+            if _rollout_is_valid(destination, target_cwd):
+                log(
+                    f"codex-home: rollout migration converged at {destination}; "
+                    "source was already claimed"
+                )
+                return True
+            raise
+        if _rollout_is_valid(
+            destination,
+            target_cwd,
+            expected_signature=source_signature,
+        ):
+            try:
+                source.unlink()
+                _fsync_directory(source.parent)
+            except FileNotFoundError:
+                pass
+            log(f"codex-home: rollout migration converged at {destination}")
+            return True
+        _quarantine_rollout(destination, log)
+
+    temp_fd, temp_name = tempfile.mkstemp(
+        dir=destination.parent,
+        prefix=_MIGRATION_TEMP_PREFIX,
+        suffix=_MIGRATION_TEMP_SUFFIX,
+    )
+    temp_path = Path(temp_name)
+    try:
+        copied_digest = hashlib.sha256()
+        copied_size = 0
+        with source.open("rb") as source_handle, os.fdopen(temp_fd, "wb") as temp_handle:
+            temp_fd = -1
+            while chunk := source_handle.read(1024 * 1024):
+                temp_handle.write(chunk)
+                copied_digest.update(chunk)
+                copied_size += len(chunk)
+            temp_handle.flush()
+            os.fsync(temp_handle.fileno())
+        copied_signature = (copied_size, copied_digest.hexdigest())
+
+        # Detect an append/change racing the copy; never unlink a newer source
+        # than the snapshot we actually installed.
+        if _file_signature(source) != copied_signature:
+            raise RuntimeError(f"rollout changed during migration: {source}")
+        if not _rollout_is_valid(
+            temp_path,
+            target_cwd,
+            expected_signature=copied_signature,
+        ):
+            raise RuntimeError(f"rollout migration temp failed validation: {temp_path}")
+
+        os.replace(temp_path, destination)
+        _fsync_directory(destination.parent)
+        if not _rollout_is_valid(
+            destination,
+            target_cwd,
+            expected_signature=copied_signature,
+        ):
+            _quarantine_rollout(destination, log)
+            raise RuntimeError(f"rollout migration final failed validation: {destination}")
+
+        try:
+            source.unlink()
+            _fsync_directory(source.parent)
+        except FileNotFoundError:
+            # A same-source migrator won the unlink race. Its destination is
+            # the same relative final; our validated atomic install converged.
+            if not _rollout_is_valid(
+                destination,
+                target_cwd,
+                expected_signature=copied_signature,
+            ):
+                raise
+            log(
+                f"codex-home: rollout migration converged at {destination}; "
+                "source was already claimed"
+            )
+        return True
+    except FileNotFoundError:
+        # The source may disappear after glob/read when a concurrent migrator
+        # claims it. Count the valid final as convergence instead of raising.
+        if _rollout_is_valid(destination, target_cwd):
+            log(
+                f"codex-home: rollout migration converged at {destination}; "
+                "source was already claimed"
+            )
+            return True
+        raise
+    finally:
+        if temp_fd >= 0:
+            os.close(temp_fd)
+        try:
+            temp_path.unlink()
+        except FileNotFoundError:
+            pass
 
 
 def move_matching_rollouts(
@@ -129,26 +358,143 @@ def move_matching_rollouts(
     source_sessions = source_home / "sessions"
     destination_sessions = destination_home / "sessions"
     target_cwd = os.path.realpath(str(working_dir))
-    if not source_sessions.exists():
-        return 0
+    # Snapshot before locking so a contender that saw the same source before
+    # the winner claimed it can still converge on the installed final.
+    candidates = list(source_sessions.glob("**/rollout-*.jsonl"))
+    destination_sessions.mkdir(parents=True, exist_ok=True)
+    lock_path = destination_sessions / _MIGRATION_LOCK_NAME
+    with lock_path.open("a+b") as lock_handle:
+        # Serializing destination writers makes temp cleanup race-free and
+        # works across daemon processes. The kernel releases flock on crash,
+        # after which the successor sweeps the abandoned private temp.
+        fcntl.flock(lock_handle.fileno(), fcntl.LOCK_EX)
+        try:
+            _sweep_migration_temps(destination_sessions, log)
+            return _move_rollout_candidates(
+                candidates,
+                source_sessions,
+                destination_sessions,
+                target_cwd,
+                log=log,
+            )
+        finally:
+            fcntl.flock(lock_handle.fileno(), fcntl.LOCK_UN)
 
+
+def _move_rollout_candidates(
+    candidates: list[Path],
+    source_sessions: Path,
+    destination_sessions: Path,
+    target_cwd: str,
+    *,
+    log: LogFn,
+) -> int:
+    """Move a pre-lock snapshot while holding the destination writer lock."""
     moved = 0
-    for source in source_sessions.glob("**/rollout-*.jsonl"):
-        rollout_cwd = _rollout_cwd(source)
-        if not rollout_cwd or os.path.realpath(rollout_cwd) != target_cwd:
-            continue
+    for source in candidates:
         relative = source.relative_to(source_sessions)
         destination = destination_sessions / relative
-        if destination.exists():
-            log(
-                f"codex-home: rollout migration collision at {destination}; "
-                f"leaving {source} in place"
-            )
+        rollout_cwd = _rollout_cwd(source)
+        if not rollout_cwd:
+            if not _path_entry_exists(source) and _rollout_is_valid(destination, target_cwd):
+                log(
+                    f"codex-home: rollout migration converged at {destination}; "
+                    "source was already claimed"
+                )
+                moved += 1
             continue
-        destination.parent.mkdir(parents=True, exist_ok=True)
-        shutil.move(str(source), str(destination))
-        moved += 1
+        if os.path.realpath(rollout_cwd) != target_cwd:
+            continue
+        if _install_rollout(source, destination, target_cwd, log=log):
+            moved += 1
     return moved
+
+
+def _write_migration_marker(codex_home: Path, moved: int) -> None:
+    """Durably commit the one-time migration gate after a successful scan."""
+    marker = codex_home / ROLLOUT_MIGRATION_MARKER
+    payload = {
+        "completed_at": datetime.now(timezone.utc).isoformat(),
+        "moved_count": moved,
+    }
+    fd, temp_name = tempfile.mkstemp(
+        dir=codex_home,
+        prefix=f".{ROLLOUT_MIGRATION_MARKER}-",
+        suffix=".tmp",
+    )
+    temp_path = Path(temp_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            fd = -1
+            json.dump(payload, handle, sort_keys=True)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temp_path, marker)
+        _fsync_directory(codex_home)
+    finally:
+        if fd >= 0:
+            os.close(fd)
+        try:
+            temp_path.unlink()
+        except FileNotFoundError:
+            pass
+
+
+def _run_initial_rollout_migration(
+    shared_home: Path,
+    resolved_home: Path,
+    working_dir: Path,
+    *,
+    log: LogFn,
+) -> int:
+    """Run and durably gate the shared-store import exactly once.
+
+    The fast marker check happens before the shared directory is scanned. A
+    contender that began during the first migration may have already captured
+    the same source list; the destination lock lets it observe the committed
+    marker and count the winner's validated finals without touching shared
+    storage again. The marker is written before the winner releases that lock,
+    closing the scan-to-marker race between concurrent spawns.
+    """
+    marker = resolved_home / ROLLOUT_MIGRATION_MARKER
+    if _path_entry_exists(marker):
+        log(f"codex-home: migration marker present at {marker}; shared rollout store not scanned")
+        return 0
+
+    source_sessions = shared_home / "sessions"
+    destination_sessions = resolved_home / "sessions"
+    candidates = list(source_sessions.glob("**/rollout-*.jsonl"))
+    target_cwd = os.path.realpath(str(working_dir))
+    lock_path = destination_sessions / _MIGRATION_LOCK_NAME
+    with lock_path.open("a+b") as lock_handle:
+        fcntl.flock(lock_handle.fileno(), fcntl.LOCK_EX)
+        try:
+            if _path_entry_exists(marker):
+                converged = sum(
+                    _rollout_is_valid(
+                        destination_sessions / source.relative_to(source_sessions),
+                        target_cwd,
+                    )
+                    for source in candidates
+                )
+                log(
+                    f"codex-home: concurrent rollout migration converged on "
+                    f"{converged} installed rollout(s); marker already committed"
+                )
+                return converged
+            _sweep_migration_temps(destination_sessions, log)
+            moved = _move_rollout_candidates(
+                candidates,
+                source_sessions,
+                destination_sessions,
+                target_cwd,
+                log=log,
+            )
+            _write_migration_marker(resolved_home, moved)
+            return moved
+        finally:
+            fcntl.flock(lock_handle.fileno(), fcntl.LOCK_UN)
 
 
 def prepare_agent_codex_home(agent: object, *, log: LogFn) -> Path:
@@ -166,9 +512,7 @@ def prepare_agent_codex_home(agent: object, *, log: LogFn) -> Path:
     shared_home = shared_codex_home().expanduser().resolve()
     resolved_home = codex_home.expanduser().resolve()
     if resolved_home == shared_home:
-        raise RuntimeError(
-            "refusing Codex spawn: per-agent CODEX_HOME resolves to the shared home"
-        )
+        raise RuntimeError("refusing Codex spawn: per-agent CODEX_HOME resolves to the shared home")
 
     auth_source = shared_home / "auth.json"
     if not auth_source.is_file() or not os.access(auth_source, os.R_OK):
@@ -184,16 +528,13 @@ def prepare_agent_codex_home(agent: object, *, log: LogFn) -> Path:
     _write_managed_config(resolved_home, working_dir, log)
     _ensure_auth_link(resolved_home, auth_source)
 
-    moved = move_matching_rollouts(
+    moved = _run_initial_rollout_migration(
         shared_home,
         resolved_home,
         working_dir,
         log=log,
     )
-    log(
-        f"codex-home: migrated {moved} cwd-matched rollout(s) into "
-        f"{resolved_home / 'sessions'}"
-    )
+    log(f"codex-home: migrated {moved} cwd-matched rollout(s) into {resolved_home / 'sessions'}")
     return resolved_home
 
 
@@ -217,8 +558,5 @@ def rollback_agent_rollouts(
         working_dir,
         log=log,
     )
-    log(
-        f"codex-home: rolled back {moved} cwd-matched rollout(s) into "
-        f"{destination / 'sessions'}"
-    )
+    log(f"codex-home: rolled back {moved} cwd-matched rollout(s) into {destination / 'sessions'}")
     return moved

--- a/src/pinky_daemon/codex_home.py
+++ b/src/pinky_daemon/codex_home.py
@@ -9,6 +9,7 @@ import json
 import math
 import os
 import stat
+import subprocess
 import tempfile
 import time
 import uuid
@@ -31,6 +32,8 @@ _MIGRATION_QUARANTINE_PREFIX = ".pinkybot-rollout-quarantine-"
 _MIGRATION_LOCK_NAME = ".pinkybot-rollout-migration.lock"
 _MIGRATION_LOCK_ASIDE_PREFIX = ".pinkybot-rollout-lock-aside-"
 _PRESERVATION_RESERVATION_SUFFIX = ".reserve"
+_PRESERVATION_RESERVATION_STALE_SECONDS = 60 * 60
+_CLAIM_DESCRIPTOR_SCAN_TIMEOUT_SECONDS = 2.0
 _DEFAULT_MIGRATION_LOCK_TIMEOUT_SECONDS = 10.0
 _MIGRATION_LOCK_RETRY_SECONDS = 0.05
 
@@ -256,25 +259,22 @@ def _migration_lock_entry_kind(entry_stat: os.stat_result) -> str:
 
 
 @contextmanager
-def _reserve_preservation_destination(
-    source: Path,
-    name_prefix: str,
+def _reserve_exclusive_destination(
+    destination_for_uuid: Callable[[str], Path],
 ) -> Iterator[Path]:
-    """Reserve a collision-free preservation name without replacing data.
+    """Reserve a collision-free private name without replacing data.
 
     Every attempt gets a fresh UUID and an adjacent O_EXCL reservation.  A
-    pre-existing preservation artifact or reservation loses that attempt and
-    forces a new name.  The reservation serializes cooperating preservers while
-    ``os.rename`` moves the entry to a path proven unused; unlike ``os.replace``,
-    the move can never intentionally overwrite a retained artifact.
+    pre-existing artifact or reservation loses that attempt and forces a new
+    name.  The caller must still use a non-replacing operation when materializing
+    the reserved destination because an uncooperating process can create the
+    destination after the reservation's absence check.
     """
     nofollow = getattr(os, "O_NOFOLLOW", 0)
     cloexec = getattr(os, "O_CLOEXEC", 0)
     flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | nofollow | cloexec
     while True:
-        destination = source.with_name(
-            f"{name_prefix}{source.name}-{uuid.uuid4().hex}"
-        )
+        destination = destination_for_uuid(uuid.uuid4().hex)
         reservation = destination.with_name(
             f".{destination.name}{_PRESERVATION_RESERVATION_SUFFIX}"
         )
@@ -294,6 +294,20 @@ def _reserve_preservation_destination(
             except FileNotFoundError:
                 pass
         return
+
+
+@contextmanager
+def _reserve_preservation_destination(
+    source: Path,
+    name_prefix: str,
+) -> Iterator[Path]:
+    """Reserve a collision-free preservation name without replacing data."""
+    with _reserve_exclusive_destination(
+        lambda reservation_id: source.with_name(
+            f"{name_prefix}{source.name}-{reservation_id}"
+        ),
+    ) as destination:
+        yield destination
 
 
 def _rename_migration_lock_aside(
@@ -421,6 +435,115 @@ def _sweep_migration_temps(destination_sessions: Path, log: LogFn) -> None:
             continue
 
 
+def _sweep_stale_reservations(root: Path, log: LogFn) -> None:
+    """Remove only old, empty, singly-linked migration reservation sidecars."""
+    if not root.exists():
+        return
+    stale_before = time.time() - _PRESERVATION_RESERVATION_STALE_SECONDS
+    for reservation in root.glob(
+        f"**/..pinkybot-rollout-*{_PRESERVATION_RESERVATION_SUFFIX}"
+    ):
+        try:
+            reservation_stat = reservation.lstat()
+        except FileNotFoundError:
+            continue
+        if (
+            not stat.S_ISREG(reservation_stat.st_mode)
+            or reservation_stat.st_nlink != 1
+            or reservation_stat.st_size != 0
+            or reservation_stat.st_mtime > stale_before
+        ):
+            continue
+        try:
+            reservation.unlink()
+            log(f"codex-home: removed stale migration reservation {reservation}")
+        except FileNotFoundError:
+            continue
+
+
+def _claim_has_open_descriptors(claim: Path, log: LogFn) -> bool | None:
+    """Return holder state from lsof, retaining the claim on scan uncertainty."""
+    try:
+        scan = subprocess.run(
+            ["lsof", "-Fn", "--", os.fspath(claim)],
+            stdin=subprocess.DEVNULL,
+            capture_output=True,
+            text=True,
+            timeout=_CLAIM_DESCRIPTOR_SCAN_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        log(
+            f"codex-home: retained rollout claim {claim}; "
+            f"descriptor scan unavailable: {exc}"
+        )
+        return None
+
+    stderr = scan.stderr.strip()
+    stdout = scan.stdout.strip()
+    if stderr:
+        log(
+            f"codex-home: retained rollout claim {claim}; "
+            f"descriptor scan failed: {stderr}"
+        )
+        return None
+    if scan.returncode == 0 and stdout:
+        return True
+    if scan.returncode == 1 and not stdout:
+        return False
+    log(
+        f"codex-home: retained rollout claim {claim}; descriptor scan returned "
+        f"unexpected status {scan.returncode}"
+    )
+    return None
+
+
+def _retire_rollout_claim(
+    claim: Path,
+    destination: Path,
+    target_cwd: str,
+    *,
+    log: LogFn,
+) -> bool:
+    """Retire a verified tombstone only after its descriptor set reaches zero.
+
+    A claim has a private, unguessable name: after the canonical link is
+    removed, path-based writers can only create a fresh canonical rollout.
+    Therefore no new descriptor can target the claim and its holder set only
+    shrinks.  Once lsof observes zero holders, a final byte-identity check is a
+    stable retirement boundary.
+    """
+    holders = _claim_has_open_descriptors(claim, log)
+    if holders is not False:
+        if holders:
+            log(
+                f"codex-home: retained rollout claim {claim}; "
+                "open descriptor holder(s) remain"
+            )
+        return False
+    try:
+        claim_signature = _file_signature(claim)
+    except FileNotFoundError:
+        return True
+    if not _rollout_is_valid(
+        destination,
+        target_cwd,
+        expected_signature=claim_signature,
+    ):
+        log(
+            f"codex-home: retained rollout claim {claim}; "
+            "installed destination is not byte-identical at retirement"
+        )
+        return False
+    try:
+        claim.unlink()
+        _fsync_directory(claim.parent)
+    except FileNotFoundError:
+        return True
+    log(f"codex-home: retired verified rollout claim {claim}")
+    return True
+
+
 def _quarantine_rollout(destination: Path, log: LogFn) -> Path:
     """Atomically move an invalid final aside so it cannot shadow discovery."""
     with _reserve_preservation_destination(
@@ -442,11 +565,11 @@ def _install_rollout(
 ) -> bool:
     """Install one rollout with crash recovery and concurrent convergence.
 
-    ``claim`` is a private name established by atomically renaming the canonical
-    source before this function is entered.  All reads, verification, and
-    cleanup stay on that private name.  A writer arriving after the rename must
-    create a fresh canonical file, which this migration never removes and a
-    later prepare can migrate independently.
+    ``claim`` is a private hard-link name established before the canonical name
+    is unlinked.  All reads, verification, and
+    cleanup stay on that private name.  A path-based writer arriving after the
+    canonical unlink must create a fresh canonical file, which this migration
+    never removes and a later prepare can migrate independently.
     """
     destination.parent.mkdir(parents=True, exist_ok=True)
 
@@ -466,11 +589,7 @@ def _install_rollout(
             target_cwd,
             expected_signature=claim_signature,
         ):
-            try:
-                claim.unlink()
-                _fsync_directory(claim.parent)
-            except FileNotFoundError:
-                pass
+            _retire_rollout_claim(claim, destination, target_cwd, log=log)
             log(f"codex-home: rollout migration converged at {destination}")
             return True
         _quarantine_rollout(destination, log)
@@ -494,7 +613,7 @@ def _install_rollout(
             os.fsync(temp_handle.fileno())
         copied_signature = (copied_size, copied_digest.hexdigest())
 
-        # A descriptor opened before the claim rename can still change the
+        # A descriptor opened before the canonical unlink can still change the
         # claimed inode.  Detect that shape before install and leave the claim
         # intact for retry; name-based late writers use the fresh canonical path.
         if _file_signature(claim) != copied_signature:
@@ -516,10 +635,10 @@ def _install_rollout(
             _quarantine_rollout(destination, log)
             raise RuntimeError(f"rollout migration final failed validation: {destination}")
 
-        # Removal targets only the private claim.  There is deliberately no
-        # check-then-remove pair on the canonical writer path.
-        claim.unlink()
-        _fsync_directory(claim.parent)
+        # Installation does not consume the private claim. Retirement is a
+        # separate verified-tombstone boundary: zero descriptor holders first,
+        # then a stable byte-identity check against the installed destination.
+        _retire_rollout_claim(claim, destination, target_cwd, log=log)
         return True
     except FileNotFoundError:
         # A crash-recovery claim may already have been consumed by a concurrent
@@ -558,17 +677,31 @@ def _claim_original_path(claim: Path) -> Path | None:
 
 
 def _claim_rollout(source: Path) -> Path | None:
-    """Atomically remove the canonical writer target before migration reads."""
+    """Claim a rollout without any replacing rename operation.
+
+    The hard link is a non-replacing atomic publication: EEXIST loses the UUID
+    attempt without touching the interleaved claim.  Only after the claim link
+    exists do we unlink the canonical writer name.  Descriptors opened before
+    that unlink remain attached to the claimed inode for verified retirement.
+    """
     while True:
-        claim = source.with_name(
-            f"{_MIGRATION_CLAIM_PREFIX}{uuid.uuid4().hex}-{source.name}"
-        )
-        if _path_entry_exists(claim):
-            continue
-        try:
-            os.rename(source, claim)
-        except FileNotFoundError:
-            return None
+        with _reserve_exclusive_destination(
+            lambda claim_id: source.with_name(
+                f"{_MIGRATION_CLAIM_PREFIX}{claim_id}-{source.name}"
+            ),
+        ) as claim:
+            try:
+                os.link(source, claim, follow_symlinks=False)
+            except FileExistsError:
+                continue
+            except FileNotFoundError:
+                return None
+            try:
+                source.unlink()
+            except FileNotFoundError:
+                # A concurrent claimant may already have removed the canonical
+                # name. This private hard link still owns the original inode.
+                pass
         _fsync_directory(source.parent)
         return claim
 
@@ -642,6 +775,8 @@ def move_matching_rollouts(
         # works across daemon processes. The kernel releases flock on crash,
         # after which the successor sweeps the abandoned private temp.
         _sweep_migration_temps(destination_sessions, log)
+        _sweep_stale_reservations(source_sessions, log)
+        _sweep_stale_reservations(destination_sessions, log)
         return _move_rollout_candidates(
             candidates,
             source_sessions,
@@ -770,6 +905,12 @@ def _run_initial_rollout_migration(
     closing the scan-to-marker race between concurrent spawns.
     """
     marker = resolved_home / ROLLOUT_MIGRATION_MARKER
+    source_sessions = shared_home / "sessions"
+    destination_sessions = resolved_home / "sessions"
+    # Reservations are private zero-byte coordination artifacts. Sweep old
+    # crash residue even when the durable marker lets migration return early.
+    _sweep_stale_reservations(source_sessions, log)
+    _sweep_stale_reservations(destination_sessions, log)
     if _path_entry_exists(marker):
         retry_sources = _read_marker_retry_sources(marker)
         if not retry_sources:
@@ -778,8 +919,6 @@ def _run_initial_rollout_migration(
                 "shared rollout store not scanned"
             )
             return 0
-        source_sessions = shared_home / "sessions"
-        destination_sessions = resolved_home / "sessions"
         candidates = _retry_rollout_candidates(source_sessions, retry_sources)
         if not candidates:
             log(
@@ -804,8 +943,6 @@ def _run_initial_rollout_migration(
         )
         return result.moved
 
-    source_sessions = shared_home / "sessions"
-    destination_sessions = resolved_home / "sessions"
     candidates = _snapshot_rollout_candidates(source_sessions)
     target_cwd = os.path.realpath(str(working_dir))
     lock_path = destination_sessions / _MIGRATION_LOCK_NAME

--- a/src/pinky_daemon/codex_home.py
+++ b/src/pinky_daemon/codex_home.py
@@ -210,6 +210,17 @@ def _file_signature(path: Path) -> tuple[int, str]:
     return size, digest.hexdigest()
 
 
+def _file_signature_from_handle(handle: BinaryIO) -> tuple[int, str]:
+    """Return an exact size+digest signature through an already-open file."""
+    handle.seek(0)
+    digest = hashlib.sha256()
+    size = 0
+    while chunk := handle.read(1024 * 1024):
+        digest.update(chunk)
+        size += len(chunk)
+    return size, digest.hexdigest()
+
+
 def _rollout_is_valid(
     path: Path,
     target_cwd: str,
@@ -465,7 +476,15 @@ def _claim_has_open_descriptors(claim: Path, log: LogFn) -> bool | None:
     """Return holder state from lsof, retaining the claim on scan uncertainty."""
     try:
         scan = subprocess.run(
-            ["lsof", "-Fn", "--", os.fspath(claim)],
+            [
+                "lsof",
+                "-Fn",
+                "-a",
+                "-p",
+                f"^{os.getpid()}",
+                "--",
+                os.fspath(claim),
+            ],
             stdin=subprocess.DEVNULL,
             capture_output=True,
             text=True,
@@ -498,6 +517,170 @@ def _claim_has_open_descriptors(claim: Path, log: LogFn) -> bool | None:
     return None
 
 
+def _parse_lsof_integer(raw: str) -> int | None:
+    """Parse a decimal or hexadecimal lsof identity field."""
+    try:
+        return int(raw, 16 if raw.lower().startswith("0x") else 10)
+    except ValueError:
+        return None
+
+
+def _inode_has_open_descriptors(
+    claim_handle: BinaryIO,
+    claim: Path,
+    log: LogFn,
+) -> bool | None:
+    """Re-scan an unlinked claim by device and inode.
+
+    A full field scan avoids depending on a pathname after unlink. The exact
+    descriptor owned by this retirement is excluded; any other descriptor,
+    including one in this process, retains the bytes through a recovery claim.
+    """
+    try:
+        scan = subprocess.run(
+            ["lsof", "-F", "pfDi"],
+            stdin=subprocess.DEVNULL,
+            capture_output=True,
+            text=True,
+            timeout=_CLAIM_DESCRIPTOR_SCAN_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        log(
+            f"codex-home: claim retirement boundary-condition check for {claim} "
+            f"could not re-scan the inode: {exc}"
+        )
+        return None
+
+    stderr = scan.stderr.strip()
+    stdout = scan.stdout.strip()
+    if stderr:
+        log(
+            f"codex-home: claim retirement boundary-condition check for {claim} "
+            f"could not re-scan the inode: {stderr}"
+        )
+        return None
+    if scan.returncode != 0 or not stdout:
+        log(
+            f"codex-home: claim retirement boundary-condition check for {claim} "
+            f"received unexpected re-scan status {scan.returncode}"
+        )
+        return None
+
+    records: list[tuple[int | None, str, int | None, int | None]] = []
+    current_pid: int | None = None
+    current_fd = ""
+    current_device: int | None = None
+    current_inode: int | None = None
+
+    def finish_record() -> None:
+        if current_fd:
+            records.append(
+                (current_pid, current_fd, current_device, current_inode)
+            )
+
+    for line in stdout.splitlines():
+        if not line:
+            continue
+        field, value = line[0], line[1:]
+        if field == "p":
+            finish_record()
+            current_pid = _parse_lsof_integer(value)
+            current_fd = ""
+            current_device = None
+            current_inode = None
+        elif field == "f":
+            finish_record()
+            current_fd = value
+            current_device = None
+            current_inode = None
+        elif field == "D" and current_fd:
+            current_device = _parse_lsof_integer(value)
+        elif field == "i" and current_fd:
+            current_inode = _parse_lsof_integer(value)
+    finish_record()
+
+    claim_stat = os.fstat(claim_handle.fileno())
+    target_identity = (claim_stat.st_dev, claim_stat.st_ino)
+    own_identity = (os.getpid(), claim_handle.fileno())
+    found_own_descriptor = False
+    for process_id, descriptor, device, inode in records:
+        if (device, inode) != target_identity:
+            continue
+        descriptor_number = ""
+        for character in descriptor:
+            if not character.isdigit():
+                break
+            descriptor_number += character
+        parsed_descriptor = (
+            int(descriptor_number) if descriptor_number else None
+        )
+        if (process_id, parsed_descriptor) == own_identity:
+            found_own_descriptor = True
+            continue
+        return True
+
+    if found_own_descriptor:
+        return False
+    log(
+        f"codex-home: claim retirement boundary-condition check for {claim} "
+        "did not find its own descriptor in the inode re-scan"
+    )
+    return None
+
+
+def _recover_unlinked_rollout_claim(
+    claim: Path,
+    claim_handle: BinaryIO,
+    log: LogFn,
+) -> Path:
+    """Copy current unlinked bytes into a complete, discoverable claim."""
+    canonical = _claim_original_path(claim)
+    if canonical is None:
+        raise RuntimeError(f"cannot recover malformed rollout claim name: {claim}")
+
+    temp_fd, temp_name = tempfile.mkstemp(
+        dir=claim.parent,
+        prefix=f"{_MIGRATION_TEMP_PREFIX}recovery-",
+        suffix=_MIGRATION_TEMP_SUFFIX,
+    )
+    temp_path = Path(temp_name)
+    try:
+        claim_handle.seek(0)
+        with os.fdopen(temp_fd, "wb") as temp_handle:
+            temp_fd = -1
+            while chunk := claim_handle.read(1024 * 1024):
+                temp_handle.write(chunk)
+            temp_handle.flush()
+            os.fsync(temp_handle.fileno())
+
+        while True:
+            with _reserve_exclusive_destination(
+                lambda recovery_id: claim.with_name(
+                    f"{_MIGRATION_CLAIM_PREFIX}{recovery_id}-{canonical.name}"
+                ),
+            ) as recovery:
+                try:
+                    os.link(temp_path, recovery, follow_symlinks=False)
+                except FileExistsError:
+                    continue
+            break
+        temp_path.unlink()
+        _fsync_directory(claim.parent)
+    finally:
+        if temp_fd >= 0:
+            os.close(temp_fd)
+        try:
+            temp_path.unlink()
+        except FileNotFoundError:
+            pass
+    log(
+        "codex-home: WARNING claim retirement boundary-condition check "
+        f"preserved current bytes as recovery claim {recovery}"
+    )
+    return recovery
+
+
 def _retire_rollout_claim(
     claim: Path,
     destination: Path,
@@ -505,41 +688,89 @@ def _retire_rollout_claim(
     *,
     log: LogFn,
 ) -> bool:
-    """Retire a verified tombstone only after its descriptor set reaches zero.
-
-    A claim has a private, unguessable name: after the canonical link is
-    removed, path-based writers can only create a fresh canonical rollout.
-    Therefore no new descriptor can target the claim and its holder set only
-    shrinks.  Once lsof observes zero holders, a final byte-identity check is a
-    stable retirement boundary.
-    """
-    holders = _claim_has_open_descriptors(claim, log)
-    if holders is not False:
-        if holders:
+    """Retire a verified tombstone with post-unlink recovery verification."""
+    nofollow = getattr(os, "O_NOFOLLOW", None)
+    if nofollow is None:
+        raise RuntimeError("rollout claim path resolution requires O_NOFOLLOW")
+    flags = os.O_RDONLY | nofollow | getattr(os, "O_CLOEXEC", 0)
+    try:
+        claim_fd = os.open(claim, flags)
+    except FileNotFoundError:
+        return True
+    with os.fdopen(claim_fd, "rb", buffering=0) as claim_handle:
+        opened_stat = os.fstat(claim_handle.fileno())
+        try:
+            current_stat = claim.lstat()
+        except FileNotFoundError:
+            current_stat = None
+        if (
+            current_stat is None
+            or not stat.S_ISREG(opened_stat.st_mode)
+            or (opened_stat.st_dev, opened_stat.st_ino)
+            != (current_stat.st_dev, current_stat.st_ino)
+        ):
             log(
                 f"codex-home: retained rollout claim {claim}; "
-                "open descriptor holder(s) remain"
+                "claim identity changed during verification"
             )
-        return False
-    try:
-        claim_signature = _file_signature(claim)
-    except FileNotFoundError:
-        return True
-    if not _rollout_is_valid(
-        destination,
-        target_cwd,
-        expected_signature=claim_signature,
-    ):
-        log(
-            f"codex-home: retained rollout claim {claim}; "
-            "installed destination is not byte-identical at retirement"
+            return False
+
+        holders = _claim_has_open_descriptors(claim, log)
+        if holders is not False:
+            if holders:
+                log(
+                    f"codex-home: retained rollout claim {claim}; "
+                    "open descriptor holder(s) remain"
+                )
+            return False
+
+        claim_signature = _file_signature_from_handle(claim_handle)
+        if not _rollout_is_valid(
+            destination,
+            target_cwd,
+            expected_signature=claim_signature,
+        ):
+            log(
+                f"codex-home: retained rollout claim {claim}; "
+                "installed destination is not byte-identical at retirement"
+            )
+            return False
+
+        try:
+            current_stat = claim.lstat()
+        except FileNotFoundError:
+            current_stat = None
+        if current_stat is not None and (
+            opened_stat.st_dev,
+            opened_stat.st_ino,
+        ) != (current_stat.st_dev, current_stat.st_ino):
+            log(
+                f"codex-home: retained rollout claim {claim}; "
+                "claim identity changed before unlink"
+            )
+            return False
+        if current_stat is not None:
+            try:
+                claim.unlink()
+            except FileNotFoundError:
+                pass
+            _fsync_directory(claim.parent)
+
+        post_unlink_holders = _inode_has_open_descriptors(
+            claim_handle,
+            claim,
+            log,
         )
-        return False
-    try:
-        claim.unlink()
-        _fsync_directory(claim.parent)
-    except FileNotFoundError:
-        return True
+        current_signature = _file_signature_from_handle(claim_handle)
+        current_destination_matches = _rollout_is_valid(
+            destination,
+            target_cwd,
+            expected_signature=current_signature,
+        )
+        if post_unlink_holders is not False or not current_destination_matches:
+            _recover_unlinked_rollout_claim(claim, claim_handle, log)
+            return False
+
     log(f"codex-home: retired verified rollout claim {claim}")
     return True
 

--- a/src/pinky_daemon/codex_home.py
+++ b/src/pinky_daemon/codex_home.py
@@ -35,6 +35,7 @@ _MIGRATION_LOCK_NAME = ".pinkybot-rollout-migration.lock"
 _MIGRATION_LOCK_ASIDE_PREFIX = ".pinkybot-rollout-lock-aside-"
 _PRESERVATION_RESERVATION_SUFFIX = ".reserve"
 _PRESERVATION_RESERVATION_STALE_SECONDS = 60 * 60
+_RESERVATION_ACQUIRE_MAX_ATTEMPTS = 8
 _CLAIM_DESCRIPTOR_SCAN_TIMEOUT_SECONDS = 2.0
 _LSOF_FALLBACK_PATHS = ("/usr/sbin/lsof", "/usr/bin/lsof")
 _CRASH_FROZEN_CLAIM_MODE = stat.S_IRUSR | stat.S_IWUSR
@@ -276,6 +277,8 @@ def _migration_lock_entry_kind(entry_stat: os.stat_result) -> str:
 @contextmanager
 def _reserve_exclusive_destination(
     destination_for_uuid: Callable[[str], Path],
+    *,
+    log: LogFn,
 ) -> Iterator[Path]:
     """Reserve a collision-free private name without replacing data.
 
@@ -288,43 +291,87 @@ def _reserve_exclusive_destination(
     nofollow = getattr(os, "O_NOFOLLOW", 0)
     cloexec = getattr(os, "O_CLOEXEC", 0)
     flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | nofollow | cloexec
-    while True:
+    last_reservation: Path | None = None
+    for _attempt in range(_RESERVATION_ACQUIRE_MAX_ATTEMPTS):
         destination = destination_for_uuid(uuid.uuid4().hex)
         reservation = destination.with_name(
             f".{destination.name}{_PRESERVATION_RESERVATION_SUFFIX}"
         )
+        last_reservation = reservation
         try:
             reservation_fd = os.open(reservation, flags, 0o600)
         except FileExistsError:
             continue
+        locked = False
         try:
-            fcntl.flock(reservation_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            try:
+                fcntl.flock(reservation_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            except OSError as exc:
+                if exc.errno in (errno.EACCES, errno.EAGAIN):
+                    continue
+                raise
+            locked = True
+            if not _path_matches_descriptor(reservation, reservation_fd):
+                continue
             if _path_entry_exists(destination):
-                reservation.unlink()
+                _unlink_locked_reservation(reservation, reservation_fd)
                 continue
             try:
                 yield destination
             finally:
-                try:
-                    reservation.unlink()
-                except FileNotFoundError:
-                    pass
+                _unlink_locked_reservation(reservation, reservation_fd)
         finally:
-            fcntl.flock(reservation_fd, fcntl.LOCK_UN)
+            if locked:
+                fcntl.flock(reservation_fd, fcntl.LOCK_UN)
             os.close(reservation_fd)
         return
+
+    message = (
+        "codex-home: exclusive migration reservation did not converge after "
+        f"{_RESERVATION_ACQUIRE_MAX_ATTEMPTS} attempts near {last_reservation}; "
+        "refusing non-replacing publication"
+    )
+    log(message)
+    raise RuntimeError(message)
+
+
+def _path_matches_descriptor(path: Path, descriptor: int) -> bool:
+    """Return whether a descriptor still owns a named directory entry."""
+    try:
+        descriptor_stat = os.fstat(descriptor)
+        path_stat = path.lstat()
+    except OSError:
+        return False
+    return (descriptor_stat.st_dev, descriptor_stat.st_ino) == (
+        path_stat.st_dev,
+        path_stat.st_ino,
+    )
+
+
+def _unlink_locked_reservation(reservation: Path, reservation_fd: int) -> bool:
+    """Unlink a reservation only while its locked descriptor owns the name."""
+    if not _path_matches_descriptor(reservation, reservation_fd):
+        return False
+    try:
+        reservation.unlink()
+    except FileNotFoundError:
+        return False
+    return True
 
 
 @contextmanager
 def _reserve_preservation_destination(
     source: Path,
     name_prefix: str,
+    *,
+    log: LogFn,
 ) -> Iterator[Path]:
     """Reserve a collision-free preservation name without replacing data."""
     with _reserve_exclusive_destination(
         lambda reservation_id: source.with_name(
             f"{name_prefix}{source.name}-{reservation_id}"
         ),
+        log=log,
     ) as destination:
         yield destination
 
@@ -348,6 +395,7 @@ def _rename_migration_lock_aside(
     with _reserve_preservation_destination(
         lock_path,
         _MIGRATION_LOCK_ASIDE_PREFIX,
+        log=log,
     ) as aside:
         os.rename(lock_path, aside)
     _fsync_directory(lock_path.parent)
@@ -501,9 +549,7 @@ def _sweep_stale_reservations(root: Path, log: LogFn) -> None:
                 if exc.errno in (errno.EACCES, errno.EAGAIN):
                     continue
                 raise
-            try:
-                reservation.unlink()
-            except FileNotFoundError:
+            if not _unlink_locked_reservation(reservation, reservation_fd):
                 continue
             kind = (
                 "stale"
@@ -825,6 +871,7 @@ def _publish_frozen_rollout_recovery(
                 lambda recovery_id: claim.with_name(
                     f"{_MIGRATION_CLAIM_PREFIX}{recovery_id}-{canonical.name}"
                 ),
+                log=log,
             ) as candidate:
                 try:
                     os.link(temp_path, candidate, follow_symlinks=False)
@@ -1024,6 +1071,7 @@ def _quarantine_rollout(destination: Path, log: LogFn) -> Path:
     with _reserve_preservation_destination(
         destination,
         _MIGRATION_QUARANTINE_PREFIX,
+        log=log,
     ) as quarantine:
         os.rename(destination, quarantine)
     _fsync_directory(destination.parent)
@@ -1165,7 +1213,7 @@ def _claim_original_path(claim: Path) -> Path | None:
     return claim.with_name(original_name)
 
 
-def _claim_rollout(source: Path) -> Path | None:
+def _claim_rollout(source: Path, *, log: LogFn) -> Path | None:
     """Claim a rollout without any replacing rename operation.
 
     The hard link is a non-replacing atomic publication: EEXIST loses the UUID
@@ -1178,6 +1226,7 @@ def _claim_rollout(source: Path) -> Path | None:
             lambda claim_id: source.with_name(
                 f"{_MIGRATION_CLAIM_PREFIX}{claim_id}-{source.name}"
             ),
+            log=log,
         ) as claim:
             try:
                 os.link(source, claim, follow_symlinks=False)
@@ -1321,7 +1370,7 @@ def _move_rollout_candidates(
             continue
         if os.path.realpath(rollout_cwd) != target_cwd:
             continue
-        claim = candidate.claim or _claim_rollout(source)
+        claim = candidate.claim or _claim_rollout(source, log=log)
         if claim is None:
             if _rollout_is_valid(destination, target_cwd):
                 log(

--- a/src/pinky_daemon/codex_home.py
+++ b/src/pinky_daemon/codex_home.py
@@ -8,6 +8,7 @@ import hashlib
 import json
 import math
 import os
+import shutil
 import stat
 import subprocess
 import tempfile
@@ -17,6 +18,7 @@ from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime, timezone
+from functools import cache
 from pathlib import Path
 from typing import BinaryIO
 
@@ -34,6 +36,7 @@ _MIGRATION_LOCK_ASIDE_PREFIX = ".pinkybot-rollout-lock-aside-"
 _PRESERVATION_RESERVATION_SUFFIX = ".reserve"
 _PRESERVATION_RESERVATION_STALE_SECONDS = 60 * 60
 _CLAIM_DESCRIPTOR_SCAN_TIMEOUT_SECONDS = 2.0
+_LSOF_FALLBACK_PATHS = ("/usr/sbin/lsof", "/usr/bin/lsof")
 _CRASH_FROZEN_CLAIM_MODE = stat.S_IRUSR | stat.S_IWUSR
 _DEFAULT_MIGRATION_LOCK_TIMEOUT_SECONDS = 10.0
 _MIGRATION_LOCK_RETRY_SECONDS = 0.05
@@ -514,6 +517,19 @@ def _sweep_stale_reservations(root: Path, log: LogFn) -> None:
             os.close(reservation_fd)
 
 
+@cache
+def _resolve_lsof_binary() -> str | None:
+    """Resolve lsof across daemon and login-shell PATH differences."""
+    resolved = shutil.which("lsof")
+    if resolved is not None:
+        return resolved
+    for fallback in _LSOF_FALLBACK_PATHS:
+        resolved = shutil.which(fallback)
+        if resolved is not None:
+            return resolved
+    return None
+
+
 def _claim_has_open_descriptors(claim: Path, log: LogFn) -> bool | None:
     """Return whether any descriptor holds a claim path.
 
@@ -521,9 +537,16 @@ def _claim_has_open_descriptors(claim: Path, log: LogFn) -> bool | None:
     live retirement. It deliberately includes this process: another retirer in
     the same process is still a live holder and must keep the freeze intact.
     """
+    lsof_binary = _resolve_lsof_binary()
+    if lsof_binary is None:
+        log(
+            f"codex-home: retained rollout claim {claim}; "
+            "descriptor scan unavailable: lsof executable not found"
+        )
+        return None
     try:
         scan = subprocess.run(
-            ["lsof", "-Fn", "--", os.fspath(claim)],
+            [lsof_binary, "-Fn", "--", os.fspath(claim)],
             stdin=subprocess.DEVNULL,
             capture_output=True,
             text=True,
@@ -570,9 +593,17 @@ def _inode_has_open_descriptors(
     log: LogFn,
 ) -> bool | None:
     """Scan a frozen claim by device and inode, excluding only this handle."""
+    lsof_binary = _resolve_lsof_binary()
+    if lsof_binary is None:
+        log(
+            f"codex-home: claim retirement boundary-condition check for {claim} "
+            "descriptor scan unavailable for frozen inode: "
+            "lsof executable not found"
+        )
+        return None
     try:
         scan = subprocess.run(
-            ["lsof", "-F", "pfDi"],
+            [lsof_binary, "-F", "pfDi"],
             stdin=subprocess.DEVNULL,
             capture_output=True,
             text=True,

--- a/src/pinky_daemon/codex_home.py
+++ b/src/pinky_daemon/codex_home.py
@@ -2,25 +2,34 @@
 
 from __future__ import annotations
 
+import errno
 import fcntl
 import hashlib
 import json
+import math
 import os
 import stat
 import tempfile
+import time
 import uuid
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import BinaryIO
 
 PER_AGENT_CODEX_HOME_ENV = "PINKY_CODEX_PER_AGENT_HOME"
 MANAGED_CONFIG_SENTINEL = "# pinkybot-managed-codex-home-v1"
 ROLLOUT_MIGRATION_MARKER = ".pinkybot-rollout-migration-v1.json"
+MIGRATION_LOCK_TIMEOUT_ENV = "PINKY_CODEX_HOME_LOCK_TIMEOUT_SECONDS"
 
 _MIGRATION_TEMP_PREFIX = ".pinkybot-rollout-migration-"
 _MIGRATION_TEMP_SUFFIX = ".tmp"
 _MIGRATION_QUARANTINE_PREFIX = ".pinkybot-rollout-quarantine-"
 _MIGRATION_LOCK_NAME = ".pinkybot-rollout-migration.lock"
+_MIGRATION_LOCK_ASIDE_PREFIX = ".pinkybot-rollout-lock-aside-"
+_DEFAULT_MIGRATION_LOCK_TIMEOUT_SECONDS = 10.0
+_MIGRATION_LOCK_RETRY_SECONDS = 0.05
 
 LogFn = Callable[[str], None]
 
@@ -207,6 +216,139 @@ def _fsync_directory(path: Path) -> None:
         os.close(fd)
 
 
+def _migration_lock_timeout_seconds() -> float:
+    """Return the bounded destination-lock acquisition window."""
+    raw = os.environ.get(MIGRATION_LOCK_TIMEOUT_ENV, "").strip()
+    if not raw:
+        return _DEFAULT_MIGRATION_LOCK_TIMEOUT_SECONDS
+    try:
+        timeout = float(raw)
+    except ValueError as exc:
+        raise RuntimeError(f"invalid {MIGRATION_LOCK_TIMEOUT_ENV}: {raw!r}") from exc
+    if not math.isfinite(timeout) or timeout <= 0:
+        raise RuntimeError(f"invalid {MIGRATION_LOCK_TIMEOUT_ENV}: {raw!r}")
+    return timeout
+
+
+def _migration_lock_entry_kind(entry_stat: os.stat_result) -> str:
+    if stat.S_ISLNK(entry_stat.st_mode) or entry_stat.st_nlink > 1:
+        return "linked"
+    if not stat.S_ISREG(entry_stat.st_mode):
+        return "non-regular"
+    return ""
+
+
+def _rename_migration_lock_aside(
+    lock_path: Path,
+    entry_stat: os.stat_result,
+    kind: str,
+    log: LogFn,
+) -> bool:
+    """Preserve a rejected lock entry without following it."""
+    try:
+        current_stat = lock_path.lstat()
+    except FileNotFoundError:
+        return False
+    if (current_stat.st_dev, current_stat.st_ino) != (
+        entry_stat.st_dev,
+        entry_stat.st_ino,
+    ):
+        return False
+    aside = lock_path.with_name(
+        f"{_MIGRATION_LOCK_ASIDE_PREFIX}{lock_path.name}-{uuid.uuid4().hex}"
+    )
+    os.replace(lock_path, aside)
+    _fsync_directory(lock_path.parent)
+    log(f"codex-home: renamed {kind} migration lock entry {lock_path} aside as {aside}")
+    return True
+
+
+def _open_migration_lock(lock_path: Path, log: LogFn) -> BinaryIO:
+    """Open a stable regular lock entry without following links."""
+    nofollow = getattr(os, "O_NOFOLLOW", None)
+    if nofollow is None:
+        raise RuntimeError("migration lock path resolution requires O_NOFOLLOW")
+    flags = os.O_RDWR | os.O_CREAT | os.O_APPEND | os.O_NONBLOCK | nofollow
+    flags |= getattr(os, "O_CLOEXEC", 0)
+
+    for _attempt in range(8):
+        try:
+            entry_stat = lock_path.lstat()
+        except FileNotFoundError:
+            entry_stat = None
+        if entry_stat is not None:
+            kind = _migration_lock_entry_kind(entry_stat)
+            if kind:
+                _rename_migration_lock_aside(lock_path, entry_stat, kind, log)
+                continue
+
+        try:
+            fd = os.open(lock_path, flags, 0o600)
+        except OSError as exc:
+            if exc.errno in (errno.ELOOP, errno.EISDIR, errno.ENXIO):
+                continue
+            raise
+
+        try:
+            opened_stat = os.fstat(fd)
+            current_stat = lock_path.lstat()
+            kind = _migration_lock_entry_kind(opened_stat)
+            same_entry = (opened_stat.st_dev, opened_stat.st_ino) == (
+                current_stat.st_dev,
+                current_stat.st_ino,
+            )
+            if not kind and same_entry:
+                return os.fdopen(fd, "a+b")
+        except FileNotFoundError:
+            kind = ""
+            current_stat = None
+            same_entry = False
+        except BaseException:
+            os.close(fd)
+            raise
+
+        os.close(fd)
+        if kind and current_stat is not None and same_entry:
+            _rename_migration_lock_aside(lock_path, current_stat, kind, log)
+
+    raise RuntimeError(f"migration lock path resolution did not converge: {lock_path}")
+
+
+@contextmanager
+def _acquire_migration_lock(lock_path: Path, log: LogFn) -> Iterator[BinaryIO]:
+    """Acquire the destination writer lock within a fixed wall-clock bound."""
+    timeout = _migration_lock_timeout_seconds()
+    deadline = time.monotonic() + timeout
+    lock_handle = _open_migration_lock(lock_path, log)
+    acquired = False
+    try:
+        while True:
+            try:
+                fcntl.flock(
+                    lock_handle.fileno(),
+                    fcntl.LOCK_EX | fcntl.LOCK_NB,
+                )
+                acquired = True
+                break
+            except OSError as exc:
+                if exc.errno not in (errno.EACCES, errno.EAGAIN):
+                    raise
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    message = (
+                        "codex-home: migration lock deadline exceeded after "
+                        f"{timeout:g}s at {lock_path}; refusing rollout migration"
+                    )
+                    log(message)
+                    raise RuntimeError(message)
+                time.sleep(min(_MIGRATION_LOCK_RETRY_SECONDS, remaining))
+        yield lock_handle
+    finally:
+        if acquired:
+            fcntl.flock(lock_handle.fileno(), fcntl.LOCK_UN)
+        lock_handle.close()
+
+
 def _sweep_migration_temps(destination_sessions: Path, log: LogFn) -> None:
     """Remove private copy temps abandoned before an atomic install."""
     if not destination_sessions.exists():
@@ -263,6 +405,8 @@ def _install_rollout(
             expected_signature=source_signature,
         ):
             try:
+                if _file_signature(source) != source_signature:
+                    raise RuntimeError(f"rollout changed before source removal: {source}")
                 source.unlink()
                 _fsync_directory(source.parent)
             except FileNotFoundError:
@@ -312,6 +456,8 @@ def _install_rollout(
             raise RuntimeError(f"rollout migration final failed validation: {destination}")
 
         try:
+            if _file_signature(source) != copied_signature:
+                raise RuntimeError(f"rollout changed before source removal: {source}")
             source.unlink()
             _fsync_directory(source.parent)
         except FileNotFoundError:
@@ -363,22 +509,18 @@ def move_matching_rollouts(
     candidates = list(source_sessions.glob("**/rollout-*.jsonl"))
     destination_sessions.mkdir(parents=True, exist_ok=True)
     lock_path = destination_sessions / _MIGRATION_LOCK_NAME
-    with lock_path.open("a+b") as lock_handle:
+    with _acquire_migration_lock(lock_path, log):
         # Serializing destination writers makes temp cleanup race-free and
         # works across daemon processes. The kernel releases flock on crash,
         # after which the successor sweeps the abandoned private temp.
-        fcntl.flock(lock_handle.fileno(), fcntl.LOCK_EX)
-        try:
-            _sweep_migration_temps(destination_sessions, log)
-            return _move_rollout_candidates(
-                candidates,
-                source_sessions,
-                destination_sessions,
-                target_cwd,
-                log=log,
-            )
-        finally:
-            fcntl.flock(lock_handle.fileno(), fcntl.LOCK_UN)
+        _sweep_migration_temps(destination_sessions, log)
+        return _move_rollout_candidates(
+            candidates,
+            source_sessions,
+            destination_sessions,
+            target_cwd,
+            log=log,
+        )
 
 
 def _move_rollout_candidates(
@@ -467,34 +609,30 @@ def _run_initial_rollout_migration(
     candidates = list(source_sessions.glob("**/rollout-*.jsonl"))
     target_cwd = os.path.realpath(str(working_dir))
     lock_path = destination_sessions / _MIGRATION_LOCK_NAME
-    with lock_path.open("a+b") as lock_handle:
-        fcntl.flock(lock_handle.fileno(), fcntl.LOCK_EX)
-        try:
-            if _path_entry_exists(marker):
-                converged = sum(
-                    _rollout_is_valid(
-                        destination_sessions / source.relative_to(source_sessions),
-                        target_cwd,
-                    )
-                    for source in candidates
+    with _acquire_migration_lock(lock_path, log):
+        if _path_entry_exists(marker):
+            converged = sum(
+                _rollout_is_valid(
+                    destination_sessions / source.relative_to(source_sessions),
+                    target_cwd,
                 )
-                log(
-                    f"codex-home: concurrent rollout migration converged on "
-                    f"{converged} installed rollout(s); marker already committed"
-                )
-                return converged
-            _sweep_migration_temps(destination_sessions, log)
-            moved = _move_rollout_candidates(
-                candidates,
-                source_sessions,
-                destination_sessions,
-                target_cwd,
-                log=log,
+                for source in candidates
             )
-            _write_migration_marker(resolved_home, moved)
-            return moved
-        finally:
-            fcntl.flock(lock_handle.fileno(), fcntl.LOCK_UN)
+            log(
+                f"codex-home: concurrent rollout migration converged on "
+                f"{converged} installed rollout(s); marker already committed"
+            )
+            return converged
+        _sweep_migration_temps(destination_sessions, log)
+        moved = _move_rollout_candidates(
+            candidates,
+            source_sessions,
+            destination_sessions,
+            target_cwd,
+            log=log,
+        )
+        _write_migration_marker(resolved_home, moved)
+        return moved
 
 
 def prepare_agent_codex_home(agent: object, *, log: LogFn) -> Path:

--- a/src/pinky_daemon/codex_session.py
+++ b/src/pinky_daemon/codex_session.py
@@ -29,6 +29,10 @@ from pinky_daemon.codex_app_server import (
     spawn_app_server,
 )
 from pinky_daemon.codex_app_server_tmux import CodexAppServerSupervisor
+from pinky_daemon.codex_home import (
+    per_agent_codex_home_enabled,
+    prepare_agent_codex_home,
+)
 from pinky_daemon.context_estimator import ContextTextEstimator
 from pinky_daemon.sessions import SessionUsage
 from pinky_daemon.streaming_session import (
@@ -196,6 +200,7 @@ class CodexSession:
                 self.agent_name,
                 working_dir=self._working_dir,
                 openai_api_key=self._openai_api_key,
+                agent_config=config,
                 log=_log,
             )
         self._app_client: CodexAppServerClient | None = None
@@ -914,6 +919,17 @@ class CodexSession:
         cmd.append("-")
         return cmd
 
+    def _build_codex_env(self) -> dict[str, str]:
+        """Build the full process environment with the agent-home overlay."""
+        env = {**os.environ}
+        if self._openai_api_key:
+            env["OPENAI_API_KEY"] = self._openai_api_key
+        if per_agent_codex_home_enabled():
+            env["CODEX_HOME"] = str(
+                prepare_agent_codex_home(self._config, log=_log)
+            )
+        return env
+
     async def _exec_codex(
         self,
         prompt: str,
@@ -938,10 +954,7 @@ class CodexSession:
 
         cmd = self._build_codex_cmd()
 
-        # Build environment
-        env = {**os.environ}
-        if self._openai_api_key:
-            env["OPENAI_API_KEY"] = self._openai_api_key
+        env = self._build_codex_env()
 
         _log(
             f"codex[{self.agent_name}]: exec "
@@ -1119,9 +1132,7 @@ class CodexSession:
                 server_request_handler=self._on_appserver_request,
             )
         else:
-            env = {**os.environ}
-            if self._openai_api_key:
-                env["OPENAI_API_KEY"] = self._openai_api_key
+            env = self._build_codex_env()
 
             self._app_client, self._app_proc = await spawn_app_server(
                 cwd=self._working_dir,

--- a/src/pinky_daemon/codex_session.py
+++ b/src/pinky_daemon/codex_session.py
@@ -924,11 +924,16 @@ class CodexSession:
         env = {**os.environ}
         if self._openai_api_key:
             env["OPENAI_API_KEY"] = self._openai_api_key
-        if per_agent_codex_home_enabled():
-            env["CODEX_HOME"] = str(
-                prepare_agent_codex_home(self._config, log=_log)
-            )
+        prepared_home = self._preflight_agent_codex_home()
+        if prepared_home is not None:
+            env["CODEX_HOME"] = prepared_home
         return env
+
+    def _preflight_agent_codex_home(self) -> str | None:
+        """Validate and prepare replacement-home state before teardown/spawn."""
+        if not per_agent_codex_home_enabled():
+            return None
+        return str(prepare_agent_codex_home(self._config, log=_log))
 
     async def _exec_codex(
         self,
@@ -1124,8 +1129,7 @@ class CodexSession:
         # replacement spawn proves its Codex home can be prepared safely.
         direct_env: dict[str, str] | None = None
         if self._use_tmux_app_server:
-            if per_agent_codex_home_enabled():
-                prepare_agent_codex_home(self._config, log=_log)
+            self._preflight_agent_codex_home()
         else:
             direct_env = self._build_codex_env()
 
@@ -1798,6 +1802,15 @@ class CodexSession:
                 _log(f"codex[{self.agent_name}]: restart blocked")
                 return False
 
+        # Prove the replacement home before taking transition ownership or
+        # touching the current process/client. A refusal leaves the live
+        # transport and its CONNECTED state intact in both app-server modes.
+        try:
+            self._preflight_agent_codex_home()
+        except Exception as e:
+            _log(f"codex[{self.agent_name}]: force restart preflight failed: {e}")
+            return False
+
         _log(f"codex[{self.agent_name}]: force restarting")
 
         # Own the CONNECTED → RECONNECTING transition (USER_AGENT = the agent's
@@ -1919,6 +1932,15 @@ class CodexSession:
         / IDLE_SLEEPING / DEAD via WATCHDOG (the default; the heartbeat-resurrect
         + watchdog-recovery callers).
         """
+        # Like force_restart, this path tears down with the intent to replace.
+        # Refuse before touching an existing transport when the replacement
+        # home cannot be prepared.
+        try:
+            self._preflight_agent_codex_home()
+        except Exception as e:
+            _log(f"codex[{self.agent_name}]: reconnect preflight failed: {e}")
+            return
+
         res = await self._state_machine.request_transition(
             SessionState.RECONNECTING, trigger, reason="attempt_reconnect"
         )

--- a/src/pinky_daemon/codex_session.py
+++ b/src/pinky_daemon/codex_session.py
@@ -41,6 +41,7 @@ from pinky_daemon.streaming_session import (
     _log,
     _notify_turn_idle,
 )
+from pinky_daemon.transport import TransportReplacementMixin
 from pinky_daemon.transport_state import (
     OwnerToken,
     SessionState,
@@ -84,7 +85,7 @@ class CodexTurnResult:
         return max(0, self.input_tokens - self.cached_input_tokens)
 
 
-class CodexSession:
+class CodexSession(TransportReplacementMixin):
     """Agent session backed by Codex CLI.
 
     Drop-in replacement for StreamingSession — exposes the same public
@@ -934,6 +935,10 @@ class CodexSession:
         if not per_agent_codex_home_enabled():
             return None
         return str(prepare_agent_codex_home(self._config, log=_log))
+
+    def _preflight_transport_replacement(self) -> None:
+        """Keep retained-session replacement refusal ahead of teardown."""
+        self._preflight_agent_codex_home()
 
     async def _exec_codex(
         self,

--- a/src/pinky_daemon/codex_session.py
+++ b/src/pinky_daemon/codex_session.py
@@ -1117,7 +1117,21 @@ class CodexSession:
         if self._app_client is not None and self._app_proc is not None:
             if self._app_proc.returncode is None:
                 return  # still running
-            # Process died under us — drop the stale client and respawn.
+
+        # Refuse an unsafe/missing per-agent auth setup before mutating any
+        # cached transport. In particular, a dead cached app-server must not be
+        # closed/cleared (and a tmux supervisor must not be started) before the
+        # replacement spawn proves its Codex home can be prepared safely.
+        direct_env: dict[str, str] | None = None
+        if self._use_tmux_app_server:
+            if per_agent_codex_home_enabled():
+                prepare_agent_codex_home(self._config, log=_log)
+        else:
+            direct_env = self._build_codex_env()
+
+        if self._app_client is not None or self._app_proc is not None:
+            # Process died under us — drop the stale client and respawn only
+            # after the replacement environment passed preparation above.
             await self._teardown_app_server()
 
         if self._use_tmux_app_server:
@@ -1132,11 +1146,10 @@ class CodexSession:
                 server_request_handler=self._on_appserver_request,
             )
         else:
-            env = self._build_codex_env()
-
+            assert direct_env is not None
             self._app_client, self._app_proc = await spawn_app_server(
                 cwd=self._working_dir,
-                env=env,
+                env=direct_env,
                 notification_handler=self._on_appserver_notification,
                 server_request_handler=self._on_appserver_request,
                 log=_log,

--- a/src/pinky_daemon/codex_tmux_session.py
+++ b/src/pinky_daemon/codex_tmux_session.py
@@ -52,6 +52,12 @@ import time
 from collections import deque
 from pathlib import Path
 
+from pinky_daemon.codex_home import (
+    MANAGED_CONFIG_SENTINEL,
+    codex_home_for,
+    per_agent_codex_home_enabled,
+    prepare_agent_codex_home,
+)
 from pinky_daemon.codex_tmux_transcript import (
     CodexTmuxTranscriptTailer,
     _discover_codex_rollout,
@@ -290,6 +296,8 @@ class CodexTmuxSession(TmuxSession):
             env["OPENAI_API_KEY"] = self._openai_api_key
         if self.agent_name:
             env["PINKY_AGENT_NAME"] = self.agent_name
+        if per_agent_codex_home_enabled():
+            env["CODEX_HOME"] = str(codex_home_for(self._config))
         return env
 
     # ── seam: transcript discovery (codex rollout store) ────────────────────
@@ -298,18 +306,26 @@ class CodexTmuxSession(TmuxSession):
         ``~/.codex/sessions``). Codex does NOT slug the cwd into the path the way
         claude does — discovery is by ``session_meta.cwd`` match, not directory
         name — so this is just the scan root."""
-        codex_home = Path(os.environ.get("CODEX_HOME") or (Path.home() / ".codex"))
-        return codex_home / "sessions"
+        return codex_home_for(self._config) / "sessions"
 
     def _has_prior_transcript(self) -> bool:
         """True iff a codex rollout for this agent's cwd already exists (gates
         ``codex resume --last``)."""
-        return _discover_codex_rollout(self._config.working_dir or ".") is not None
+        return (
+            _discover_codex_rollout(
+                self._config.working_dir or ".",
+                agent=self._config,
+            )
+            is not None
+        )
 
     def _discover_transcript_path(self) -> Path | None:
         """Newest rollout whose ``session_meta.cwd`` == this agent's cwd, or None
         (cold start before the first turn writes a rollout)."""
-        return _discover_codex_rollout(self._config.working_dir or ".")
+        return _discover_codex_rollout(
+            self._config.working_dir or ".",
+            agent=self._config,
+        )
 
     # ── seam: tailer class ──────────────────────────────────────────────────
     async def _start_tailer(self) -> None:
@@ -551,6 +567,7 @@ class CodexTmuxSession(TmuxSession):
     # ── seam: cold-start (codex trust pre-seed + NUX dismissal + readiness) ──
     async def _spawn_tmux_repl(self) -> None:
         cwd = str(Path(self._config.working_dir or ".").resolve())
+        prepare_agent_codex_home(self._config, log=_log)
         self._seed_codex_trust(cwd)
         await super()._spawn_tmux_repl()
         await self._codex_dismiss_nux_and_ready()
@@ -595,11 +612,19 @@ class CodexTmuxSession(TmuxSession):
         from a trusted parent dir. Best-effort; a failure here at worst leaves
         the trust NUX for ``_codex_dismiss_nux_and_ready`` to handle."""
         try:
-            codex_home = Path(os.environ.get("CODEX_HOME") or (Path.home() / ".codex"))
+            codex_home = codex_home_for(self._config)
             cfg = codex_home / "config.toml"
             real = os.path.realpath(cwd)
             header = f'[projects."{real}"]'
             existing = cfg.read_text(encoding="utf-8") if cfg.exists() else ""
+            if per_agent_codex_home_enabled() and not existing.startswith(
+                MANAGED_CONFIG_SENTINEL
+            ):
+                _log(
+                    f"tmux[{self.agent_name}]: managed codex config unavailable "
+                    f"at {cfg}; trust seed skipped"
+                )
+                return
             if header in existing:
                 return
             codex_home.mkdir(parents=True, exist_ok=True)

--- a/src/pinky_daemon/codex_tmux_session.py
+++ b/src/pinky_daemon/codex_tmux_session.py
@@ -565,6 +565,10 @@ class CodexTmuxSession(TmuxSession):
         super()._on_transcript_entry(entry)
 
     # ── seam: cold-start (codex trust pre-seed + NUX dismissal + readiness) ──
+    def _preflight_transport_replacement(self) -> None:
+        """Prove the isolated Codex home before an inherited tmux teardown."""
+        prepare_agent_codex_home(self._config, log=_log)
+
     async def _spawn_tmux_repl(self) -> None:
         cwd = str(Path(self._config.working_dir or ".").resolve())
         prepare_agent_codex_home(self._config, log=_log)

--- a/src/pinky_daemon/codex_tmux_transcript.py
+++ b/src/pinky_daemon/codex_tmux_transcript.py
@@ -49,6 +49,7 @@ import sys
 from pathlib import Path
 from typing import Awaitable, Callable
 
+from pinky_daemon.codex_home import codex_home_for
 from pinky_daemon.turn_response import TurnResponse
 
 
@@ -206,7 +207,11 @@ class _CodexTurnBuffer:
 # ──────────────────────────────────────────────────────────────────────────
 
 
-def _discover_codex_rollout(working_dir: str | Path) -> Path | None:
+def _discover_codex_rollout(
+    working_dir: str | Path,
+    *,
+    agent: object | None = None,
+) -> Path | None:
     """Scan ``~/.codex/sessions/**/rollout-*.jsonl`` and return the
     newest file whose ``session_meta.payload.cwd`` equals
     ``os.path.realpath(working_dir)``.
@@ -220,11 +225,10 @@ def _discover_codex_rollout(working_dir: str | Path) -> Path | None:
     """
     target_cwd = os.path.realpath(str(working_dir))
 
-    # Honor CODEX_HOME (the fleet sets it; #792 hardened its propagation to
-    # codex under tmux) — else fall back to ~/.codex. Discovery MUST scan the
-    # same session store the codex process actually writes to, or an agent
-    # launched with a fleet CODEX_HOME would never bind its transcript.
-    codex_home = Path(os.environ.get("CODEX_HOME") or (Path.home() / ".codex"))
+    # Discovery MUST scan the same store the Codex process writes to. An
+    # agent-scoped caller supplies its config so the helper applies the same
+    # flag, explicit override, and fallback as every launch transport.
+    codex_home = codex_home_for(agent)
     sessions_root = codex_home / "sessions"
     if not sessions_root.exists():
         return None

--- a/src/pinky_daemon/streaming_session.py
+++ b/src/pinky_daemon/streaming_session.py
@@ -21,6 +21,7 @@ from pathlib import Path
 from pinky_daemon.context_window import resolve_context_window
 from pinky_daemon.effort import CLI_EFFORT_LEVELS, resolve_cli_effort
 from pinky_daemon.sessions import SessionUsage
+from pinky_daemon.transport import TransportReplacementMixin
 from pinky_daemon.transport_state import SessionState, StateMachine, Trigger
 from pinky_daemon.turn_response import TurnResponse
 from pinky_daemon.wake_prompt import (
@@ -264,7 +265,7 @@ def _describe_tool_use(tool_name: str, tool_input: dict) -> str:
     return name
 
 
-class StreamingSession:
+class StreamingSession(TransportReplacementMixin):
     """Persistent bidirectional Claude Code session via SDK client.
 
     Unlike Session which blocks on each send(), StreamingSession:

--- a/src/pinky_daemon/streaming_session.py
+++ b/src/pinky_daemon/streaming_session.py
@@ -138,6 +138,7 @@ class StreamingSessionConfig:
     subagents: dict = field(default_factory=dict)  # name -> AgentDefinition
     provider_url: str = ""   # ANTHROPIC_BASE_URL override (e.g. "http://localhost:11434" for Ollama)
     provider_key: str = ""   # ANTHROPIC_API_KEY override (empty = use env var)
+    codex_home: str = ""  # Explicit per-agent CODEX_HOME override (flag-gated)
     thinking_effort: str = "medium"  # low, medium, high, xhigh, max, ultracode — default thinking depth
     # When True, the verify_effort CLI hook blocks tool calls if the runtime
     # effort drifts from thinking_effort. Default False (warn-only). See #429.

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -8322,6 +8322,7 @@ class TmuxSession(TransportReplacementMixin):
         had to cancel the old worker to prevent the race window
         Murzik flagged on commit 2).
         """
+        self._preflight_transport_replacement()
         if (
             not bypass_guard
             and self._has_completed_turn
@@ -8551,6 +8552,7 @@ class TmuxSession(TransportReplacementMixin):
                 ``SCHEDULER`` from cron-driven resurrect, ``API_ADMIN`` from
                 explicit operator action.
         """
+        self._preflight_transport_replacement()
         # Drive into RECONNECTING. If we're already there (e.g. force_restart
         # is mid-flight), let that owner finish.
         if self.state == SessionState.RECONNECTING:

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -88,6 +88,7 @@ from pinky_daemon.tmux_transcript import (
     TmuxTranscriptTailer,
     TurnResponse,
 )
+from pinky_daemon.transport import TransportReplacementMixin
 from pinky_daemon.transport_state import (
     SessionState,
     StateMachine,
@@ -1285,7 +1286,7 @@ _MODEL_DIALOG_NEEDLES = ("change model", "switch model?")
 _MODEL_ERROR_NEEDLES = ("unknown model", "invalid model", "not a valid model")
 
 
-class TmuxSession:
+class TmuxSession(TransportReplacementMixin):
     """Agent session backed by an interactive ``claude`` REPL in tmux.
 
     Implements the ``Transport`` protocol (see ``transport.py``). Drop-in

--- a/src/pinky_daemon/transport.py
+++ b/src/pinky_daemon/transport.py
@@ -71,9 +71,70 @@ Brad's Dymok test agent).
 
 from __future__ import annotations
 
+import inspect
+from collections.abc import Awaitable, Callable
 from typing import Any, Protocol, runtime_checkable
 
 from pinky_daemon.transport_state import SessionState
+
+ReplacementStep = Callable[[], Awaitable[None] | None]
+ReplacementConnectWrapper = Callable[[ReplacementStep], Awaitable[None]]
+
+
+class TransportReplacementMixin:
+    """One guarded teardown-and-bring-up chokepoint for retained sessions.
+
+    Backends may override ``_preflight_transport_replacement`` to prove any
+    spawn prerequisites while the current transport is still intact. API code
+    supplies only configuration and bring-up callbacks; it cannot accidentally
+    move the prerequisite check behind teardown by composing ``disconnect`` and
+    ``connect`` itself.
+    """
+
+    def _preflight_transport_replacement(self) -> None:
+        """Prove that a replacement may be started without mutating transport."""
+
+    @staticmethod
+    async def _run_replacement_step(step: ReplacementStep | None) -> None:
+        if step is None:
+            return
+        result = step()
+        if inspect.isawaitable(result):
+            await result
+
+    async def restart_transport(
+        self,
+        *,
+        configure: ReplacementStep | None = None,
+        bring_up: ReplacementStep | None = None,
+        connect_wrapper: ReplacementConnectWrapper | None = None,
+        suppress_teardown_errors: bool = False,
+    ) -> None:
+        """Preflight, configure, tear down, then bring the replacement up.
+
+        ``configure`` runs only after a successful preflight and immediately
+        before teardown, allowing force-fresh latches to be armed without
+        corrupting a live session on refusal. ``bring_up`` defaults to this
+        retained object's ``connect`` method but may rebuild via a registry
+        callback when the route intentionally replaces the object as well.
+        """
+        if bring_up is not None and connect_wrapper is not None:
+            raise ValueError("connect_wrapper and bring_up are mutually exclusive")
+        self._preflight_transport_replacement()
+        await self._run_replacement_step(configure)
+        try:
+            await self.disconnect()  # type: ignore[attr-defined]
+        except Exception:
+            if not suppress_teardown_errors:
+                raise
+        if bring_up is None:
+            connect = self.connect  # type: ignore[attr-defined]
+            if connect_wrapper is None:
+                await connect()
+            else:
+                await connect_wrapper(connect)
+        else:
+            await self._run_replacement_step(bring_up)
 
 
 @runtime_checkable
@@ -218,6 +279,17 @@ class Transport(Protocol):
         ``disconnect`` itself becomes the side-effect runner, not the
         intent declarer.
         """
+        ...
+
+    async def restart_transport(
+        self,
+        *,
+        configure: ReplacementStep | None = None,
+        bring_up: ReplacementStep | None = None,
+        connect_wrapper: ReplacementConnectWrapper | None = None,
+        suppress_teardown_errors: bool = False,
+    ) -> None:
+        """Run the guarded preflight → teardown → bring-up sequence."""
         ...
 
     async def send(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,7 +24,10 @@ opt out via the ``real_auth`` pytest marker (set as a module-level
 
 from __future__ import annotations
 
+import atexit
 import os
+import shutil
+import tempfile
 
 import pytest
 from fastapi.testclient import TestClient
@@ -33,6 +36,8 @@ from fastapi.testclient import TestClient
 # production. Tests that need to override (e.g. test_auth.py) do so via
 # ``monkeypatch.setenv`` for the duration of their test.
 TEST_SESSION_SECRET = "test-session-secret-do-not-use-in-prod-32bytes-min"
+TEST_CODEX_HOME = tempfile.mkdtemp(prefix="pinkybot-test-codex-home-")
+atexit.register(shutil.rmtree, TEST_CODEX_HOME, ignore_errors=True)
 
 # Repository tests must not inherit live daemon behavior from their invoking
 # shell.  The source tree contains many PINKY_* switches that can select real
@@ -40,6 +45,7 @@ TEST_SESSION_SECRET = "test-session-secret-do-not-use-in-prod-32bytes-min"
 # Scrub the whole namespace so newly-added switches are isolated by default,
 # then pin only the deterministic values the suite relies on.
 _PINNED_TEST_ENV = {
+    "CODEX_HOME": TEST_CODEX_HOME,
     "PINKY_AUTH_DENY_DEFAULT": "shadow",
     "PINKY_DREAM_TRANSPORT": "sdk",
     "PINKY_SESSION_SECRET": TEST_SESSION_SECRET,
@@ -50,8 +56,8 @@ _REAL_TRANSPORT_OPTED_IN = os.environ.get(
 ).strip().lower() in {"1", "true", "yes", "on"}
 
 
-def _scrub_pinky_env() -> None:
-    """Replace ambient PINKY_* configuration with deterministic test values."""
+def _scrub_test_env() -> None:
+    """Replace ambient runtime configuration with deterministic test values."""
     for key in tuple(os.environ):
         if key.startswith("PINKY_"):
             os.environ.pop(key, None)
@@ -60,7 +66,7 @@ def _scrub_pinky_env() -> None:
 
 # Run during conftest import, before pytest imports test modules that may import
 # source modules with environment-derived module constants.
-_scrub_pinky_env()
+_scrub_test_env()
 
 
 def pytest_configure(config: pytest.Config) -> None:
@@ -109,7 +115,7 @@ def _ensure_test_session_secret():
 
 
 @pytest.fixture(autouse=True)
-def _isolate_pinky_env(monkeypatch):
+def _isolate_test_env(monkeypatch):
     """Re-apply the ambient guard before every test.
 
     Tests remain free to override a value explicitly with ``monkeypatch`` in
@@ -125,11 +131,11 @@ def _isolate_pinky_env(monkeypatch):
         yield
     finally:
         # Also contain direct os.environ writes that bypassed monkeypatch.
-        _scrub_pinky_env()
+        _scrub_test_env()
 
 
 @pytest.fixture(autouse=True)
-def _auto_cookie_test_client(request, monkeypatch, _isolate_pinky_env):
+def _auto_cookie_test_client(request, monkeypatch, _isolate_test_env):
     """Auto-inject a valid session cookie into every TestClient.
 
     Skipped for tests marked ``real_auth`` — those construct their own

--- a/tests/test_agent_registry.py
+++ b/tests/test_agent_registry.py
@@ -481,6 +481,18 @@ class TestAgentCRUD:
         registry.register("plain", dedicated_config_dir=True)
         assert registry.get("plain").dedicated_config_dir is True
 
+    def test_codex_home_override_round_trip(self, registry, tmp_path):
+        override = str(tmp_path / "codex-home")
+
+        created = registry.register("codex-home-test", codex_home=override)
+
+        assert created.codex_home == override
+        assert registry.get("codex-home-test").codex_home == override
+        assert registry.get("codex-home-test").to_dict()["codex_home"] == override
+
+        updated = registry.register("codex-home-test", codex_home="")
+        assert updated.codex_home == ""
+
     def test_isolation_mode_round_trip(self, registry):
         """#149 phase-3: isolation_mode persists through insert/get/to_dict,
         defaults to 'local', and is settable via the update path."""

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1765,6 +1765,75 @@ class TestAPI:
                 assert resp.status_code == 403
                 assert "projects" in resp.json()["detail"].lower()
 
+    def test_transcript_path_uses_agent_codex_home_when_enabled(
+        self, monkeypatch
+    ):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            shared_home = os.path.join(tmpdir, "shared-codex")
+            work_dir = os.path.join(tmpdir, "agents", "codex-test")
+            monkeypatch.setenv("CODEX_HOME", shared_home)
+            monkeypatch.setenv("PINKY_CODEX_PER_AGENT_HOME", "1")
+            app = self._make_app(db_path)
+            with TestClient(app) as client:
+                registered = client.post(
+                    "/agents",
+                    json={
+                        "name": "codex-test",
+                        "model": "gpt-test",
+                        "runtime": "codex_cli",
+                        "working_dir": work_dir,
+                    },
+                )
+                assert registered.status_code == 200
+
+                isolated = os.path.join(
+                    work_dir, ".codex", "sessions", "2026", "rollout.jsonl"
+                )
+                accepted = client.post(
+                    "/agents/codex-test/transport/transcript-path",
+                    json={"transcript_path": isolated},
+                )
+                assert accepted.status_code == 200
+
+                shared = os.path.join(
+                    shared_home, "sessions", "2026", "rollout.jsonl"
+                )
+                denied = client.post(
+                    "/agents/codex-test/transport/transcript-path",
+                    json={"transcript_path": shared},
+                )
+                assert denied.status_code == 403
+
+    def test_transcript_path_flag_off_keeps_shared_codex_root(self, monkeypatch):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            shared_home = os.path.join(tmpdir, "shared-codex")
+            work_dir = os.path.join(tmpdir, "agents", "codex-test")
+            monkeypatch.setenv("CODEX_HOME", shared_home)
+            monkeypatch.delenv("PINKY_CODEX_PER_AGENT_HOME", raising=False)
+            app = self._make_app(db_path)
+            with TestClient(app) as client:
+                registered = client.post(
+                    "/agents",
+                    json={
+                        "name": "codex-test",
+                        "model": "gpt-test",
+                        "runtime": "codex_cli",
+                        "working_dir": work_dir,
+                    },
+                )
+                assert registered.status_code == 200
+
+                shared = os.path.join(
+                    shared_home, "sessions", "2026", "rollout.jsonl"
+                )
+                accepted = client.post(
+                    "/agents/codex-test/transport/transcript-path",
+                    json={"transcript_path": shared},
+                )
+                assert accepted.status_code == 200
+
     def test_unix_user_agent_cannot_start_before_provisioner(self):
         """#149 phase-3 (Murzik #642 P1): an agent labeled isolation_mode=
         'unix_user' is accepted at registration but REFUSES to start (501)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import ast
 import asyncio
+import inspect
 import json
 import logging
 import os
@@ -958,6 +960,7 @@ class TestAPI:
             self.sent: list[tuple[str, str, str]] = []
             self.disconnect_calls = 0
             self.connect_calls = 0
+            self.restart_transport_calls = 0
 
         @property
         def state(self):
@@ -983,6 +986,66 @@ class TestAPI:
         async def connect(self):
             self.connect_calls += 1
             self._state = self._TS.CONNECTED
+
+        async def restart_transport(
+            self,
+            *,
+            configure=None,
+            bring_up=None,
+            connect_wrapper=None,
+            suppress_teardown_errors=False,
+        ):
+            self.restart_transport_calls += 1
+            if configure is not None:
+                result = configure()
+                if inspect.isawaitable(result):
+                    await result
+            try:
+                await self.disconnect()
+            except Exception:
+                if not suppress_teardown_errors:
+                    raise
+            if bring_up is not None:
+                result = bring_up()
+                if inspect.isawaitable(result):
+                    await result
+            elif connect_wrapper is not None:
+                await connect_wrapper(self.connect)
+            else:
+                await self.connect()
+
+    def test_replacement_routes_use_one_transport_chokepoint(self):
+        """R3 P1-2: API replacement routes cannot recompose raw teardown/start."""
+        api_path = Path(__file__).parents[1] / "src" / "pinky_daemon" / "api.py"
+        module = ast.parse(api_path.read_text(encoding="utf-8"))
+        replacement_routes = {
+            "_restart_streaming_session_after_response",
+            "set_streaming_model",
+            "archive_streaming_session",
+            "_watchdog_recover",
+            "_watchdog_mcp_recover",
+            "admin_force_restart_agent",
+        }
+        functions = {
+            node.name: node
+            for node in ast.walk(module)
+            if isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef))
+            and node.name in replacement_routes
+        }
+
+        assert functions.keys() == replacement_routes
+        for name, function in functions.items():
+            session_calls = [
+                node.func.attr
+                for node in ast.walk(function)
+                if isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and isinstance(node.func.value, ast.Name)
+                and node.func.value.id == "ss"
+            ]
+            assert "restart_transport" in session_calls, name
+            assert "disconnect" not in session_calls, name
+            assert "connect" not in session_calls, name
 
     def test_root(self):
         client = self._make_client()

--- a/tests/test_codex_app_server_tmux.py
+++ b/tests/test_codex_app_server_tmux.py
@@ -18,11 +18,14 @@ import stat
 import subprocess
 import sys
 import tempfile
+from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
 from pinky_daemon import codex_app_server_tmux as mod
 from pinky_daemon.codex_app_server_tmux import CodexAppServerSupervisor, _TmuxAppServerProc
+from pinky_daemon.codex_home import PER_AGENT_CODEX_HOME_ENV
 
 _REPO_SRC = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src"))
 _FAKE = os.path.join(os.path.dirname(__file__), "_fake_app_server.py")
@@ -97,7 +100,10 @@ def workdir():
 
 def _make_supervisor(workdir: str, fake: FakeTmux, **kw) -> CodexAppServerSupervisor:
     sup = CodexAppServerSupervisor(
-        "kztest", working_dir=workdir, openai_api_key=kw.get("key", "sk-SENTINEL"),
+        "test-agent",
+        working_dir=workdir,
+        openai_api_key=kw.get("key", "test-key"),
+        agent_config=kw.get("agent_config"),
     )
     sup._tmux = fake
     return sup
@@ -115,7 +121,7 @@ async def test_start_spawns_shim_and_initialize_round_trips(workdir):
         # Env injected for the shell/child: PATH (codex resolution) + the key
         # (item H — must reach the grandchild codex via tmux -e -> shim -> child).
         assert "PATH" in fake.new_session_env
-        assert fake.new_session_env.get("OPENAI_API_KEY") == "sk-SENTINEL"
+        assert fake.new_session_env.get("OPENAI_API_KEY") == "test-key"
         # The single initialize (the daemon's real gate) round-trips end to end.
         res = await client.initialize(name="pinkybot", version="1")
         assert res["userAgent"] == "fake/1"
@@ -161,8 +167,41 @@ async def test_full_daemon_env_propagated_to_session(workdir, monkeypatch):
     }.items():
         assert env.get(key) == val, f"daemon env {key} not propagated to tmux session"
     # The configured key is overlaid (item H), and tmux-internal vars are dropped.
-    assert env.get("OPENAI_API_KEY") == "sk-SENTINEL"
+    assert env.get("OPENAI_API_KEY") == "test-key"
     assert "TMUX" not in env
+
+
+def test_per_agent_home_overlaid_for_tmux_app_server(workdir, monkeypatch):
+    shared_home = Path(workdir) / "shared-codex"
+    shared_home.mkdir()
+    (shared_home / "auth.json").write_text('{"test": true}\n', encoding="utf-8")
+    monkeypatch.setenv("CODEX_HOME", str(shared_home))
+    monkeypatch.setenv(PER_AGENT_CODEX_HOME_ENV, "1")
+    fake = FakeTmux(spawn=False)
+    config = SimpleNamespace(working_dir=workdir, codex_home="")
+    sup = _make_supervisor(workdir, fake, agent_config=config)
+
+    env = sup._build_env()
+
+    agent_home = Path(workdir).resolve() / ".codex"
+    assert env["CODEX_HOME"] == str(agent_home)
+    assert (agent_home / "auth.json").is_symlink()
+
+
+@pytest.mark.asyncio
+async def test_auth_absence_fails_before_tmux_cleanup(workdir, monkeypatch):
+    shared_home = Path(workdir) / "missing-auth-codex"
+    shared_home.mkdir()
+    monkeypatch.setenv("CODEX_HOME", str(shared_home))
+    monkeypatch.setenv(PER_AGENT_CODEX_HOME_ENV, "1")
+    fake = FakeTmux(spawn=False)
+    config = SimpleNamespace(working_dir=workdir, codex_home="")
+    sup = _make_supervisor(workdir, fake, agent_config=config)
+
+    with pytest.raises(RuntimeError, match="shared auth file is absent or unreadable"):
+        await sup.start()
+
+    assert fake.calls == []
 
 
 @pytest.mark.asyncio
@@ -171,7 +210,7 @@ async def test_long_working_dir_falls_back_to_short_sock_dir():
     to a short, owner-only 0700 dir — not a predictable /tmp path, and not an
     unbindable long one (would surface as a readiness timeout)."""
     long_wd = "/tmp/" + ("d" * 140)
-    sup = CodexAppServerSupervisor("kztest", working_dir=long_wd)
+    sup = CodexAppServerSupervisor("test-agent", working_dir=long_wd)
     try:
         assert sup._sock_dir_is_tmp is True
         assert len(sup.sock_path) <= 104

--- a/tests/test_codex_home.py
+++ b/tests/test_codex_home.py
@@ -505,7 +505,7 @@ def test_frozen_claim_with_held_writer_retains_every_append_in_named_claim(
         working_dir,
     )
     original = source.read_bytes()
-    claim = codex_home_mod._claim_rollout(source)
+    claim = codex_home_mod._claim_rollout(source, log=lambda _message: None)
     assert claim is not None
     destination = _rollout(
         destination_home,
@@ -620,7 +620,7 @@ def test_recovery_publication_failure_restores_named_claim_without_litter(
         working_dir,
     )
     original = source.read_bytes()
-    claim = codex_home_mod._claim_rollout(source)
+    claim = codex_home_mod._claim_rollout(source, log=lambda _message: None)
     assert claim is not None
     original_mode = stat.S_IMODE(claim.stat().st_mode)
     appended = b'{"type":"event_msg","payload":{"message":"new bytes"}}\n'
@@ -828,7 +828,7 @@ def test_live_mode_freeze_is_transiently_retained_without_thaw(tmp_path):
         "rollout-live-concurrent-freeze.jsonl",
         working_dir,
     )
-    claim = codex_home_mod._claim_rollout(source)
+    claim = codex_home_mod._claim_rollout(source, log=lambda _message: None)
     assert claim is not None
     destination = _rollout(
         destination_home,
@@ -868,7 +868,7 @@ def test_crashed_mode_freeze_repairs_without_an_open_holder(tmp_path):
         "rollout-crashed-freeze.jsonl",
         working_dir,
     )
-    claim = codex_home_mod._claim_rollout(source)
+    claim = codex_home_mod._claim_rollout(source, log=lambda _message: None)
     assert claim is not None
     claim.chmod(0)
     logs: list[str] = []
@@ -891,7 +891,7 @@ def test_install_open_eacces_race_is_a_loud_retryable_retain(tmp_path, monkeypat
         "rollout-install-eacces-race.jsonl",
         working_dir,
     )
-    claim = codex_home_mod._claim_rollout(source)
+    claim = codex_home_mod._claim_rollout(source, log=lambda _message: None)
     assert claim is not None
     destination = _rollout(
         destination_home,
@@ -941,7 +941,7 @@ def test_hard_exit_freeze_seams_keep_discoverable_complete_bytes(
         working_dir,
     )
     original = source.read_bytes()
-    claim = codex_home_mod._claim_rollout(source)
+    claim = codex_home_mod._claim_rollout(source, log=lambda _message: None)
     assert claim is not None
     appended = b'{"type":"event_msg","payload":{"message":"latest"}}\n'
     current = original + appended
@@ -1104,7 +1104,7 @@ def test_claim_link_collision_retries_without_replacing_interleaved_claim(
 
     monkeypatch.setattr(codex_home_mod.os, "link", collide_before_link)
 
-    claim = codex_home_mod._claim_rollout(source)
+    claim = codex_home_mod._claim_rollout(source, log=lambda _message: None)
 
     assert injected is True
     assert claim is not None
@@ -1173,7 +1173,8 @@ def test_active_reservation_lock_prevents_crash_sweeper_race(tmp_path):
     logs: list[str] = []
 
     with codex_home_mod._reserve_exclusive_destination(
-        lambda _reservation_id: destination
+        lambda _reservation_id: destination,
+        log=logs.append,
     ) as reserved:
         assert reserved == destination
         assert reservation.exists()
@@ -1184,6 +1185,292 @@ def test_active_reservation_lock_prevents_crash_sweeper_race(tmp_path):
         assert not logs
 
     assert not reservation.exists()
+
+
+def test_reservation_swept_between_create_and_flock_retries_without_double_grant(
+    tmp_path, monkeypatch
+):
+    """R8 R1: the exact swept-before-flock interleaving cannot double-grant."""
+    destination = tmp_path / ".pinkybot-rollout-claim-race-rollout-test.jsonl"
+    reservation = destination.with_name(
+        f".{destination.name}{codex_home_mod._PRESERVATION_RESERVATION_SUFFIX}"
+    )
+    real_open = codex_home_mod.os.open
+    real_flock = codex_home_mod.fcntl.flock
+    creator_a_before_flock = threading.Event()
+    allow_creator_a_flock = threading.Event()
+    creator_a_retry_blocked = threading.Event()
+    creator_a_granted = threading.Event()
+    release_creator_a = threading.Event()
+    creator_b_granted = threading.Event()
+    release_creator_b = threading.Event()
+    creator_b_exited = threading.Event()
+    state_lock = threading.Lock()
+    creator_a_attempts = 0
+    active_grants = 0
+    maximum_active_grants = 0
+    grant_order: list[tuple[str, Path]] = []
+    errors: list[BaseException] = []
+    sweep_logs: list[str] = []
+
+    def interleaved_open(path, flags, *args, **kwargs):
+        nonlocal creator_a_attempts
+        if (
+            threading.current_thread().name == "reservation-creator-a"
+            and flags & os.O_EXCL
+            and Path(path) == reservation
+        ):
+            creator_a_attempts += 1
+            if creator_a_attempts == 2:
+                creator_a_retry_blocked.set()
+                if not creator_b_exited.wait(timeout=5):
+                    raise AssertionError("creator B did not release its reservation")
+        return real_open(path, flags, *args, **kwargs)
+
+    def pause_creator_a_before_flock(descriptor: int, operation: int) -> None:
+        if (
+            threading.current_thread().name == "reservation-creator-a"
+            and operation & fcntl.LOCK_EX
+            and not creator_a_before_flock.is_set()
+        ):
+            creator_a_before_flock.set()
+            if not allow_creator_a_flock.wait(timeout=5):
+                raise AssertionError("creator A was not released to flock")
+        real_flock(descriptor, operation)
+
+    def reserve(name: str, granted: threading.Event, release: threading.Event) -> None:
+        nonlocal active_grants, maximum_active_grants
+        try:
+            with codex_home_mod._reserve_exclusive_destination(
+                lambda _reservation_id: destination,
+                log=lambda _message: None,
+            ) as reserved:
+                with state_lock:
+                    active_grants += 1
+                    maximum_active_grants = max(
+                        maximum_active_grants,
+                        active_grants,
+                    )
+                    grant_order.append((name, reserved))
+                granted.set()
+                if not release.wait(timeout=5):
+                    raise AssertionError(f"creator {name} was not released")
+                with state_lock:
+                    active_grants -= 1
+        except BaseException as exc:
+            errors.append(exc)
+            granted.set()
+        finally:
+            if name == "b":
+                creator_b_exited.set()
+
+    monkeypatch.setattr(codex_home_mod.os, "open", interleaved_open)
+    monkeypatch.setattr(
+        codex_home_mod.fcntl,
+        "flock",
+        pause_creator_a_before_flock,
+    )
+    creator_a = threading.Thread(
+        target=reserve,
+        args=("a", creator_a_granted, release_creator_a),
+        name="reservation-creator-a",
+    )
+    creator_b = threading.Thread(
+        target=reserve,
+        args=("b", creator_b_granted, release_creator_b),
+        name="reservation-creator-b",
+    )
+    try:
+        creator_a.start()
+        assert creator_a_before_flock.wait(timeout=5)
+
+        codex_home_mod._sweep_stale_reservations(tmp_path, sweep_logs.append)
+        assert not reservation.exists()
+
+        creator_b.start()
+        assert creator_b_granted.wait(timeout=5)
+        assert not errors
+        assert reservation.exists()
+
+        allow_creator_a_flock.set()
+        assert creator_a_retry_blocked.wait(timeout=5)
+        assert not creator_a_granted.is_set()
+        assert maximum_active_grants == 1
+        assert list(tmp_path.glob("*.reserve")) == [reservation]
+
+        release_creator_b.set()
+        assert creator_b_exited.wait(timeout=5)
+        assert creator_a_granted.wait(timeout=5)
+        assert not errors
+        assert list(tmp_path.glob("*.reserve")) == [reservation]
+        assert maximum_active_grants == 1
+    finally:
+        allow_creator_a_flock.set()
+        release_creator_b.set()
+        release_creator_a.set()
+        if creator_a.ident is not None:
+            creator_a.join(timeout=5)
+        if creator_b.ident is not None:
+            creator_b.join(timeout=5)
+
+    assert not creator_a.is_alive()
+    assert not creator_b.is_alive()
+    assert errors == []
+    assert creator_a_attempts == 2
+    assert grant_order == [("b", destination), ("a", destination)]
+    assert maximum_active_grants == 1
+    assert not reservation.exists()
+    assert len(sweep_logs) == 1
+    assert "removed orphaned migration reservation" in sweep_logs[0]
+
+
+def test_creator_cleanup_does_not_unlink_replacement_live_reservation(tmp_path):
+    """R8 R2: an old creator cannot unlink a new holder's sidecar name."""
+    destination = tmp_path / ".pinkybot-rollout-claim-cleanup-rollout-test.jsonl"
+    reservation = destination.with_name(
+        f".{destination.name}{codex_home_mod._PRESERVATION_RESERVATION_SUFFIX}"
+    )
+    replacement_fd = -1
+    try:
+        with codex_home_mod._reserve_exclusive_destination(
+            lambda _reservation_id: destination,
+            log=lambda _message: None,
+        ):
+            original_stat = reservation.lstat()
+            reservation.unlink()
+            replacement_fd = os.open(
+                reservation,
+                os.O_RDWR | os.O_CREAT | os.O_EXCL,
+                0o600,
+            )
+            fcntl.flock(replacement_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            replacement_stat = os.fstat(replacement_fd)
+            assert (replacement_stat.st_dev, replacement_stat.st_ino) != (
+                original_stat.st_dev,
+                original_stat.st_ino,
+            )
+
+        current_stat = reservation.lstat()
+        assert (current_stat.st_dev, current_stat.st_ino) == (
+            replacement_stat.st_dev,
+            replacement_stat.st_ino,
+        )
+    finally:
+        if replacement_fd >= 0:
+            fcntl.flock(replacement_fd, fcntl.LOCK_UN)
+            os.close(replacement_fd)
+        reservation.unlink(missing_ok=True)
+
+
+def test_sweeper_cleanup_does_not_unlink_replacement_live_reservation(
+    tmp_path, monkeypatch
+):
+    """R8 R2: a sweeper cannot unlink a new holder after locking the old inode."""
+    destination = tmp_path / ".pinkybot-rollout-claim-sweeper-rollout-test.jsonl"
+    reservation = destination.with_name(
+        f".{destination.name}{codex_home_mod._PRESERVATION_RESERVATION_SUFFIX}"
+    )
+    reservation.touch()
+    real_unlink_locked = codex_home_mod._unlink_locked_reservation
+    replacement_fd = -1
+    replacement_stat = None
+
+    def replace_before_sweeper_cleanup(path: Path, locked_fd: int) -> bool:
+        nonlocal replacement_fd, replacement_stat
+        original_stat = os.fstat(locked_fd)
+        path.unlink()
+        replacement_fd = os.open(
+            path,
+            os.O_RDWR | os.O_CREAT | os.O_EXCL,
+            0o600,
+        )
+        fcntl.flock(replacement_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        replacement_stat = os.fstat(replacement_fd)
+        assert (replacement_stat.st_dev, replacement_stat.st_ino) != (
+            original_stat.st_dev,
+            original_stat.st_ino,
+        )
+        return real_unlink_locked(path, locked_fd)
+
+    monkeypatch.setattr(
+        codex_home_mod,
+        "_unlink_locked_reservation",
+        replace_before_sweeper_cleanup,
+    )
+    logs: list[str] = []
+    try:
+        codex_home_mod._sweep_stale_reservations(tmp_path, logs.append)
+
+        assert replacement_stat is not None
+        current_stat = reservation.lstat()
+        assert (current_stat.st_dev, current_stat.st_ino) == (
+            replacement_stat.st_dev,
+            replacement_stat.st_ino,
+        )
+        assert not logs
+    finally:
+        if replacement_fd >= 0:
+            fcntl.flock(replacement_fd, fcntl.LOCK_UN)
+            os.close(replacement_fd)
+        reservation.unlink(missing_ok=True)
+
+
+def test_reservation_retry_exhaustion_is_loud_and_retains_source(
+    tmp_path, monkeypatch
+):
+    """R8 R3: repeated pre-lock sweeps stop loudly without claiming bytes."""
+    working_dir = tmp_path / "agent"
+    working_dir.mkdir()
+    source = _rollout(
+        tmp_path / "source",
+        "rollout-reservation-exhaustion.jsonl",
+        working_dir,
+    )
+    source_bytes = source.read_bytes()
+    real_open = codex_home_mod.os.open
+    real_flock = codex_home_mod.fcntl.flock
+    reservation_paths: dict[int, Path] = {}
+    swept_reservations: list[Path] = []
+    logs: list[str] = []
+
+    def track_reservation_open(path, flags, *args, **kwargs):
+        descriptor = real_open(path, flags, *args, **kwargs)
+        if flags & os.O_EXCL and os.fspath(path).endswith(
+            codex_home_mod._PRESERVATION_RESERVATION_SUFFIX
+        ):
+            reservation_paths[descriptor] = Path(path)
+        return descriptor
+
+    def sweep_every_reservation_before_flock(
+        descriptor: int,
+        operation: int,
+    ) -> None:
+        reservation = reservation_paths.get(descriptor)
+        if operation & fcntl.LOCK_EX and reservation is not None:
+            reservation.unlink()
+            swept_reservations.append(reservation)
+        real_flock(descriptor, operation)
+
+    monkeypatch.setattr(codex_home_mod, "_RESERVATION_ACQUIRE_MAX_ATTEMPTS", 3)
+    monkeypatch.setattr(codex_home_mod.os, "open", track_reservation_open)
+    monkeypatch.setattr(
+        codex_home_mod.fcntl,
+        "flock",
+        sweep_every_reservation_before_flock,
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match="exclusive migration reservation did not converge after 3 attempts",
+    ):
+        codex_home_mod._claim_rollout(source, log=logs.append)
+
+    assert len(swept_reservations) == 3
+    assert source.read_bytes() == source_bytes
+    assert not list(source.parent.glob(f"{codex_home_mod._MIGRATION_CLAIM_PREFIX}*"))
+    assert not list(source.parent.glob("*.reserve"))
+    assert len(logs) == 1
+    assert "refusing non-replacing publication" in logs[0]
 
 
 @pytest.mark.parametrize("write_phase", ["during_copy", "post_install"])

--- a/tests/test_codex_home.py
+++ b/tests/test_codex_home.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import fcntl
 import json
 import os
+import stat
 import threading
+import time
 import tomllib
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
@@ -66,6 +69,7 @@ def test_flag_off_preserves_shared_path_and_performs_no_bootstrap(tmp_path, monk
     override = tmp_path / "override"
     monkeypatch.setenv("CODEX_HOME", str(shared_home))
     monkeypatch.delenv(PER_AGENT_CODEX_HOME_ENV, raising=False)
+    monkeypatch.setenv(codex_home_mod.MIGRATION_LOCK_TIMEOUT_ENV, "invalid")
     scope = _scope(working_dir, codex_home=str(override))
 
     assert codex_home_for(scope) == shared_home
@@ -273,6 +277,218 @@ def test_partial_migration_final_is_quarantined_and_retry_converges(tmp_path, mo
     assert quarantines[0].read_bytes() == partial_bytes
     assert any("removed abandoned rollout migration temp" in message for message in logs)
     assert any("quarantined invalid rollout migration final" in message for message in logs)
+
+
+def test_initial_migration_lock_deadline_preserves_source_and_markerless_state(
+    tmp_path, monkeypatch
+):
+    """R2 P1-1: a held destination lock cannot block prepare indefinitely."""
+    shared_home = tmp_path / "shared"
+    working_dir = tmp_path / "agent"
+    agent_home = working_dir / ".codex"
+    working_dir.mkdir()
+    _auth(shared_home)
+    source = _rollout(shared_home, "rollout-held-lock.jsonl", working_dir)
+    source_bytes = source.read_bytes()
+    destination_sessions = agent_home / "sessions"
+    destination_sessions.mkdir(parents=True)
+    lock_path = destination_sessions / codex_home_mod._MIGRATION_LOCK_NAME
+    logs: list[str] = []
+    monkeypatch.setenv("CODEX_HOME", str(shared_home))
+    monkeypatch.setenv(PER_AGENT_CODEX_HOME_ENV, "1")
+    monkeypatch.setenv(codex_home_mod.MIGRATION_LOCK_TIMEOUT_ENV, "0.05")
+
+    with lock_path.open("a+b") as held_lock:
+        fcntl.flock(held_lock.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        started = time.monotonic()
+        with pytest.raises(RuntimeError, match="migration lock deadline exceeded"):
+            prepare_agent_codex_home(_scope(working_dir), log=logs.append)
+        elapsed = time.monotonic() - started
+
+    assert elapsed < 0.5
+    assert source.read_bytes() == source_bytes
+    assert not (agent_home / ROLLOUT_MIGRATION_MARKER).exists()
+    assert any("migration lock deadline exceeded" in message for message in logs)
+
+
+def test_reverse_migration_uses_same_bounded_lock_acquisition(tmp_path, monkeypatch):
+    """R2 P1-1: the public reverse-migration entry point shares the deadline."""
+    source_home = tmp_path / "agent-home"
+    destination_home = tmp_path / "shared"
+    working_dir = tmp_path / "agent"
+    working_dir.mkdir()
+    source = _rollout(source_home, "rollout-reverse-held-lock.jsonl", working_dir)
+    source_bytes = source.read_bytes()
+    destination_sessions = destination_home / "sessions"
+    destination_sessions.mkdir(parents=True)
+    lock_path = destination_sessions / codex_home_mod._MIGRATION_LOCK_NAME
+    monkeypatch.setenv(codex_home_mod.MIGRATION_LOCK_TIMEOUT_ENV, "0.05")
+
+    with lock_path.open("a+b") as held_lock:
+        fcntl.flock(held_lock.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        with pytest.raises(RuntimeError, match="migration lock deadline exceeded"):
+            move_matching_rollouts(
+                source_home,
+                destination_home,
+                working_dir,
+                log=lambda _message: None,
+            )
+
+    assert source.read_bytes() == source_bytes
+
+
+def test_source_change_after_final_validation_remains_authoritative_and_retryable(
+    tmp_path, monkeypatch
+):
+    """R2 P1-2: recheck the source immediately before removing it."""
+    shared_home = tmp_path / "shared"
+    working_dir = tmp_path / "agent"
+    agent_home = working_dir / ".codex"
+    working_dir.mkdir()
+    _auth(shared_home)
+    source = _rollout(shared_home, "rollout-late-append.jsonl", working_dir)
+    original = source.read_bytes()
+    appended = b'{"type":"event_msg","payload":{"message":"late append"}}\n'
+    relative = source.relative_to(shared_home / "sessions")
+    destination = agent_home / "sessions" / relative
+    real_rollout_is_valid = codex_home_mod._rollout_is_valid
+    injected = False
+
+    def append_after_final_validation(path, target_cwd, *, expected_signature=None):
+        nonlocal injected
+        valid = real_rollout_is_valid(
+            path,
+            target_cwd,
+            expected_signature=expected_signature,
+        )
+        if path == destination and expected_signature is not None and valid and not injected:
+            with source.open("ab") as handle:
+                handle.write(appended)
+                handle.flush()
+                os.fsync(handle.fileno())
+            injected = True
+        return valid
+
+    monkeypatch.setattr(
+        codex_home_mod,
+        "_rollout_is_valid",
+        append_after_final_validation,
+    )
+    monkeypatch.setenv("CODEX_HOME", str(shared_home))
+    monkeypatch.setenv(PER_AGENT_CODEX_HOME_ENV, "1")
+
+    with pytest.raises(RuntimeError, match="changed before source removal"):
+        prepare_agent_codex_home(_scope(working_dir), log=lambda _message: None)
+
+    assert source.read_bytes() == original + appended
+    assert destination.read_bytes() == original
+    assert not (agent_home / ROLLOUT_MIGRATION_MARKER).exists()
+
+    prepare_agent_codex_home(_scope(working_dir), log=lambda _message: None)
+
+    assert not source.exists()
+    assert destination.read_bytes() == original + appended
+    assert (agent_home / ROLLOUT_MIGRATION_MARKER).exists()
+
+
+def test_linked_lock_entry_is_preserved_aside_without_touching_target(
+    tmp_path, monkeypatch
+):
+    """R2 P2-4: classify and preserve a linked lock before opening it."""
+    shared_home = tmp_path / "shared"
+    destination_home = tmp_path / "agent-home"
+    working_dir = tmp_path / "agent"
+    working_dir.mkdir()
+    destination_sessions = destination_home / "sessions"
+    destination_sessions.mkdir(parents=True)
+    unintended_target = tmp_path / "must-not-be-created.lock"
+    lock_path = destination_sessions / codex_home_mod._MIGRATION_LOCK_NAME
+    lock_path.symlink_to(unintended_target)
+    logs: list[str] = []
+
+    moved = move_matching_rollouts(
+        shared_home,
+        destination_home,
+        working_dir,
+        log=logs.append,
+    )
+
+    assert moved == 0
+    assert not unintended_target.exists()
+    assert lock_path.is_file()
+    assert not lock_path.is_symlink()
+    asides = list(
+        destination_sessions.glob(f"{codex_home_mod._MIGRATION_LOCK_ASIDE_PREFIX}*")
+    )
+    assert len(asides) == 1
+    assert asides[0].is_symlink()
+    assert os.readlink(asides[0]) == str(unintended_target)
+    assert any("renamed linked migration lock entry" in message for message in logs)
+
+
+def test_hard_linked_lock_entry_is_preserved_aside_without_mutating_peer(tmp_path):
+    """A multiply-linked regular entry follows the same preserve-aside rule."""
+    source_home = tmp_path / "source-home"
+    destination_home = tmp_path / "destination-home"
+    working_dir = tmp_path / "agent"
+    working_dir.mkdir()
+    destination_sessions = destination_home / "sessions"
+    destination_sessions.mkdir(parents=True)
+    peer = tmp_path / "operator-lock"
+    peer.write_bytes(b"operator bytes")
+    peer.chmod(0o640)
+    lock_path = destination_sessions / codex_home_mod._MIGRATION_LOCK_NAME
+    os.link(peer, lock_path)
+    original_mode = peer.stat().st_mode
+    logs: list[str] = []
+
+    moved = move_matching_rollouts(
+        source_home,
+        destination_home,
+        working_dir,
+        log=logs.append,
+    )
+
+    assert moved == 0
+    assert peer.read_bytes() == b"operator bytes"
+    assert peer.stat().st_mode == original_mode
+    assert lock_path.is_file()
+    assert lock_path.stat().st_ino != peer.stat().st_ino
+    asides = list(
+        destination_sessions.glob(f"{codex_home_mod._MIGRATION_LOCK_ASIDE_PREFIX}*")
+    )
+    assert len(asides) == 1
+    assert asides[0].stat().st_ino == peer.stat().st_ino
+    assert any("renamed linked migration lock entry" in message for message in logs)
+
+
+def test_nonregular_lock_entry_is_preserved_aside_without_blocking(tmp_path):
+    """A FIFO lock entry is classified before open and cannot stall prepare."""
+    source_home = tmp_path / "source-home"
+    destination_home = tmp_path / "destination-home"
+    working_dir = tmp_path / "agent"
+    working_dir.mkdir()
+    destination_sessions = destination_home / "sessions"
+    destination_sessions.mkdir(parents=True)
+    lock_path = destination_sessions / codex_home_mod._MIGRATION_LOCK_NAME
+    os.mkfifo(lock_path)
+    logs: list[str] = []
+
+    moved = move_matching_rollouts(
+        source_home,
+        destination_home,
+        working_dir,
+        log=logs.append,
+    )
+
+    assert moved == 0
+    assert lock_path.is_file()
+    asides = list(
+        destination_sessions.glob(f"{codex_home_mod._MIGRATION_LOCK_ASIDE_PREFIX}*")
+    )
+    assert len(asides) == 1
+    assert stat.S_ISFIFO(asides[0].lstat().st_mode)
+    assert any("renamed non-regular migration lock entry" in message for message in logs)
 
 
 def test_same_source_migration_loser_converges_and_counts_result(tmp_path, monkeypatch):

--- a/tests/test_codex_home.py
+++ b/tests/test_codex_home.py
@@ -406,6 +406,212 @@ def test_claim_boundary_never_removes_fresh_canonical_writer_bytes(tmp_path, mon
     assert str(relative) in marker_payload["retry_sources"]
 
 
+def test_descriptor_held_writer_retains_claim_then_remigrates_bytes(
+    tmp_path, monkeypatch
+):
+    """R4 P1-1: a pre-claim descriptor write survives the retirement boundary."""
+    shared_home = tmp_path / "shared"
+    working_dir = tmp_path / "agent"
+    agent_home = working_dir / ".codex"
+    working_dir.mkdir()
+    _auth(shared_home)
+    source = _rollout(shared_home, "rollout-held-descriptor.jsonl", working_dir)
+    original = source.read_bytes()
+    appended = b'{"type":"event_msg","payload":{"message":"late append"}}\n'
+    assert len(appended) == 57
+    relative = source.relative_to(shared_home / "sessions")
+    destination = agent_home / "sessions" / relative
+    real_file_signature = codex_home_mod._file_signature
+    injected = False
+
+    with source.open("ab", buffering=0) as held_writer:
+
+        def append_after_claim_signature(path: Path):
+            nonlocal injected
+            signature = real_file_signature(path)
+            if (
+                path.parent == source.parent
+                and path.name.startswith(codex_home_mod._MIGRATION_CLAIM_PREFIX)
+                and not injected
+            ):
+                held_writer.write(appended)
+                os.fsync(held_writer.fileno())
+                injected = True
+            return signature
+
+        monkeypatch.setattr(
+            codex_home_mod,
+            "_file_signature",
+            append_after_claim_signature,
+        )
+        monkeypatch.setenv("CODEX_HOME", str(shared_home))
+        monkeypatch.setenv(PER_AGENT_CODEX_HOME_ENV, "1")
+
+        prepare_agent_codex_home(_scope(working_dir), log=lambda _message: None)
+
+        claims = list(
+            source.parent.glob(f"{codex_home_mod._MIGRATION_CLAIM_PREFIX}*")
+        )
+        assert injected is True
+        assert len(claims) == 1
+        assert claims[0].read_bytes() == original + appended
+        assert destination.read_bytes() == original
+
+    prepare_agent_codex_home(_scope(working_dir), log=lambda _message: None)
+
+    assert destination.read_bytes() == original + appended
+
+
+def test_zero_holder_identical_claim_retires(tmp_path, monkeypatch):
+    """R4 P1-1: zero holders plus reverified identity retires the tombstone."""
+    working_dir = tmp_path / "agent"
+    working_dir.mkdir()
+    claim_home = tmp_path / "claims"
+    destination_home = tmp_path / "destination"
+    claim = _rollout(claim_home, "rollout-zero-holder.jsonl", working_dir)
+    destination = _rollout(
+        destination_home,
+        "rollout-zero-holder.jsonl",
+        working_dir,
+    )
+    monkeypatch.setattr(
+        codex_home_mod,
+        "_claim_has_open_descriptors",
+        lambda _claim, _log: False,
+    )
+
+    retired = codex_home_mod._retire_rollout_claim(
+        claim,
+        destination,
+        os.path.realpath(working_dir),
+        log=lambda _message: None,
+    )
+
+    assert retired is True
+    assert not claim.exists()
+
+
+def test_descriptor_scan_unavailable_keeps_claim(tmp_path, monkeypatch):
+    """R4 P1-1: lsof absence fails toward claim retention, never deletion."""
+    working_dir = tmp_path / "agent"
+    working_dir.mkdir()
+    claim_home = tmp_path / "claims"
+    destination_home = tmp_path / "destination"
+    claim = _rollout(claim_home, "rollout-scan-unavailable.jsonl", working_dir)
+    destination = _rollout(
+        destination_home,
+        "rollout-scan-unavailable.jsonl",
+        working_dir,
+    )
+    logs: list[str] = []
+
+    def unavailable(*_args, **_kwargs):
+        raise FileNotFoundError("lsof")
+
+    monkeypatch.setattr(codex_home_mod.subprocess, "run", unavailable)
+
+    retired = codex_home_mod._retire_rollout_claim(
+        claim,
+        destination,
+        os.path.realpath(working_dir),
+        log=logs.append,
+    )
+
+    assert retired is False
+    assert claim.exists()
+    assert any("descriptor scan unavailable" in message for message in logs)
+
+
+def test_claim_link_collision_retries_without_replacing_interleaved_claim(
+    tmp_path, monkeypatch
+):
+    """R4 P2-3: link EEXIST preserves the winner and retries a fresh UUID."""
+    working_dir = tmp_path / "agent"
+    working_dir.mkdir()
+    source_home = tmp_path / "shared"
+    source = _rollout(source_home, "rollout-link-collision.jsonl", working_dir)
+    source_bytes = source.read_bytes()
+    collision_hex = "e" * 32
+    fresh_hex = "f" * 32
+    prior = source.with_name(
+        f"{codex_home_mod._MIGRATION_CLAIM_PREFIX}"
+        f"{collision_hex}-{source.name}"
+    )
+    generated = iter(
+        [SimpleNamespace(hex=collision_hex), SimpleNamespace(hex=fresh_hex)]
+    )
+    monkeypatch.setattr(codex_home_mod.uuid, "uuid4", lambda: next(generated))
+    real_link = os.link
+    injected = False
+
+    def collide_before_link(source_path, claim_path, *args, **kwargs):
+        nonlocal injected
+        if not injected:
+            Path(claim_path).write_bytes(b"interleaved prior claim")
+            injected = True
+        return real_link(source_path, claim_path, *args, **kwargs)
+
+    monkeypatch.setattr(codex_home_mod.os, "link", collide_before_link)
+
+    claim = codex_home_mod._claim_rollout(source)
+
+    assert injected is True
+    assert claim is not None
+    assert claim.name == (
+        f"{codex_home_mod._MIGRATION_CLAIM_PREFIX}{fresh_hex}-{source.name}"
+    )
+    assert prior.read_bytes() == b"interleaved prior claim"
+    assert claim.read_bytes() == source_bytes
+    assert not source.exists()
+    assert not list(source.parent.glob("*.reserve"))
+
+
+def test_stale_empty_reservations_are_swept_data_safely(tmp_path, monkeypatch):
+    """R4 debt: marker fast paths sweep only stale empty private sidecars."""
+    source_home = tmp_path / "source"
+    destination_home = tmp_path / "destination"
+    working_dir = tmp_path / "agent"
+    working_dir.mkdir()
+    _auth(source_home)
+    monkeypatch.setenv("CODEX_HOME", str(source_home))
+    monkeypatch.setenv(PER_AGENT_CODEX_HOME_ENV, "1")
+    scope = _scope(working_dir, codex_home=str(destination_home))
+    prepare_agent_codex_home(scope, log=lambda _message: None)
+    source_sessions = source_home / "sessions"
+    destination_sessions = destination_home / "sessions"
+    source_sessions.mkdir(parents=True)
+    destination_sessions.mkdir(parents=True, exist_ok=True)
+    stale = source_sessions / (
+        f".{codex_home_mod._MIGRATION_CLAIM_PREFIX}"
+        f"{'a' * 32}-rollout-stale.jsonl"
+        f"{codex_home_mod._PRESERVATION_RESERVATION_SUFFIX}"
+    )
+    recent = destination_sessions / (
+        f".{codex_home_mod._MIGRATION_QUARANTINE_PREFIX}"
+        f"rollout-recent.jsonl-{'b' * 32}"
+        f"{codex_home_mod._PRESERVATION_RESERVATION_SUFFIX}"
+    )
+    nonempty = destination_sessions / (
+        f".{codex_home_mod._MIGRATION_LOCK_ASIDE_PREFIX}"
+        f"lock-{'c' * 32}{codex_home_mod._PRESERVATION_RESERVATION_SUFFIX}"
+    )
+    stale.touch()
+    recent.touch()
+    nonempty.write_text("operator bytes", encoding="utf-8")
+    old = time.time() - codex_home_mod._PRESERVATION_RESERVATION_STALE_SECONDS - 1
+    os.utime(stale, (old, old))
+    os.utime(nonempty, (old, old))
+    logs: list[str] = []
+
+    prepared = prepare_agent_codex_home(scope, log=logs.append)
+
+    assert prepared == destination_home
+    assert not stale.exists()
+    assert recent.exists()
+    assert nonempty.read_text(encoding="utf-8") == "operator bytes"
+    assert any("removed stale migration reservation" in message for message in logs)
+
+
 @pytest.mark.parametrize("write_phase", ["during_copy", "post_install"])
 def test_fresh_canonical_writer_path_remigrates_on_next_prepare(
     tmp_path, monkeypatch, write_phase

--- a/tests/test_codex_home.py
+++ b/tests/test_codex_home.py
@@ -1,0 +1,263 @@
+"""Per-agent Codex home isolation, auth, and rollout migration tests."""
+
+from __future__ import annotations
+
+import json
+import os
+import tomllib
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from pinky_daemon.codex_home import (
+    MANAGED_CONFIG_SENTINEL,
+    PER_AGENT_CODEX_HOME_ENV,
+    codex_home_for,
+    prepare_agent_codex_home,
+    rollback_agent_rollouts,
+)
+from pinky_daemon.codex_session import CodexSession
+from pinky_daemon.codex_tmux_transcript import _discover_codex_rollout
+from pinky_daemon.streaming_session import StreamingSessionConfig
+
+
+def _scope(working_dir: Path, *, codex_home: str = "") -> SimpleNamespace:
+    return SimpleNamespace(
+        agent_name="test-agent",
+        working_dir=str(working_dir),
+        codex_home=codex_home,
+    )
+
+
+def _auth(shared_home: Path) -> Path:
+    shared_home.mkdir(parents=True, exist_ok=True)
+    path = shared_home / "auth.json"
+    path.write_text('{"test": true}\n', encoding="utf-8")
+    path.chmod(0o600)
+    return path
+
+
+def _rollout(home: Path, name: str, cwd: Path) -> Path:
+    path = home / "sessions" / "2026" / "08" / "13" / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "type": "session_meta",
+                "payload": {"id": name, "cwd": str(cwd.resolve())},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_flag_off_preserves_shared_path_and_performs_no_bootstrap(
+    tmp_path, monkeypatch
+):
+    shared_home = tmp_path / "shared"
+    working_dir = tmp_path / "agent"
+    override = tmp_path / "override"
+    monkeypatch.setenv("CODEX_HOME", str(shared_home))
+    monkeypatch.delenv(PER_AGENT_CODEX_HOME_ENV, raising=False)
+    scope = _scope(working_dir, codex_home=str(override))
+
+    assert codex_home_for(scope) == shared_home
+    assert prepare_agent_codex_home(scope, log=lambda _message: None) == shared_home
+    assert not working_dir.exists()
+    assert not override.exists()
+    assert not shared_home.exists()
+
+
+def test_flag_off_home_fallback_is_test_controlled(tmp_path, monkeypatch):
+    monkeypatch.delenv("CODEX_HOME", raising=False)
+    monkeypatch.delenv(PER_AGENT_CODEX_HOME_ENV, raising=False)
+    monkeypatch.setattr("pinky_daemon.codex_home.Path.home", lambda: tmp_path)
+
+    assert codex_home_for(_scope(tmp_path / "agent")) == tmp_path / ".codex"
+
+
+def test_prepare_generates_minimal_home_auth_link_and_migrates_matches(
+    tmp_path, monkeypatch
+):
+    shared_home = tmp_path / "shared"
+    working_dir = tmp_path / "agent"
+    other_dir = tmp_path / "other"
+    working_dir.mkdir()
+    other_dir.mkdir()
+    auth_source = _auth(shared_home)
+    matching = _rollout(shared_home, "rollout-match.jsonl", working_dir)
+    other = _rollout(shared_home, "rollout-other.jsonl", other_dir)
+    logs: list[str] = []
+
+    monkeypatch.setenv("CODEX_HOME", str(shared_home))
+    monkeypatch.setenv(PER_AGENT_CODEX_HOME_ENV, "1")
+    home = prepare_agent_codex_home(_scope(working_dir), log=logs.append)
+
+    assert home == working_dir / ".codex"
+    config_text = (home / "config.toml").read_text(encoding="utf-8")
+    assert config_text.startswith(MANAGED_CONFIG_SENTINEL)
+    config = tomllib.loads(config_text)
+    assert config["features"] == {"apps": False, "plugins": False}
+    assert config["projects"][str(working_dir.resolve())]["trust_level"] == "trusted"
+    assert "mcp_servers" not in config
+    assert "plugins" not in config
+    assert "marketplaces" not in config
+    assert (home / "sessions").is_dir()
+    assert (home / "auth.json").is_symlink()
+    assert os.path.samefile(home / "auth.json", auth_source)
+
+    migrated = home / "sessions" / matching.relative_to(shared_home / "sessions")
+    assert migrated.exists()
+    assert not matching.exists()
+    assert other.exists()
+    assert any("migrated 1 cwd-matched rollout(s)" in message for message in logs)
+
+    before = config_text
+    prepare_agent_codex_home(_scope(working_dir), log=logs.append)
+    assert (home / "config.toml").read_text(encoding="utf-8") == before
+
+
+def test_explicit_override_wins_only_when_flag_is_enabled(tmp_path, monkeypatch):
+    shared_home = tmp_path / "shared"
+    working_dir = tmp_path / "agent"
+    override = tmp_path / "custom-codex"
+    working_dir.mkdir()
+    _auth(shared_home)
+    monkeypatch.setenv("CODEX_HOME", str(shared_home))
+    monkeypatch.setenv(PER_AGENT_CODEX_HOME_ENV, "1")
+
+    scope = _scope(working_dir, codex_home=str(override))
+    assert codex_home_for(scope) == override
+    assert prepare_agent_codex_home(scope, log=lambda _message: None) == override
+    assert (override / "auth.json").is_symlink()
+
+
+def test_unmanaged_config_is_preserved_with_loud_log(tmp_path, monkeypatch):
+    shared_home = tmp_path / "shared"
+    working_dir = tmp_path / "agent"
+    agent_home = working_dir / ".codex"
+    working_dir.mkdir()
+    agent_home.mkdir()
+    _auth(shared_home)
+    manual = "# operator-managed\n[features]\nplugins = true\n"
+    (agent_home / "config.toml").write_text(manual, encoding="utf-8")
+    logs: list[str] = []
+    monkeypatch.setenv("CODEX_HOME", str(shared_home))
+    monkeypatch.setenv(PER_AGENT_CODEX_HOME_ENV, "1")
+
+    prepare_agent_codex_home(_scope(working_dir), log=logs.append)
+
+    assert (agent_home / "config.toml").read_text(encoding="utf-8") == manual
+    assert any("preserving unmanaged config" in message for message in logs)
+
+
+def test_linked_config_never_mutates_shared_config(tmp_path, monkeypatch):
+    shared_home = tmp_path / "shared"
+    working_dir = tmp_path / "agent"
+    agent_home = working_dir / ".codex"
+    working_dir.mkdir()
+    agent_home.mkdir()
+    _auth(shared_home)
+    shared_config = shared_home / "config.toml"
+    original = f"{MANAGED_CONFIG_SENTINEL}\n# shared\n"
+    shared_config.write_text(original, encoding="utf-8")
+    (agent_home / "config.toml").symlink_to(shared_config)
+    logs: list[str] = []
+    monkeypatch.setenv("CODEX_HOME", str(shared_home))
+    monkeypatch.setenv(PER_AGENT_CODEX_HOME_ENV, "1")
+
+    prepare_agent_codex_home(_scope(working_dir), log=logs.append)
+
+    assert shared_config.read_text(encoding="utf-8") == original
+    assert any("preserving linked config" in message for message in logs)
+
+
+def test_auth_absence_refuses_spawn_before_creating_agent_home(tmp_path, monkeypatch):
+    shared_home = tmp_path / "shared"
+    shared_home.mkdir()
+    working_dir = tmp_path / "agent"
+    working_dir.mkdir()
+    monkeypatch.setenv("CODEX_HOME", str(shared_home))
+    monkeypatch.setenv(PER_AGENT_CODEX_HOME_ENV, "1")
+
+    with pytest.raises(RuntimeError, match="shared auth file is absent or unreadable"):
+        prepare_agent_codex_home(_scope(working_dir), log=lambda _message: None)
+
+    assert not (working_dir / ".codex").exists()
+
+
+def test_existing_non_symlink_auth_refuses_spawn(tmp_path, monkeypatch):
+    shared_home = tmp_path / "shared"
+    working_dir = tmp_path / "agent"
+    agent_home = working_dir / ".codex"
+    working_dir.mkdir()
+    agent_home.mkdir()
+    _auth(shared_home)
+    (agent_home / "auth.json").write_text('{"forked": true}\n', encoding="utf-8")
+    monkeypatch.setenv("CODEX_HOME", str(shared_home))
+    monkeypatch.setenv(PER_AGENT_CODEX_HOME_ENV, "1")
+
+    with pytest.raises(RuntimeError, match="not the managed auth symlink"):
+        prepare_agent_codex_home(_scope(working_dir), log=lambda _message: None)
+
+
+def test_discovery_uses_agent_home_not_shared_home(tmp_path, monkeypatch):
+    shared_home = tmp_path / "shared"
+    working_dir = tmp_path / "agent"
+    working_dir.mkdir()
+    agent_home = working_dir / ".codex"
+    shared_match = _rollout(shared_home, "rollout-shared.jsonl", working_dir)
+    agent_match = _rollout(agent_home, "rollout-agent.jsonl", working_dir)
+    os.utime(shared_match, (agent_match.stat().st_mtime + 10,) * 2)
+    monkeypatch.setenv("CODEX_HOME", str(shared_home))
+    monkeypatch.setenv(PER_AGENT_CODEX_HOME_ENV, "1")
+
+    assert _discover_codex_rollout(working_dir, agent=_scope(working_dir)) == agent_match
+
+
+def test_subprocess_transport_overlays_prepared_home(tmp_path, monkeypatch):
+    shared_home = tmp_path / "shared"
+    working_dir = tmp_path / "agent"
+    working_dir.mkdir()
+    _auth(shared_home)
+    monkeypatch.setenv("CODEX_HOME", str(shared_home))
+    monkeypatch.setenv(PER_AGENT_CODEX_HOME_ENV, "1")
+    config = StreamingSessionConfig(
+        agent_name="test-agent",
+        working_dir=str(working_dir),
+        provider_url="codex_cli",
+    )
+
+    env = CodexSession(config)._build_codex_env()
+
+    assert env["CODEX_HOME"] == str(working_dir / ".codex")
+    assert (working_dir / ".codex" / "auth.json").is_symlink()
+
+
+def test_reverse_migration_moves_only_matching_rollouts(tmp_path):
+    shared_home = tmp_path / "shared"
+    working_dir = tmp_path / "agent"
+    other_dir = tmp_path / "other"
+    working_dir.mkdir()
+    other_dir.mkdir()
+    agent_home = working_dir / ".codex"
+    matching = _rollout(agent_home, "rollout-match.jsonl", working_dir)
+    other = _rollout(agent_home, "rollout-other.jsonl", other_dir)
+    logs: list[str] = []
+
+    moved = rollback_agent_rollouts(
+        working_dir,
+        agent_home,
+        shared_home=shared_home,
+        log=logs.append,
+    )
+
+    restored = shared_home / "sessions" / matching.relative_to(agent_home / "sessions")
+    assert moved == 1
+    assert restored.exists()
+    assert not matching.exists()
+    assert other.exists()
+    assert any("rolled back 1 cwd-matched rollout(s)" in message for message in logs)

--- a/tests/test_codex_home.py
+++ b/tests/test_codex_home.py
@@ -279,6 +279,33 @@ def test_partial_migration_final_is_quarantined_and_retry_converges(tmp_path, mo
     assert any("quarantined invalid rollout migration final" in message for message in logs)
 
 
+def test_quarantine_uuid_collision_retains_both_artifacts(tmp_path, monkeypatch):
+    """R3 P2-3: quarantine reservation retries instead of replacing history."""
+    destination = tmp_path / "rollout-collision.jsonl"
+    destination.write_bytes(b"new invalid bytes")
+    collision_hex = "a" * 32
+    fresh_hex = "b" * 32
+    prior = destination.with_name(
+        f"{codex_home_mod._MIGRATION_QUARANTINE_PREFIX}"
+        f"{destination.name}-{collision_hex}"
+    )
+    prior.write_bytes(b"prior invalid bytes")
+    generated = iter(
+        [SimpleNamespace(hex=collision_hex), SimpleNamespace(hex=fresh_hex)]
+    )
+    monkeypatch.setattr(codex_home_mod.uuid, "uuid4", lambda: next(generated))
+
+    retained = codex_home_mod._quarantine_rollout(
+        destination,
+        log=lambda _message: None,
+    )
+
+    assert prior.read_bytes() == b"prior invalid bytes"
+    assert retained.read_bytes() == b"new invalid bytes"
+    assert retained != prior
+    assert not destination.exists()
+
+
 def test_initial_migration_lock_deadline_preserves_source_and_markerless_state(
     tmp_path, monkeypatch
 ):
@@ -337,10 +364,8 @@ def test_reverse_migration_uses_same_bounded_lock_acquisition(tmp_path, monkeypa
     assert source.read_bytes() == source_bytes
 
 
-def test_source_change_after_final_validation_remains_authoritative_and_retryable(
-    tmp_path, monkeypatch
-):
-    """R2 P1-2: recheck the source immediately before removing it."""
+def test_claim_boundary_never_removes_fresh_canonical_writer_bytes(tmp_path, monkeypatch):
+    """R3 P1-1: a write inside the former check/unlink interval survives."""
     shared_home = tmp_path / "shared"
     working_dir = tmp_path / "agent"
     agent_home = working_dir / ".codex"
@@ -351,43 +376,104 @@ def test_source_change_after_final_validation_remains_authoritative_and_retryabl
     appended = b'{"type":"event_msg","payload":{"message":"late append"}}\n'
     relative = source.relative_to(shared_home / "sessions")
     destination = agent_home / "sessions" / relative
-    real_rollout_is_valid = codex_home_mod._rollout_is_valid
+    real_unlink = Path.unlink
     injected = False
 
-    def append_after_final_validation(path, target_cwd, *, expected_signature=None):
+    def write_at_claim_removal(path: Path, *args, **kwargs):
         nonlocal injected
-        valid = real_rollout_is_valid(
-            path,
-            target_cwd,
-            expected_signature=expected_signature,
-        )
-        if path == destination and expected_signature is not None and valid and not injected:
-            with source.open("ab") as handle:
-                handle.write(appended)
-                handle.flush()
-                os.fsync(handle.fileno())
+        if (
+            path.parent == source.parent
+            and path.name.startswith(codex_home_mod._MIGRATION_CLAIM_PREFIX)
+            and not injected
+        ):
+            source.write_bytes(appended)
             injected = True
-        return valid
+        return real_unlink(path, *args, **kwargs)
 
-    monkeypatch.setattr(
-        codex_home_mod,
-        "_rollout_is_valid",
-        append_after_final_validation,
-    )
+    monkeypatch.setattr(Path, "unlink", write_at_claim_removal)
     monkeypatch.setenv("CODEX_HOME", str(shared_home))
     monkeypatch.setenv(PER_AGENT_CODEX_HOME_ENV, "1")
 
-    with pytest.raises(RuntimeError, match="changed before source removal"):
-        prepare_agent_codex_home(_scope(working_dir), log=lambda _message: None)
+    prepare_agent_codex_home(_scope(working_dir), log=lambda _message: None)
 
-    assert source.read_bytes() == original + appended
+    assert injected is True
+    assert source.read_bytes() == appended
     assert destination.read_bytes() == original
-    assert not (agent_home / ROLLOUT_MIGRATION_MARKER).exists()
+    assert not list(source.parent.glob(f"{codex_home_mod._MIGRATION_CLAIM_PREFIX}*"))
+    marker_payload = json.loads(
+        (agent_home / ROLLOUT_MIGRATION_MARKER).read_text(encoding="utf-8")
+    )
+    assert str(relative) in marker_payload["retry_sources"]
+
+
+@pytest.mark.parametrize("write_phase", ["during_copy", "post_install"])
+def test_fresh_canonical_writer_path_remigrates_on_next_prepare(
+    tmp_path, monkeypatch, write_phase
+):
+    """R3 P1-1: writes after claim become the next prepare's authority."""
+    shared_home = tmp_path / "shared"
+    working_dir = tmp_path / "agent"
+    agent_home = working_dir / ".codex"
+    working_dir.mkdir()
+    _auth(shared_home)
+    source = _rollout(shared_home, f"rollout-{write_phase}.jsonl", working_dir)
+    original = source.read_bytes()
+    appended = b'{"type":"event_msg","payload":{"message":"fresh path"}}\n'
+    fresh_bytes = original + appended
+    relative = source.relative_to(shared_home / "sessions")
+    destination = agent_home / "sessions" / relative
+    injected = False
+
+    if write_phase == "during_copy":
+        real_file_signature = codex_home_mod._file_signature
+
+        def write_after_claim_copy(path: Path):
+            nonlocal injected
+            signature = real_file_signature(path)
+            if (
+                path.parent == source.parent
+                and path.name.startswith(codex_home_mod._MIGRATION_CLAIM_PREFIX)
+                and not injected
+            ):
+                source.write_bytes(fresh_bytes)
+                injected = True
+            return signature
+
+        monkeypatch.setattr(codex_home_mod, "_file_signature", write_after_claim_copy)
+    else:
+        real_rollout_is_valid = codex_home_mod._rollout_is_valid
+
+        def write_after_final_install(path, target_cwd, *, expected_signature=None):
+            nonlocal injected
+            valid = real_rollout_is_valid(
+                path,
+                target_cwd,
+                expected_signature=expected_signature,
+            )
+            if path == destination and expected_signature is not None and valid and not injected:
+                source.write_bytes(fresh_bytes)
+                injected = True
+            return valid
+
+        monkeypatch.setattr(
+            codex_home_mod,
+            "_rollout_is_valid",
+            write_after_final_install,
+        )
+
+    monkeypatch.setenv("CODEX_HOME", str(shared_home))
+    monkeypatch.setenv(PER_AGENT_CODEX_HOME_ENV, "1")
+
+    prepare_agent_codex_home(_scope(working_dir), log=lambda _message: None)
+
+    assert injected is True
+    assert source.read_bytes() == fresh_bytes
+    assert destination.read_bytes() == original
 
     prepare_agent_codex_home(_scope(working_dir), log=lambda _message: None)
 
     assert not source.exists()
-    assert destination.read_bytes() == original + appended
+    assert destination.read_bytes() == fresh_bytes
     assert (agent_home / ROLLOUT_MIGRATION_MARKER).exists()
 
 
@@ -424,6 +510,48 @@ def test_linked_lock_entry_is_preserved_aside_without_touching_target(
     assert asides[0].is_symlink()
     assert os.readlink(asides[0]) == str(unintended_target)
     assert any("renamed linked migration lock entry" in message for message in logs)
+
+
+def test_lock_aside_uuid_collision_retains_both_artifacts(tmp_path, monkeypatch):
+    """R3 P2-3: lock-aside reservation retries instead of replacing history."""
+    source_home = tmp_path / "source-home"
+    destination_home = tmp_path / "destination-home"
+    working_dir = tmp_path / "agent"
+    working_dir.mkdir()
+    destination_sessions = destination_home / "sessions"
+    destination_sessions.mkdir(parents=True)
+    lock_path = destination_sessions / codex_home_mod._MIGRATION_LOCK_NAME
+    lock_path.write_bytes(b"new linked bytes")
+    peer = tmp_path / "peer.lock"
+    os.link(lock_path, peer)
+    collision_hex = "c" * 32
+    fresh_hex = "d" * 32
+    prior = destination_sessions / (
+        f"{codex_home_mod._MIGRATION_LOCK_ASIDE_PREFIX}"
+        f"{lock_path.name}-{collision_hex}"
+    )
+    prior.write_bytes(b"prior retained bytes")
+    generated = iter(
+        [SimpleNamespace(hex=collision_hex), SimpleNamespace(hex=fresh_hex)]
+    )
+    monkeypatch.setattr(codex_home_mod.uuid, "uuid4", lambda: next(generated))
+
+    moved = move_matching_rollouts(
+        source_home,
+        destination_home,
+        working_dir,
+        log=lambda _message: None,
+    )
+
+    retained = destination_sessions / (
+        f"{codex_home_mod._MIGRATION_LOCK_ASIDE_PREFIX}"
+        f"{lock_path.name}-{fresh_hex}"
+    )
+    assert moved == 0
+    assert prior.read_bytes() == b"prior retained bytes"
+    assert retained.read_bytes() == b"new linked bytes"
+    assert peer.read_bytes() == b"new linked bytes"
+    assert lock_path.is_file()
 
 
 def test_hard_linked_lock_entry_is_preserved_aside_without_mutating_peer(tmp_path):

--- a/tests/test_codex_home.py
+++ b/tests/test_codex_home.py
@@ -4,20 +4,26 @@ from __future__ import annotations
 
 import json
 import os
+import threading
 import tomllib
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
 
+from pinky_daemon import codex_home as codex_home_mod
 from pinky_daemon.codex_home import (
     MANAGED_CONFIG_SENTINEL,
     PER_AGENT_CODEX_HOME_ENV,
+    ROLLOUT_MIGRATION_MARKER,
     codex_home_for,
+    move_matching_rollouts,
     prepare_agent_codex_home,
     rollback_agent_rollouts,
 )
 from pinky_daemon.codex_session import CodexSession
+from pinky_daemon.codex_tmux_session import CodexTmuxSession
 from pinky_daemon.codex_tmux_transcript import _discover_codex_rollout
 from pinky_daemon.streaming_session import StreamingSessionConfig
 
@@ -54,9 +60,7 @@ def _rollout(home: Path, name: str, cwd: Path) -> Path:
     return path
 
 
-def test_flag_off_preserves_shared_path_and_performs_no_bootstrap(
-    tmp_path, monkeypatch
-):
+def test_flag_off_preserves_shared_path_and_performs_no_bootstrap(tmp_path, monkeypatch):
     shared_home = tmp_path / "shared"
     working_dir = tmp_path / "agent"
     override = tmp_path / "override"
@@ -79,9 +83,7 @@ def test_flag_off_home_fallback_is_test_controlled(tmp_path, monkeypatch):
     assert codex_home_for(_scope(tmp_path / "agent")) == tmp_path / ".codex"
 
 
-def test_prepare_generates_minimal_home_auth_link_and_migrates_matches(
-    tmp_path, monkeypatch
-):
+def test_prepare_generates_minimal_home_auth_link_and_migrates_matches(tmp_path, monkeypatch):
     shared_home = tmp_path / "shared"
     working_dir = tmp_path / "agent"
     other_dir = tmp_path / "other"
@@ -118,6 +120,50 @@ def test_prepare_generates_minimal_home_auth_link_and_migrates_matches(
     before = config_text
     prepare_agent_codex_home(_scope(working_dir), log=logs.append)
     assert (home / "config.toml").read_text(encoding="utf-8") == before
+
+
+def test_migration_marker_permanently_hides_late_shared_rollout(tmp_path, monkeypatch):
+    """Review P1-1: migration is a one-time bridge, not a spawn-time scan."""
+    shared_home = tmp_path / "shared"
+    working_dir = tmp_path / "agent"
+    working_dir.mkdir()
+    _auth(shared_home)
+    first = _rollout(shared_home, "rollout-first.jsonl", working_dir)
+    monkeypatch.setenv("CODEX_HOME", str(shared_home))
+    monkeypatch.setenv(PER_AGENT_CODEX_HOME_ENV, "1")
+
+    home = prepare_agent_codex_home(_scope(working_dir), log=lambda _message: None)
+    migrated = home / "sessions" / first.relative_to(shared_home / "sessions")
+    assert migrated.exists()
+    marker = home / ROLLOUT_MIGRATION_MARKER
+    marker_payload = json.loads(marker.read_text(encoding="utf-8"))
+    assert marker_payload["moved_count"] == 1
+    assert marker_payload["completed_at"]
+    marker_bytes = marker.read_bytes()
+
+    # Make the isolated store intentionally empty, then plant a new ambient
+    # rollout with the same cwd. A later spawn must remain fresh.
+    migrated.unlink()
+    late = _rollout(shared_home, "rollout-planted-after-gate.jsonl", working_dir)
+    second_logs: list[str] = []
+    prepare_agent_codex_home(_scope(working_dir), log=second_logs.append)
+
+    assert marker.read_bytes() == marker_bytes
+    assert late.exists()
+    assert not (home / "sessions" / late.relative_to(shared_home / "sessions")).exists()
+    assert any("migration marker present" in message for message in second_logs)
+    assert any("migrated 0 cwd-matched rollout(s)" in message for message in second_logs)
+
+    config = StreamingSessionConfig(
+        agent_name="test-agent",
+        working_dir=str(working_dir),
+        provider_url="codex_cli",
+    )
+    session = CodexTmuxSession(config)
+    command = session._build_claude_cmd()
+    assert "resume --last" not in command
+    assert " -C " in command
+    assert session._last_launch_used_continue is False
 
 
 def test_explicit_override_wins_only_when_flag_is_enabled(tmp_path, monkeypatch):
@@ -173,6 +219,181 @@ def test_linked_config_never_mutates_shared_config(tmp_path, monkeypatch):
 
     assert shared_config.read_text(encoding="utf-8") == original
     assert any("preserving linked config" in message for message in logs)
+
+
+def test_dangling_config_symlink_is_preserved_without_write_through(tmp_path, monkeypatch):
+    """Review P1-2: exists() must never precede symlink classification."""
+    shared_home = tmp_path / "shared"
+    working_dir = tmp_path / "agent"
+    agent_home = working_dir / ".codex"
+    working_dir.mkdir()
+    agent_home.mkdir()
+    _auth(shared_home)
+    missing_shared_target = shared_home / "config.toml"
+    config_link = agent_home / "config.toml"
+    config_link.symlink_to(missing_shared_target)
+    logs: list[str] = []
+    monkeypatch.setenv("CODEX_HOME", str(shared_home))
+    monkeypatch.setenv(PER_AGENT_CODEX_HOME_ENV, "1")
+
+    prepare_agent_codex_home(_scope(working_dir), log=logs.append)
+
+    assert config_link.is_symlink()
+    assert not missing_shared_target.exists()
+    assert any("preserving linked config" in message for message in logs)
+
+
+def test_partial_migration_final_is_quarantined_and_retry_converges(tmp_path, monkeypatch):
+    """Review P1-3: recover an old crash artifact without shadowing source."""
+    shared_home = tmp_path / "shared"
+    working_dir = tmp_path / "agent"
+    agent_home = working_dir / ".codex"
+    working_dir.mkdir()
+    _auth(shared_home)
+    source = _rollout(shared_home, "rollout-crash.jsonl", working_dir)
+    source_bytes = source.read_bytes()
+    relative = source.relative_to(shared_home / "sessions")
+    final = agent_home / "sessions" / relative
+    final.parent.mkdir(parents=True, exist_ok=True)
+    partial_bytes = b'\xff{"type":"session_meta"'
+    final.write_bytes(partial_bytes)
+    abandoned = final.parent / ".pinkybot-rollout-migration-abandoned.tmp"
+    abandoned.write_text("partial", encoding="utf-8")
+    logs: list[str] = []
+    monkeypatch.setenv("CODEX_HOME", str(shared_home))
+    monkeypatch.setenv(PER_AGENT_CODEX_HOME_ENV, "1")
+
+    prepare_agent_codex_home(_scope(working_dir), log=logs.append)
+
+    assert not source.exists()
+    assert final.read_bytes() == source_bytes
+    assert not abandoned.exists()
+    quarantines = list(final.parent.glob(f".pinkybot-rollout-quarantine-{final.name}-*"))
+    assert len(quarantines) == 1
+    assert quarantines[0].read_bytes() == partial_bytes
+    assert any("removed abandoned rollout migration temp" in message for message in logs)
+    assert any("quarantined invalid rollout migration final" in message for message in logs)
+
+
+def test_same_source_migration_loser_converges_and_counts_result(tmp_path, monkeypatch):
+    """Review P2: losing the source unlink race is successful convergence."""
+    shared_home = tmp_path / "shared"
+    destination_home = tmp_path / "agent-home"
+    working_dir = tmp_path / "agent"
+    working_dir.mkdir()
+    source = _rollout(shared_home, "rollout-race.jsonl", working_dir)
+    relative = source.relative_to(shared_home / "sessions")
+    destination = destination_home / "sessions" / relative
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    destination.write_bytes(source.read_bytes())
+    real_unlink = Path.unlink
+
+    def winner_claimed_then_raised(path: Path, *args, **kwargs):
+        if path == source:
+            real_unlink(path)
+            raise FileNotFoundError(path)
+        return real_unlink(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "unlink", winner_claimed_then_raised)
+    logs: list[str] = []
+
+    moved = move_matching_rollouts(
+        shared_home,
+        destination_home,
+        working_dir,
+        log=logs.append,
+    )
+
+    assert moved == 1
+    assert not source.exists()
+    assert destination.exists()
+    assert any("migration converged" in message for message in logs)
+
+
+def test_concurrent_same_source_migrators_both_converge(tmp_path, monkeypatch):
+    """Review P2 exact shape: two pre-lock scans, one atomic final."""
+    shared_home = tmp_path / "shared"
+    destination_home = tmp_path / "agent-home"
+    working_dir = tmp_path / "agent"
+    working_dir.mkdir()
+    source = _rollout(shared_home, "rollout-concurrent.jsonl", working_dir)
+    relative = source.relative_to(shared_home / "sessions")
+    destination = destination_home / "sessions" / relative
+    source_sessions = shared_home / "sessions"
+    scan_barrier = threading.Barrier(2)
+    real_glob = Path.glob
+
+    def synchronized_glob(path: Path, pattern: str):
+        found = list(real_glob(path, pattern))
+        if path == source_sessions and pattern == "**/rollout-*.jsonl":
+            scan_barrier.wait(timeout=5)
+        return iter(found)
+
+    monkeypatch.setattr(Path, "glob", synchronized_glob)
+    logs: list[str] = []
+
+    def migrate() -> int:
+        return move_matching_rollouts(
+            shared_home,
+            destination_home,
+            working_dir,
+            log=logs.append,
+        )
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        futures = [pool.submit(migrate), pool.submit(migrate)]
+        moved = [future.result(timeout=10) for future in futures]
+
+    assert moved == [1, 1]
+    assert not source.exists()
+    assert destination.exists()
+    assert any("source was already claimed" in message for message in logs)
+
+
+def test_concurrent_initial_migration_commits_one_accurate_marker(
+    tmp_path, monkeypatch
+):
+    """The one-time marker closes the scan-to-gate race between spawns."""
+    shared_home = tmp_path / "shared"
+    destination_home = tmp_path / "agent-home"
+    working_dir = tmp_path / "agent"
+    working_dir.mkdir()
+    source = _rollout(shared_home, "rollout-initial-race.jsonl", working_dir)
+    source_sessions = shared_home / "sessions"
+    destination_sessions = destination_home / "sessions"
+    destination_sessions.mkdir(parents=True)
+    scan_barrier = threading.Barrier(2)
+    real_glob = Path.glob
+
+    def synchronized_glob(path: Path, pattern: str):
+        found = list(real_glob(path, pattern))
+        if path == source_sessions and pattern == "**/rollout-*.jsonl":
+            scan_barrier.wait(timeout=5)
+        return iter(found)
+
+    monkeypatch.setattr(Path, "glob", synchronized_glob)
+    logs: list[str] = []
+
+    def migrate() -> int:
+        return codex_home_mod._run_initial_rollout_migration(
+            shared_home,
+            destination_home,
+            working_dir,
+            log=logs.append,
+        )
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        futures = [pool.submit(migrate), pool.submit(migrate)]
+        moved = [future.result(timeout=10) for future in futures]
+
+    marker = destination_home / ROLLOUT_MIGRATION_MARKER
+    marker_payload = json.loads(marker.read_text(encoding="utf-8"))
+    destination = destination_sessions / source.relative_to(source_sessions)
+    assert moved == [1, 1]
+    assert marker_payload["moved_count"] == 1
+    assert not source.exists()
+    assert destination.exists()
+    assert any("marker already committed" in message for message in logs)
 
 
 def test_auth_absence_refuses_spawn_before_creating_agent_home(tmp_path, monkeypatch):

--- a/tests/test_codex_home.py
+++ b/tests/test_codex_home.py
@@ -491,10 +491,10 @@ def test_zero_holder_identical_claim_retires(tmp_path, monkeypatch):
     assert not claim.exists()
 
 
-def test_claim_retirement_timing_window_keeps_appended_bytes_recoverable(
+def test_frozen_claim_with_held_writer_retains_every_append_in_named_claim(
     tmp_path, monkeypatch
 ):
-    """R6 boundary-condition check: pathname-appended bytes stay recoverable."""
+    """R7 R1: a holder may keep writing, so retirement retains its pathname."""
     working_dir = tmp_path / "agent"
     working_dir.mkdir()
     claim_home = tmp_path / "claims"
@@ -512,17 +512,13 @@ def test_claim_retirement_timing_window_keeps_appended_bytes_recoverable(
         "rollout-retirement-timing-window.jsonl",
         working_dir,
     )
-    appended = b'{"type":"event_msg","payload":{"message":"timing window"}}\n'
+    before_freeze = b'{"type":"event_msg","payload":{"message":"before freeze"}}\n'
+    after_scan = b'{"type":"event_msg","payload":{"message":"after scan"}}\n'
     real_rollout_is_valid = codex_home_mod._rollout_is_valid
+    real_inode_scan = codex_home_mod._inode_has_open_descriptors
     late_writer = None
     injected = False
     logs: list[str] = []
-
-    monkeypatch.setattr(
-        codex_home_mod,
-        "_claim_has_open_descriptors",
-        lambda _claim, _log: False,
-    )
 
     def append_during_destination_verification(
         path: Path,
@@ -538,7 +534,7 @@ def test_claim_retirement_timing_window_keeps_appended_bytes_recoverable(
         )
         if path == destination and expected_signature is not None and not injected:
             late_writer = claim.open("ab", buffering=0)
-            late_writer.write(appended)
+            late_writer.write(before_freeze)
             os.fsync(late_writer.fileno())
             injected = True
         return valid
@@ -548,7 +544,26 @@ def test_claim_retirement_timing_window_keeps_appended_bytes_recoverable(
         "_rollout_is_valid",
         append_during_destination_verification,
     )
+
+    def append_after_frozen_scan_decision(claim_handle, claim_path, log):
+        holders = real_inode_scan(claim_handle, claim_path, log)
+        assert late_writer is not None
+        late_writer.write(after_scan)
+        os.fsync(late_writer.fileno())
+        return holders
+
+    monkeypatch.setattr(
+        codex_home_mod,
+        "_inode_has_open_descriptors",
+        append_after_frozen_scan_decision,
+    )
     try:
+        claim_signature = codex_home_mod._file_signature(claim)
+        assert codex_home_mod._rollout_is_valid(
+            destination,
+            os.path.realpath(working_dir),
+            expected_signature=claim_signature,
+        )
         retired = codex_home_mod._retire_rollout_claim(
             claim,
             destination,
@@ -556,31 +571,391 @@ def test_claim_retirement_timing_window_keeps_appended_bytes_recoverable(
             log=logs.append,
         )
 
-        recovery_claims = list(
-            claim.parent.glob(f"{codex_home_mod._MIGRATION_CLAIM_PREFIX}*")
-        )
         assert injected is True
         assert retired is False
-        assert not claim.exists()
-        assert len(recovery_claims) == 1
-        assert recovery_claims[0].name != claim.name
-        assert recovery_claims[0].read_bytes() == original + appended
+        assert claim.read_bytes() == original + before_freeze + after_scan
         assert destination.read_bytes() == original
         assert any(
-            "retirement boundary-condition check" in message
-            and "recovery claim" in message
+            "open descriptor holder(s) remain at the frozen boundary" in message
             for message in logs
         )
-        assert not list(
-            claim.parent.glob(
-                f"{codex_home_mod._MIGRATION_TEMP_PREFIX}recovery-*"
-                f"{codex_home_mod._MIGRATION_TEMP_SUFFIX}"
-            )
-        )
-        assert not list(claim.parent.glob("*.reserve"))
+        assert stat.S_IMODE(claim.stat().st_mode) != 0
     finally:
         if late_writer is not None:
             late_writer.close()
+
+
+def test_file_mode_freeze_blocks_new_open_but_preserves_descriptor_rights(tmp_path):
+    """R7 boundary semantics: file mode freeze is portable for a non-root owner."""
+    claim = tmp_path / "claim"
+    claim.write_bytes(b"stable bytes")
+    claim.chmod(0o640)
+    claim_fd = os.open(claim, os.O_RDONLY)
+    try:
+        os.fchmod(claim_fd, 0)
+
+        with pytest.raises(PermissionError):
+            os.open(claim, os.O_RDONLY)
+
+        os.lseek(claim_fd, 0, os.SEEK_SET)
+        assert os.read(claim_fd, 64) == b"stable bytes"
+        os.chmod(claim, 0o640, follow_symlinks=False)
+        assert stat.S_IMODE(claim.stat().st_mode) == 0o640
+    finally:
+        os.fchmod(claim_fd, 0o640)
+        os.close(claim_fd)
+
+
+def test_recovery_publication_failure_restores_named_claim_without_litter(
+    tmp_path, monkeypatch
+):
+    """R7 R2a: publication failure occurs while the complete old name remains."""
+    working_dir = tmp_path / "agent"
+    working_dir.mkdir()
+    claim_home = tmp_path / "claims"
+    destination_home = tmp_path / "destination"
+    source = _rollout(
+        claim_home,
+        "rollout-recovery-publication-failure.jsonl",
+        working_dir,
+    )
+    original = source.read_bytes()
+    claim = codex_home_mod._claim_rollout(source)
+    assert claim is not None
+    original_mode = stat.S_IMODE(claim.stat().st_mode)
+    appended = b'{"type":"event_msg","payload":{"message":"new bytes"}}\n'
+    current = original + appended
+    claim.write_bytes(current)
+    destination = _rollout(
+        destination_home,
+        "rollout-recovery-publication-failure.jsonl",
+        working_dir,
+    )
+    real_link = codex_home_mod.os.link
+    logs: list[str] = []
+
+    monkeypatch.setattr(
+        codex_home_mod,
+        "_inode_has_open_descriptors",
+        lambda _handle, _claim, _log: False,
+    )
+
+    def fail_recovery_link(source_path, destination_path, *args, **kwargs):
+        if Path(source_path).name.startswith(
+            f"{codex_home_mod._MIGRATION_TEMP_PREFIX}recovery-"
+        ):
+            raise OSError(5, "forced recovery publication failure")
+        return real_link(source_path, destination_path, *args, **kwargs)
+
+    monkeypatch.setattr(codex_home_mod.os, "link", fail_recovery_link)
+
+    retired = codex_home_mod._retire_rollout_claim(
+        claim,
+        destination,
+        os.path.realpath(working_dir),
+        log=logs.append,
+    )
+
+    assert retired is False
+    assert claim.read_bytes() == current
+    assert stat.S_IMODE(claim.stat().st_mode) == original_mode
+    assert destination.read_bytes() == original
+    assert not list(
+        claim.parent.glob(
+            f"{codex_home_mod._MIGRATION_TEMP_PREFIX}recovery-*"
+            f"{codex_home_mod._MIGRATION_TEMP_SUFFIX}"
+        )
+    )
+    assert not list(claim.parent.glob("*.reserve"))
+    assert any(
+        "recovery publication failed before unlink" in message for message in logs
+    )
+
+
+@pytest.mark.parametrize(
+    ("device_field", "inode_field"),
+    [
+        ("unparseable-device", "matching"),
+        ("matching", "unparseable-inode"),
+    ],
+)
+def test_frozen_inode_half_parse_is_loud_uncertainty(
+    tmp_path, monkeypatch, device_field, inode_field
+):
+    """R7 R4: a matching identity half never becomes verified absence."""
+    claim = tmp_path / "claim"
+    claim.write_bytes(b"bytes")
+    logs: list[str] = []
+
+    with claim.open("rb", buffering=0) as claim_handle:
+        claim_stat = os.fstat(claim_handle.fileno())
+        device = (
+            str(claim_stat.st_dev)
+            if device_field == "matching"
+            else device_field
+        )
+        inode = (
+            str(claim_stat.st_ino)
+            if inode_field == "matching"
+            else inode_field
+        )
+        output = "\n".join(
+            [
+                f"p{os.getpid()}",
+                f"f{claim_handle.fileno()}r",
+                f"D{claim_stat.st_dev}",
+                f"i{claim_stat.st_ino}",
+                "p987654",
+                "f9w",
+                f"D{device}",
+                f"i{inode}",
+                "",
+            ]
+        )
+        monkeypatch.setattr(
+            codex_home_mod.subprocess,
+            "run",
+            lambda *_args, **_kwargs: SimpleNamespace(
+                returncode=0,
+                stdout=output,
+                stderr="",
+            ),
+        )
+
+        holders = codex_home_mod._inode_has_open_descriptors(
+            claim_handle,
+            claim,
+            logs.append,
+        )
+
+    assert holders is None
+    assert any(
+        "could not parse a device or inode field for a potential holder" in message
+        for message in logs
+    )
+
+
+def test_live_mode_freeze_is_transiently_retained_without_thaw(tmp_path):
+    """R7 R5: a concurrent retirer cannot repair another live freeze."""
+    working_dir = tmp_path / "agent"
+    working_dir.mkdir()
+    claim_home = tmp_path / "claims"
+    destination_home = tmp_path / "destination"
+    source = _rollout(
+        claim_home,
+        "rollout-live-concurrent-freeze.jsonl",
+        working_dir,
+    )
+    claim = codex_home_mod._claim_rollout(source)
+    assert claim is not None
+    destination = _rollout(
+        destination_home,
+        "rollout-live-concurrent-freeze.jsonl",
+        working_dir,
+    )
+    logs: list[str] = []
+    live_retirement_fd = os.open(claim, os.O_RDONLY)
+    try:
+        os.fchmod(live_retirement_fd, 0)
+
+        retired = codex_home_mod._retire_rollout_claim(
+            claim,
+            destination,
+            os.path.realpath(working_dir),
+            log=logs.append,
+        )
+
+        assert retired is False
+        assert stat.S_IMODE(claim.stat().st_mode) == 0
+        assert any(
+            "another retirement still holds the frozen claim" in message
+            for message in logs
+        )
+    finally:
+        os.fchmod(live_retirement_fd, 0o600)
+        os.close(live_retirement_fd)
+
+
+def test_crashed_mode_freeze_repairs_without_an_open_holder(tmp_path):
+    """R7 R3: an owner can thaw a crashed mode-000 claim by pathname."""
+    working_dir = tmp_path / "agent"
+    working_dir.mkdir()
+    claim_home = tmp_path / "claims"
+    source = _rollout(
+        claim_home,
+        "rollout-crashed-freeze.jsonl",
+        working_dir,
+    )
+    claim = codex_home_mod._claim_rollout(source)
+    assert claim is not None
+    claim.chmod(0)
+    logs: list[str] = []
+
+    repaired = codex_home_mod._repair_frozen_rollout_claim(claim, logs.append)
+
+    assert repaired is True
+    assert stat.S_IMODE(claim.stat().st_mode) == 0o600
+    assert any("repaired crashed mode-000 rollout claim" in message for message in logs)
+
+
+def test_install_open_eacces_race_is_a_loud_retryable_retain(tmp_path, monkeypatch):
+    """R7 R5: a claim reader racing the freeze does not fail the migration."""
+    working_dir = tmp_path / "agent"
+    working_dir.mkdir()
+    claim_home = tmp_path / "claims"
+    destination_home = tmp_path / "destination"
+    source = _rollout(
+        claim_home,
+        "rollout-install-eacces-race.jsonl",
+        working_dir,
+    )
+    claim = codex_home_mod._claim_rollout(source)
+    assert claim is not None
+    destination = _rollout(
+        destination_home,
+        "rollout-install-eacces-race.jsonl",
+        working_dir,
+    )
+    claim.chmod(0)
+    logs: list[str] = []
+    monkeypatch.setattr(
+        codex_home_mod,
+        "_repair_frozen_rollout_claim",
+        lambda _claim, _log: True,
+    )
+
+    installed = codex_home_mod._install_rollout(
+        claim,
+        destination,
+        os.path.realpath(working_dir),
+        log=logs.append,
+    )
+
+    assert installed is False
+    assert destination.exists()
+    assert stat.S_IMODE(claim.stat().st_mode) == 0
+    assert any(
+        "claim pathname access was denied during a concurrent freeze" in message
+        for message in logs
+    )
+    claim.chmod(0o600)
+
+
+@pytest.mark.parametrize(
+    "seam",
+    ["after_freeze", "after_scan", "mid_publication", "before_unlink"],
+)
+def test_hard_exit_freeze_seams_keep_discoverable_complete_bytes(
+    tmp_path, monkeypatch, seam
+):
+    """R7 R2b/R3: every hard-exit seam leaves a complete discoverable claim."""
+    working_dir = tmp_path / "agent"
+    working_dir.mkdir()
+    claim_home = tmp_path / "claims"
+    destination_home = tmp_path / "destination"
+    source = _rollout(
+        claim_home,
+        f"rollout-hard-exit-{seam}.jsonl",
+        working_dir,
+    )
+    original = source.read_bytes()
+    claim = codex_home_mod._claim_rollout(source)
+    assert claim is not None
+    appended = b'{"type":"event_msg","payload":{"message":"latest"}}\n'
+    current = original + appended
+    claim.write_bytes(current)
+    destination = _rollout(
+        destination_home,
+        f"rollout-hard-exit-{seam}.jsonl",
+        working_dir,
+    )
+    hard_exit_code = 73
+    monkeypatch.setattr(
+        codex_home_mod,
+        "_claim_has_open_descriptors",
+        lambda _claim, _log: False,
+    )
+    monkeypatch.setattr(
+        codex_home_mod,
+        "_inode_has_open_descriptors",
+        lambda _handle, _claim, _log: False,
+    )
+
+    child_pid = os.fork()
+    if child_pid == 0:
+        if seam == "after_freeze":
+            codex_home_mod._inode_has_open_descriptors = (
+                lambda *_args, **_kwargs: os._exit(hard_exit_code)
+            )
+        elif seam == "after_scan":
+            codex_home_mod._file_signature_from_handle = (
+                lambda *_args, **_kwargs: os._exit(hard_exit_code)
+            )
+        elif seam == "mid_publication":
+            real_link = codex_home_mod.os.link
+
+            def exit_during_publication(source_path, destination_path, *args, **kwargs):
+                if Path(source_path).name.startswith(
+                    f"{codex_home_mod._MIGRATION_TEMP_PREFIX}recovery-"
+                ):
+                    os._exit(hard_exit_code)
+                return real_link(source_path, destination_path, *args, **kwargs)
+
+            codex_home_mod.os.link = exit_during_publication
+        else:
+            real_unlink = Path.unlink
+
+            def exit_before_claim_unlink(path, *args, **kwargs):
+                if path == claim:
+                    os._exit(hard_exit_code)
+                return real_unlink(path, *args, **kwargs)
+
+            Path.unlink = exit_before_claim_unlink
+
+        codex_home_mod._retire_rollout_claim(
+            claim,
+            destination,
+            os.path.realpath(working_dir),
+            log=lambda _message: None,
+        )
+        os._exit(74)
+
+    waited_pid, wait_status = os.waitpid(child_pid, 0)
+    assert waited_pid == child_pid
+    assert os.WIFEXITED(wait_status)
+    assert os.WEXITSTATUS(wait_status) == hard_exit_code
+
+    surviving_claims = list(
+        claim.parent.glob(f"{codex_home_mod._MIGRATION_CLAIM_PREFIX}*")
+    )
+    assert surviving_claims
+    repair_logs: list[str] = []
+    for surviving_claim in surviving_claims:
+        assert codex_home_mod._repair_frozen_rollout_claim(
+            surviving_claim,
+            repair_logs.append,
+        )
+    assert any(path.read_bytes() == current for path in surviving_claims)
+
+    moved = move_matching_rollouts(
+        claim_home,
+        destination_home,
+        working_dir,
+        log=repair_logs.append,
+    )
+
+    assert moved >= 1
+    assert destination.read_bytes() == current
+    assert not list(
+        claim.parent.glob(f"{codex_home_mod._MIGRATION_CLAIM_PREFIX}*")
+    )
+    assert not list(
+        claim.parent.glob(
+            f"{codex_home_mod._MIGRATION_TEMP_PREFIX}recovery-*"
+            f"{codex_home_mod._MIGRATION_TEMP_SUFFIX}"
+        )
+    )
+    assert not list(claim.parent.glob("*.reserve"))
 
 
 def test_descriptor_scan_unavailable_keeps_claim(tmp_path, monkeypatch):
@@ -659,7 +1034,7 @@ def test_claim_link_collision_retries_without_replacing_interleaved_claim(
 
 
 def test_stale_empty_reservations_are_swept_data_safely(tmp_path, monkeypatch):
-    """R4 debt: marker fast paths sweep only stale empty private sidecars."""
+    """R7: marker fast paths sweep unlocked crash or stale empty sidecars."""
     source_home = tmp_path / "source"
     destination_home = tmp_path / "destination"
     working_dir = tmp_path / "agent"
@@ -699,9 +1074,32 @@ def test_stale_empty_reservations_are_swept_data_safely(tmp_path, monkeypatch):
 
     assert prepared == destination_home
     assert not stale.exists()
-    assert recent.exists()
+    assert not recent.exists()
     assert nonempty.read_text(encoding="utf-8") == "operator bytes"
     assert any("removed stale migration reservation" in message for message in logs)
+    assert any("removed orphaned migration reservation" in message for message in logs)
+
+
+def test_active_reservation_lock_prevents_crash_sweeper_race(tmp_path):
+    """R7 R3: immediate orphan cleanup never removes a live publisher's name."""
+    destination = tmp_path / ".pinkybot-rollout-claim-live-rollout-test.jsonl"
+    reservation = destination.with_name(
+        f".{destination.name}{codex_home_mod._PRESERVATION_RESERVATION_SUFFIX}"
+    )
+    logs: list[str] = []
+
+    with codex_home_mod._reserve_exclusive_destination(
+        lambda _reservation_id: destination
+    ) as reserved:
+        assert reserved == destination
+        assert reservation.exists()
+
+        codex_home_mod._sweep_stale_reservations(tmp_path, logs.append)
+
+        assert reservation.exists()
+        assert not logs
+
+    assert not reservation.exists()
 
 
 @pytest.mark.parametrize("write_phase", ["during_copy", "post_install"])

--- a/tests/test_codex_home.py
+++ b/tests/test_codex_home.py
@@ -491,6 +491,98 @@ def test_zero_holder_identical_claim_retires(tmp_path, monkeypatch):
     assert not claim.exists()
 
 
+def test_claim_retirement_timing_window_keeps_appended_bytes_recoverable(
+    tmp_path, monkeypatch
+):
+    """R6 boundary-condition check: pathname-appended bytes stay recoverable."""
+    working_dir = tmp_path / "agent"
+    working_dir.mkdir()
+    claim_home = tmp_path / "claims"
+    destination_home = tmp_path / "destination"
+    source = _rollout(
+        claim_home,
+        "rollout-retirement-timing-window.jsonl",
+        working_dir,
+    )
+    original = source.read_bytes()
+    claim = codex_home_mod._claim_rollout(source)
+    assert claim is not None
+    destination = _rollout(
+        destination_home,
+        "rollout-retirement-timing-window.jsonl",
+        working_dir,
+    )
+    appended = b'{"type":"event_msg","payload":{"message":"timing window"}}\n'
+    real_rollout_is_valid = codex_home_mod._rollout_is_valid
+    late_writer = None
+    injected = False
+    logs: list[str] = []
+
+    monkeypatch.setattr(
+        codex_home_mod,
+        "_claim_has_open_descriptors",
+        lambda _claim, _log: False,
+    )
+
+    def append_during_destination_verification(
+        path: Path,
+        target_cwd: str,
+        *,
+        expected_signature=None,
+    ) -> bool:
+        nonlocal injected, late_writer
+        valid = real_rollout_is_valid(
+            path,
+            target_cwd,
+            expected_signature=expected_signature,
+        )
+        if path == destination and expected_signature is not None and not injected:
+            late_writer = claim.open("ab", buffering=0)
+            late_writer.write(appended)
+            os.fsync(late_writer.fileno())
+            injected = True
+        return valid
+
+    monkeypatch.setattr(
+        codex_home_mod,
+        "_rollout_is_valid",
+        append_during_destination_verification,
+    )
+    try:
+        retired = codex_home_mod._retire_rollout_claim(
+            claim,
+            destination,
+            os.path.realpath(working_dir),
+            log=logs.append,
+        )
+
+        recovery_claims = list(
+            claim.parent.glob(f"{codex_home_mod._MIGRATION_CLAIM_PREFIX}*")
+        )
+        assert injected is True
+        assert retired is False
+        assert not claim.exists()
+        assert len(recovery_claims) == 1
+        assert recovery_claims[0].name != claim.name
+        assert recovery_claims[0].read_bytes() == original + appended
+        assert destination.read_bytes() == original
+        assert any(
+            "retirement boundary-condition check" in message
+            and "recovery claim" in message
+            for message in logs
+        )
+        assert not list(
+            claim.parent.glob(
+                f"{codex_home_mod._MIGRATION_TEMP_PREFIX}recovery-*"
+                f"{codex_home_mod._MIGRATION_TEMP_SUFFIX}"
+            )
+        )
+        assert not list(claim.parent.glob("*.reserve"))
+    finally:
+        if late_writer is not None:
+            late_writer.close()
+
+
 def test_descriptor_scan_unavailable_keeps_claim(tmp_path, monkeypatch):
     """R4 P1-1: lsof absence fails toward claim retention, never deletion."""
     working_dir = tmp_path / "agent"

--- a/tests/test_codex_home.py
+++ b/tests/test_codex_home.py
@@ -735,6 +735,88 @@ def test_frozen_inode_half_parse_is_loud_uncertainty(
     )
 
 
+def test_lsof_resolver_finds_macos_binary_outside_daemon_path(monkeypatch):
+    """R8: the production daemon PATH still reaches macOS' system lsof."""
+    daemon_path = "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
+    lookups: list[tuple[str, str]] = []
+
+    def resolve(command: str) -> str | None:
+        lookups.append((command, os.environ["PATH"]))
+        if command == "lsof":
+            return None
+        if command == "/usr/sbin/lsof":
+            return command
+        raise AssertionError(f"unexpected lsof candidate: {command}")
+
+    monkeypatch.setenv("PATH", daemon_path)
+    monkeypatch.setattr(codex_home_mod.shutil, "which", resolve)
+    codex_home_mod._resolve_lsof_binary.cache_clear()
+    try:
+        assert codex_home_mod._resolve_lsof_binary() == "/usr/sbin/lsof"
+        assert codex_home_mod._resolve_lsof_binary() == "/usr/sbin/lsof"
+    finally:
+        codex_home_mod._resolve_lsof_binary.cache_clear()
+
+    assert lookups == [
+        ("lsof", daemon_path),
+        ("/usr/sbin/lsof", daemon_path),
+    ]
+
+
+def test_both_descriptor_scans_invoke_resolved_lsof_binary(tmp_path, monkeypatch):
+    """R8: neither descriptor scan falls back to subprocess PATH lookup."""
+    claim = tmp_path / "claim"
+    claim.write_bytes(b"bytes")
+    resolved_lsof = "/resolved/system/lsof"
+    commands: list[list[str]] = []
+    monkeypatch.setattr(
+        codex_home_mod,
+        "_resolve_lsof_binary",
+        lambda: resolved_lsof,
+    )
+
+    with claim.open("rb", buffering=0) as claim_handle:
+        claim_stat = os.fstat(claim_handle.fileno())
+        inode_output = "\n".join(
+            [
+                f"p{os.getpid()}",
+                f"f{claim_handle.fileno()}r",
+                f"D{claim_stat.st_dev}",
+                f"i{claim_stat.st_ino}",
+                "",
+            ]
+        )
+
+        def scan(command, **_kwargs):
+            commands.append(command)
+            if command[1:] == ["-Fn", "--", os.fspath(claim)]:
+                return SimpleNamespace(returncode=1, stdout="", stderr="")
+            if command[1:] == ["-F", "pfDi"]:
+                return SimpleNamespace(
+                    returncode=0,
+                    stdout=inode_output,
+                    stderr="",
+                )
+            raise AssertionError(f"unexpected lsof command: {command}")
+
+        monkeypatch.setattr(codex_home_mod.subprocess, "run", scan)
+
+        assert codex_home_mod._claim_has_open_descriptors(
+            claim,
+            log=lambda _message: None,
+        ) is False
+        assert codex_home_mod._inode_has_open_descriptors(
+            claim_handle,
+            claim,
+            log=lambda _message: None,
+        ) is False
+
+    assert commands == [
+        [resolved_lsof, "-Fn", "--", os.fspath(claim)],
+        [resolved_lsof, "-F", "pfDi"],
+    ]
+
+
 def test_live_mode_freeze_is_transiently_retained_without_thaw(tmp_path):
     """R7 R5: a concurrent retirer cannot repair another live freeze."""
     working_dir = tmp_path / "agent"
@@ -972,10 +1054,11 @@ def test_descriptor_scan_unavailable_keeps_claim(tmp_path, monkeypatch):
     )
     logs: list[str] = []
 
-    def unavailable(*_args, **_kwargs):
-        raise FileNotFoundError("lsof")
+    def unexpected_subprocess(*_args, **_kwargs):
+        raise AssertionError("subprocess must not run without a resolved lsof")
 
-    monkeypatch.setattr(codex_home_mod.subprocess, "run", unavailable)
+    monkeypatch.setattr(codex_home_mod, "_resolve_lsof_binary", lambda: None)
+    monkeypatch.setattr(codex_home_mod.subprocess, "run", unexpected_subprocess)
 
     retired = codex_home_mod._retire_rollout_claim(
         claim,
@@ -987,6 +1070,7 @@ def test_descriptor_scan_unavailable_keeps_claim(tmp_path, monkeypatch):
     assert retired is False
     assert claim.exists()
     assert any("descriptor scan unavailable" in message for message in logs)
+    assert any("lsof executable not found" in message for message in logs)
 
 
 def test_claim_link_collision_retries_without_replacing_interleaved_claim(

--- a/tests/test_codex_session.py
+++ b/tests/test_codex_session.py
@@ -1739,7 +1739,10 @@ class TestCodexStateMachine:
         assert s._app_proc is proc
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize("entry_point", ["force_restart", "attempt_reconnect"])
+    @pytest.mark.parametrize(
+        "entry_point",
+        ["force_restart", "attempt_reconnect", "restart_transport"],
+    )
     async def test_direct_replacement_preflight_preserves_cached_transport(
         self, tmp_path, monkeypatch, entry_point
     ):
@@ -1778,7 +1781,12 @@ class TestCodexStateMachine:
         s._app_client = client
         s._app_proc = proc
 
-        result = await getattr(s, entry_point)()
+        if entry_point == "restart_transport":
+            with pytest.raises(RuntimeError, match="shared auth file is absent"):
+                await s.restart_transport()
+            result = None
+        else:
+            result = await getattr(s, entry_point)()
 
         if entry_point == "force_restart":
             assert result is False

--- a/tests/test_codex_session.py
+++ b/tests/test_codex_session.py
@@ -1739,6 +1739,59 @@ class TestCodexStateMachine:
         assert s._app_proc is proc
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("entry_point", ["force_restart", "attempt_reconnect"])
+    async def test_direct_replacement_preflight_preserves_cached_transport(
+        self, tmp_path, monkeypatch, entry_point
+    ):
+        """R2 P1-3: every replacement entry preflights before teardown."""
+        shared_home = tmp_path / "shared"
+        working_dir = tmp_path / "agent"
+        shared_home.mkdir()
+        working_dir.mkdir()
+        monkeypatch.setenv("CODEX_HOME", str(shared_home))
+        monkeypatch.setenv("PINKY_CODEX_PER_AGENT_HOME", "1")
+        s = _appserver_session(working_dir=str(working_dir))
+        await _to_connected(s)
+
+        class _CachedClient:
+            def __init__(self):
+                self.closed = False
+
+            async def close(self):
+                self.closed = True
+
+        class _CachedProc:
+            returncode = None
+            pid = 123
+
+            def __init__(self):
+                self.killed = False
+
+            def kill(self):
+                self.killed = True
+
+            async def wait(self):
+                return -9
+
+        client = _CachedClient()
+        proc = _CachedProc()
+        s._app_client = client
+        s._app_proc = proc
+
+        result = await getattr(s, entry_point)()
+
+        if entry_point == "force_restart":
+            assert result is False
+        else:
+            assert result is None
+        assert s.state == SessionState.CONNECTED
+        assert s._app_client is client
+        assert s._app_proc is proc
+        assert client.closed is False
+        assert proc.killed is False
+        assert s.stats["reconnects"] == 0
+
+    @pytest.mark.asyncio
     async def test_warm_reconnect_exposes_reconnecting_then_connected(self):
         s = _appserver_session()
         await _to_dead(s)

--- a/tests/test_codex_session.py
+++ b/tests/test_codex_session.py
@@ -1697,6 +1697,48 @@ class TestCodexStateMachine:
         assert s._app_proc is not None
 
     @pytest.mark.asyncio
+    async def test_direct_auth_refusal_precedes_stale_transport_teardown(
+        self, tmp_path, monkeypatch
+    ):
+        """Review P2: replacement auth is proven before cached state mutates."""
+        shared_home = tmp_path / "shared"
+        working_dir = tmp_path / "agent"
+        shared_home.mkdir()
+        working_dir.mkdir()
+        monkeypatch.setenv("CODEX_HOME", str(shared_home))
+        monkeypatch.setenv("PINKY_CODEX_PER_AGENT_HOME", "1")
+        s = _appserver_session(working_dir=str(working_dir))
+
+        class _StaleClient:
+            def __init__(self):
+                self.closed = False
+
+            async def close(self):
+                self.closed = True
+
+        class _StaleProc:
+            returncode = 1
+            pid = 123
+
+            def kill(self):  # pragma: no cover - refusal must precede teardown
+                raise AssertionError("stale process was killed")
+
+            async def wait(self):  # pragma: no cover
+                raise AssertionError("stale process was waited")
+
+        client = _StaleClient()
+        proc = _StaleProc()
+        s._app_client = client
+        s._app_proc = proc
+
+        with pytest.raises(RuntimeError, match="shared auth file is absent or unreadable"):
+            await s._ensure_app_server()
+
+        assert client.closed is False
+        assert s._app_client is client
+        assert s._app_proc is proc
+
+    @pytest.mark.asyncio
     async def test_warm_reconnect_exposes_reconnecting_then_connected(self):
         s = _appserver_session()
         await _to_dead(s)

--- a/tests/test_codex_session_tmux_app_server.py
+++ b/tests/test_codex_session_tmux_app_server.py
@@ -14,6 +14,7 @@ from pinky_daemon.codex_app_server_tmux import CodexAppServerSupervisor
 from pinky_daemon.codex_home import PER_AGENT_CODEX_HOME_ENV
 from pinky_daemon.codex_session import CodexSession
 from pinky_daemon.streaming_session import StreamingSessionConfig
+from pinky_daemon.transport_state import SessionState, Trigger
 
 
 def _make_session(**overrides) -> CodexSession:
@@ -27,6 +28,17 @@ def _make_session(**overrides) -> CodexSession:
         **overrides,
     )
     return CodexSession(config)
+
+
+async def _to_connected(session: CodexSession) -> None:
+    boot = await session._state_machine.request_transition(
+        SessionState.BOOTING, Trigger.BOOT
+    )
+    await session._state_machine.transition_complete(
+        boot.owner_token,
+        SessionState.CONNECTED,
+        trigger=Trigger.BOOT_COMPLETE,
+    )
 
 
 def test_tmux_flag_off_by_default(monkeypatch):
@@ -144,6 +156,41 @@ async def test_tmux_auth_refusal_precedes_stale_transport_teardown(tmp_path, mon
     assert fake.client.closed is False
     assert s._app_client is fake.client
     assert s._app_proc is fake.proc
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("entry_point", ["force_restart", "attempt_reconnect"])
+async def test_tmux_replacement_preflight_preserves_cached_transport(
+    tmp_path, monkeypatch, entry_point
+):
+    """R2 P1-3: every replacement entry preflights before teardown/start."""
+    shared_home = tmp_path / "shared"
+    working_dir = tmp_path / "agent"
+    shared_home.mkdir()
+    working_dir.mkdir()
+    monkeypatch.setenv("CODEX_HOME", str(shared_home))
+    monkeypatch.setenv(PER_AGENT_CODEX_HOME_ENV, "1")
+    monkeypatch.setenv("PINKY_CODEX_APP_SERVER", "1")
+    monkeypatch.setenv("PINKY_CODEX_TMUX_APP_SERVER", "1")
+    s = _make_session(working_dir=str(working_dir))
+    await _to_connected(s)
+    fake = _FakeSupervisor()
+    s._app_supervisor = fake
+    s._app_client = fake.client
+    s._app_proc = fake.proc
+
+    result = await getattr(s, entry_point)()
+
+    if entry_point == "force_restart":
+        assert result is False
+    else:
+        assert result is None
+    assert s.state == SessionState.CONNECTED
+    assert fake.started == 0
+    assert fake.client.closed is False
+    assert s._app_client is fake.client
+    assert s._app_proc is fake.proc
+    assert s.stats["reconnects"] == 0
 
 
 def test_stats_mode_subprocess_when_tmux_off(monkeypatch):

--- a/tests/test_codex_session_tmux_app_server.py
+++ b/tests/test_codex_session_tmux_app_server.py
@@ -159,7 +159,10 @@ async def test_tmux_auth_refusal_precedes_stale_transport_teardown(tmp_path, mon
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("entry_point", ["force_restart", "attempt_reconnect"])
+@pytest.mark.parametrize(
+    "entry_point",
+    ["force_restart", "attempt_reconnect", "restart_transport"],
+)
 async def test_tmux_replacement_preflight_preserves_cached_transport(
     tmp_path, monkeypatch, entry_point
 ):
@@ -179,7 +182,12 @@ async def test_tmux_replacement_preflight_preserves_cached_transport(
     s._app_client = fake.client
     s._app_proc = fake.proc
 
-    result = await getattr(s, entry_point)()
+    if entry_point == "restart_transport":
+        with pytest.raises(RuntimeError, match="shared auth file is absent"):
+            await s.restart_transport()
+        result = None
+    else:
+        result = await getattr(s, entry_point)()
 
     if entry_point == "force_restart":
         assert result is False

--- a/tests/test_codex_session_tmux_app_server.py
+++ b/tests/test_codex_session_tmux_app_server.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import pytest
 
 from pinky_daemon.codex_app_server_tmux import CodexAppServerSupervisor
+from pinky_daemon.codex_home import PER_AGENT_CODEX_HOME_ENV
 from pinky_daemon.codex_session import CodexSession
 from pinky_daemon.streaming_session import StreamingSessionConfig
 
@@ -20,7 +21,7 @@ def _make_session(**overrides) -> CodexSession:
         agent_name="test-agent",
         label="main",
         model="",
-        working_dir="/tmp",
+        working_dir=overrides.pop("working_dir", "/tmp"),
         provider_url="codex_cli",
         provider_key="test-key",
         **overrides,
@@ -57,6 +58,7 @@ def test_tmux_flag_on_creates_supervisor(monkeypatch):
 class _FakeClient:
     def __init__(self) -> None:
         self.initialized = False
+        self.closed = False
 
     def start(self) -> None:  # pragma: no cover - not called on this path
         pass
@@ -66,7 +68,7 @@ class _FakeClient:
         return {"userAgent": "fake/1"}
 
     async def close(self) -> None:
-        pass
+        self.closed = True
 
 
 class _FakeProc:
@@ -115,6 +117,33 @@ async def test_ensure_app_server_uses_supervisor_in_tmux_mode(monkeypatch):
     assert stats["tmux_session"] == "pinky-codex-as-test-agent"
     assert stats["sock_path"] == fake.sock_path
     assert stats["child_pid"] == 4321
+
+
+@pytest.mark.asyncio
+async def test_tmux_auth_refusal_precedes_stale_transport_teardown(tmp_path, monkeypatch):
+    """Review P2: validate auth before stale close and supervisor.start."""
+    shared_home = tmp_path / "shared"
+    working_dir = tmp_path / "agent"
+    shared_home.mkdir()
+    working_dir.mkdir()
+    monkeypatch.setenv("CODEX_HOME", str(shared_home))
+    monkeypatch.setenv(PER_AGENT_CODEX_HOME_ENV, "1")
+    monkeypatch.setenv("PINKY_CODEX_APP_SERVER", "1")
+    monkeypatch.setenv("PINKY_CODEX_TMUX_APP_SERVER", "1")
+    s = _make_session(working_dir=str(working_dir))
+    fake = _FakeSupervisor()
+    fake.proc.returncode = 1
+    s._app_supervisor = fake
+    s._app_client = fake.client
+    s._app_proc = fake.proc
+
+    with pytest.raises(RuntimeError, match="shared auth file is absent or unreadable"):
+        await s._ensure_app_server()
+
+    assert fake.started == 0
+    assert fake.client.closed is False
+    assert s._app_client is fake.client
+    assert s._app_proc is fake.proc
 
 
 def test_stats_mode_subprocess_when_tmux_off(monkeypatch):

--- a/tests/test_codex_tmux_session.py
+++ b/tests/test_codex_tmux_session.py
@@ -35,7 +35,7 @@ from pinky_daemon.tmux_session import (
     _TmuxControl,
 )
 from pinky_daemon.tmux_transcript import TurnResponse
-from pinky_daemon.transport_state import SessionState
+from pinky_daemon.transport_state import SessionState, Trigger
 
 
 def _ok(stdout: str = "") -> TmuxCommandResult:
@@ -68,6 +68,52 @@ def _session(*, model="gpt-5.5", effort="medium", mcp=None, working_dir="/tmp/co
         mcp_servers=mcp or {},
     )
     return CodexTmuxSession(cfg, tmux_control=tmux or _mock_tmux())
+
+
+async def _to_connected(session: CodexTmuxSession) -> None:
+    boot = await session._state_machine.request_transition(
+        SessionState.BOOTING,
+        Trigger.BOOT,
+    )
+    await session._state_machine.transition_complete(
+        boot.owner_token,
+        SessionState.CONNECTED,
+        trigger=Trigger.BOOT_COMPLETE,
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("entry_point", ["force_restart", "attempt_reconnect"])
+async def test_inherited_replacement_preflight_refuses_before_tmux_teardown(
+    tmp_path, monkeypatch, entry_point
+):
+    """R4 P1-2: inherited recovery cannot own transition state before refusal."""
+    shared_home = tmp_path / "shared"
+    working_dir = tmp_path / "agent"
+    shared_home.mkdir()
+    working_dir.mkdir()
+    monkeypatch.setenv("CODEX_HOME", str(shared_home))
+    monkeypatch.setenv(PER_AGENT_CODEX_HOME_ENV, "1")
+    tmux = _mock_tmux()
+    session = _session(working_dir=str(working_dir), tmux=tmux)
+    await _to_connected(session)
+    cached_tailer = object()
+    session._tailer = cached_tailer
+    session._processing = True
+
+    with pytest.raises(RuntimeError, match="shared auth file is absent"):
+        if entry_point == "force_restart":
+            await session.force_restart(bypass_guard=True)
+        else:
+            await session.attempt_reconnect(trigger=Trigger.WATCHDOG)
+
+    assert session.state == SessionState.CONNECTED
+    assert session.state != SessionState.DEAD
+    assert session._tailer is cached_tailer
+    assert session._processing is True
+    assert session.stats["reconnects"] == 0
+    tmux.kill_session.assert_not_awaited()
+    tmux.new_session.assert_not_awaited()
 
 
 # ── session name ────────────────────────────────────────────────────────────

--- a/tests/test_codex_tmux_session.py
+++ b/tests/test_codex_tmux_session.py
@@ -309,6 +309,28 @@ def test_flag_on_trust_seed_preserves_unmanaged_agent_config(
     assert not (shared_home / "config.toml").exists()
 
 
+@pytest.mark.asyncio
+async def test_restart_transport_preflight_refusal_preserves_tmux_transport(
+    monkeypatch, tmp_path
+):
+    """R3 P1-2: the common API chokepoint protects Codex tmux too."""
+    shared_home = tmp_path / "shared"
+    working_dir = tmp_path / "agent"
+    shared_home.mkdir()
+    working_dir.mkdir()
+    monkeypatch.setenv("CODEX_HOME", str(shared_home))
+    monkeypatch.setenv(PER_AGENT_CODEX_HOME_ENV, "1")
+    ss = _session(working_dir=str(working_dir))
+    ss.disconnect = AsyncMock()
+    ss.connect = AsyncMock()
+
+    with pytest.raises(RuntimeError, match="shared auth file is absent"):
+        await ss.restart_transport()
+
+    ss.disconnect.assert_not_awaited()
+    ss.connect.assert_not_awaited()
+
+
 # ── tailer class ────────────────────────────────────────────────────────────
 @pytest.mark.asyncio
 async def test_start_tailer_uses_codex_tailer(monkeypatch):

--- a/tests/test_codex_tmux_session.py
+++ b/tests/test_codex_tmux_session.py
@@ -12,12 +12,14 @@ bottom (opt-in, like the app-server soak) — it's the make-or-break proof and w
 validated live 2026-06-17.
 """
 import asyncio
+import json
 import os
 import time
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from pinky_daemon.codex_home import PER_AGENT_CODEX_HOME_ENV
 from pinky_daemon.codex_tmux_session import (
     _CODEX_ENTER_DELAY_MS,
     CodexTmuxSession,
@@ -55,13 +57,14 @@ def _mock_tmux() -> MagicMock:
 
 
 def _session(*, model="gpt-5.5", effort="medium", mcp=None, working_dir="/tmp/codex-tmux-test",
-             provider_key="sk-test", tmux=None) -> CodexTmuxSession:
+             provider_key="sk-test", codex_home="", tmux=None) -> CodexTmuxSession:
     cfg = StreamingSessionConfig(
         agent_name="murzik",
         working_dir=working_dir,
         model=model,
         thinking_effort=effort,
         provider_key=provider_key,
+        codex_home=codex_home,
         mcp_servers=mcp or {},
     )
     return CodexTmuxSession(cfg, tmux_control=tmux or _mock_tmux())
@@ -173,6 +176,17 @@ def test_build_repl_env_falls_back_to_openai_env(monkeypatch):
     assert ss._build_repl_env()["OPENAI_API_KEY"] == "sk-env"
 
 
+def test_build_repl_env_overlays_agent_home_when_enabled(monkeypatch, tmp_path):
+    shared_home = tmp_path / "shared"
+    working_dir = tmp_path / "agent"
+    monkeypatch.setenv("CODEX_HOME", str(shared_home))
+    monkeypatch.setenv(PER_AGENT_CODEX_HOME_ENV, "1")
+
+    env = _session(working_dir=str(working_dir))._build_repl_env()
+
+    assert env["CODEX_HOME"] == str(working_dir / ".codex")
+
+
 # ── transcript discovery ────────────────────────────────────────────────────
 def test_project_dir_is_codex_sessions(monkeypatch, tmp_path):
     monkeypatch.setenv("CODEX_HOME", str(tmp_path / "ch"))
@@ -180,13 +194,56 @@ def test_project_dir_is_codex_sessions(monkeypatch, tmp_path):
     assert ss._project_dir() == (tmp_path / "ch" / "sessions")
 
 
+def test_project_dir_uses_agent_home_when_enabled(monkeypatch, tmp_path):
+    working_dir = tmp_path / "agent"
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path / "shared"))
+    monkeypatch.setenv(PER_AGENT_CODEX_HOME_ENV, "1")
+    ss = _session(working_dir=str(working_dir))
+
+    assert ss._project_dir() == working_dir / ".codex" / "sessions"
+
+
+def test_resume_gate_reads_agent_home_only(monkeypatch, tmp_path):
+    working_dir = tmp_path / "agent"
+    working_dir.mkdir()
+    shared_home = tmp_path / "shared"
+    agent_home = working_dir / ".codex"
+
+    def write_rollout(home, name):
+        path = home / "sessions" / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps(
+                {
+                    "type": "session_meta",
+                    "payload": {"id": name, "cwd": str(working_dir)},
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        return path
+
+    shared_rollout = write_rollout(shared_home, "rollout-shared.jsonl")
+    agent_rollout = write_rollout(agent_home, "rollout-agent.jsonl")
+    monkeypatch.setenv("CODEX_HOME", str(shared_home))
+    monkeypatch.setenv(PER_AGENT_CODEX_HOME_ENV, "1")
+    ss = _session(working_dir=str(working_dir))
+
+    assert "resume --last" in ss._build_claude_cmd()
+    agent_rollout.unlink()
+    assert shared_rollout.exists()
+    assert "resume --last" not in ss._build_claude_cmd()
+
+
 def test_discovery_delegates_to_codex_rollout(monkeypatch):
     import pinky_daemon.codex_tmux_session as cm
     sentinel = object()
     seen = {}
 
-    def fake(wd):
+    def fake(wd, *, agent=None):
         seen["wd"] = wd
+        seen["agent"] = agent
         return sentinel
 
     monkeypatch.setattr(cm, "_discover_codex_rollout", fake)
@@ -194,6 +251,7 @@ def test_discovery_delegates_to_codex_rollout(monkeypatch):
     assert ss._discover_transcript_path() is sentinel
     assert ss._has_prior_transcript() is True
     assert seen["wd"] == "/tmp/abc"
+    assert seen["agent"] is ss._config
 
 
 # ── codex trust pre-seed ────────────────────────────────────────────────────
@@ -211,11 +269,55 @@ def test_seed_codex_trust_writes_and_idempotent(monkeypatch, tmp_path):
     assert (ch / "config.toml").read_text().count(f'[projects."{real}"]') == 1
 
 
+def test_flag_off_trust_seed_preserves_legacy_path_and_bytes(monkeypatch, tmp_path):
+    shared_home = tmp_path / "shared"
+    shared_home.mkdir()
+    config = shared_home / "config.toml"
+    original = "[features]\napps = true\n"
+    config.write_text(original, encoding="utf-8")
+    working_dir = tmp_path / "agent"
+    monkeypatch.setenv("CODEX_HOME", str(shared_home))
+    monkeypatch.delenv(PER_AGENT_CODEX_HOME_ENV, raising=False)
+    ss = _session(working_dir=str(working_dir))
+
+    ss._seed_codex_trust(str(working_dir))
+
+    real = os.path.realpath(working_dir)
+    assert config.read_text(encoding="utf-8") == (
+        original + f'\n[projects."{real}"]\ntrust_level = "trusted"\n'
+    )
+    assert not (working_dir / ".codex").exists()
+
+
+def test_flag_on_trust_seed_preserves_unmanaged_agent_config(
+    monkeypatch, tmp_path
+):
+    shared_home = tmp_path / "shared"
+    working_dir = tmp_path / "agent"
+    agent_home = working_dir / ".codex"
+    agent_home.mkdir(parents=True)
+    config = agent_home / "config.toml"
+    manual = "# manual\n[features]\nplugins = true\n"
+    config.write_text(manual, encoding="utf-8")
+    monkeypatch.setenv("CODEX_HOME", str(shared_home))
+    monkeypatch.setenv(PER_AGENT_CODEX_HOME_ENV, "1")
+    ss = _session(working_dir=str(working_dir))
+
+    ss._seed_codex_trust(str(working_dir))
+
+    assert config.read_text(encoding="utf-8") == manual
+    assert not (shared_home / "config.toml").exists()
+
+
 # ── tailer class ────────────────────────────────────────────────────────────
 @pytest.mark.asyncio
 async def test_start_tailer_uses_codex_tailer(monkeypatch):
     import pinky_daemon.codex_tmux_session as cm
-    monkeypatch.setattr(cm, "_discover_codex_rollout", lambda wd: None)  # cold start
+    monkeypatch.setattr(
+        cm,
+        "_discover_codex_rollout",
+        lambda wd, *, agent=None: None,
+    )  # cold start
     ss = _session()
     await ss._start_tailer()
     try:

--- a/tests/test_codex_tmux_transcript.py
+++ b/tests/test_codex_tmux_transcript.py
@@ -1000,7 +1000,7 @@ class TestDiscoverCodexRollout:
     def test_returns_none_when_no_sessions_root(self, tmp_path, monkeypatch):
         """No ~/.codex/sessions → returns None, no crash."""
         monkeypatch.setattr(
-            "pinky_daemon.codex_tmux_transcript.Path.home",
+            "pinky_daemon.codex_home.Path.home",
             lambda: tmp_path,
         )
         result = _discover_codex_rollout("/some/cwd")
@@ -1019,7 +1019,7 @@ class TestDiscoverCodexRollout:
         match = self._fake_rollout(sessions, "rollout-new.jsonl", target_cwd, mtime_offset=0)
 
         monkeypatch.setattr(
-            "pinky_daemon.codex_tmux_transcript.Path.home",
+            "pinky_daemon.codex_home.Path.home",
             lambda: tmp_path,
         )
         result = _discover_codex_rollout(target_cwd)
@@ -1037,7 +1037,7 @@ class TestDiscoverCodexRollout:
         newer = self._fake_rollout(sessions, "rollout-newer.jsonl", target_cwd, mtime_offset=-5)
 
         monkeypatch.setattr(
-            "pinky_daemon.codex_tmux_transcript.Path.home",
+            "pinky_daemon.codex_home.Path.home",
             lambda: tmp_path,
         )
         result = _discover_codex_rollout(target_cwd)
@@ -1050,7 +1050,7 @@ class TestDiscoverCodexRollout:
         self._fake_rollout(sessions, "rollout-other.jsonl", "/some/other/cwd")
 
         monkeypatch.setattr(
-            "pinky_daemon.codex_tmux_transcript.Path.home",
+            "pinky_daemon.codex_home.Path.home",
             lambda: tmp_path,
         )
         result = _discover_codex_rollout("/requested/cwd")
@@ -1072,7 +1072,7 @@ class TestDiscoverCodexRollout:
         good = self._fake_rollout(sessions, "rollout-good.jsonl", target_cwd, mtime_offset=0)
 
         monkeypatch.setattr(
-            "pinky_daemon.codex_tmux_transcript.Path.home",
+            "pinky_daemon.codex_home.Path.home",
             lambda: tmp_path,
         )
         result = _discover_codex_rollout(target_cwd)
@@ -1092,7 +1092,7 @@ class TestDiscoverCodexRollout:
         empty_home = tmp_path / "wrong-home"
         empty_home.mkdir()
         monkeypatch.setattr(
-            "pinky_daemon.codex_tmux_transcript.Path.home",
+            "pinky_daemon.codex_home.Path.home",
             lambda: empty_home,
         )
         result = _discover_codex_rollout(target_cwd)

--- a/tests/test_test_env_guard.py
+++ b/tests/test_test_env_guard.py
@@ -30,6 +30,7 @@ class _TransportItem:
 
 
 def test_runtime_env_is_deterministic():
+    assert os.environ["CODEX_HOME"] == suite_conftest.TEST_CODEX_HOME
     assert os.environ["PINKY_DREAM_TRANSPORT"] == "sdk"
     assert os.environ["PINKY_AUTH_DENY_DEFAULT"] == "shadow"
     assert "PINKY_CONTAINER_RUNTIME" not in os.environ

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -19,7 +19,7 @@ import inspect
 
 import pytest
 
-from pinky_daemon.transport import Transport
+from pinky_daemon.transport import Transport, TransportReplacementMixin
 from pinky_daemon.transport_state import SessionState
 
 
@@ -49,6 +49,7 @@ class _StubTransport:
 
     async def connect(self) -> None: ...
     async def disconnect(self) -> None: ...
+    async def restart_transport(self, **kwargs) -> None: ...
 
     async def send(
         self,
@@ -125,6 +126,50 @@ class TestRuntimeCheckable:
         assert not isinstance(_MissingState(), Transport)
 
 
+class TestTransportReplacementMixin:
+    class _ReplacementTransport(TransportReplacementMixin):
+        def __init__(self, *, refuse: bool = False):
+            self.refuse = refuse
+            self.events: list[str] = []
+
+        def _preflight_transport_replacement(self) -> None:
+            self.events.append("preflight")
+            if self.refuse:
+                raise RuntimeError("replacement refused")
+
+        async def disconnect(self) -> None:
+            self.events.append("disconnect")
+
+        async def connect(self) -> None:
+            self.events.append("connect")
+
+    @pytest.mark.asyncio
+    async def test_preflight_configure_teardown_bring_up_order(self):
+        transport = self._ReplacementTransport()
+
+        await transport.restart_transport(
+            configure=lambda: transport.events.append("configure")
+        )
+
+        assert transport.events == [
+            "preflight",
+            "configure",
+            "disconnect",
+            "connect",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_preflight_refusal_preserves_live_transport_and_config(self):
+        transport = self._ReplacementTransport(refuse=True)
+
+        with pytest.raises(RuntimeError, match="replacement refused"):
+            await transport.restart_transport(
+                configure=lambda: transport.events.append("configure")
+            )
+
+        assert transport.events == ["preflight"]
+
+
 class TestSurfaceShape:
     """Lock in the public surface so silent name drift fails a test.
 
@@ -145,6 +190,7 @@ class TestSurfaceShape:
     REQUIRED_ASYNC_METHODS = {
         "connect",
         "disconnect",
+        "restart_transport",
         "send",
         "force_restart",
         "idle_sleep",


### PR DESCRIPTION
## Summary

- add a default-off `PINKY_CODEX_PER_AGENT_HOME` guard that resolves one Codex home for every reader and launch transport
- generate a minimal managed config with apps and plugins disabled, preserve unmanaged configs, and fail before spawn when shared auth is absent or forked
- link per-agent auth to the shared credential source, migrate cwd-matched rollouts on cutover, and include a rollback tool
- pin the test suite to a temporary `CODEX_HOME` so tests cannot read the real user-level store

## Root cause and impact

Shared user-level Codex config leaks host-scoped settings into fleet agent sessions. A process environment overlay alone is insufficient because transcript discovery, resume gating, trust seeding, and the rollout endpoint also resolve the Codex home. The helper keeps those paths uniform. With the feature flag unset, paths, environment overlays, and trust-seeder writes retain their previous behavior.

## Auth rewrite probe

The auth strategy was selected empirically with Codex CLI 0.144.0. A 0600 scratch credential copy was linked as `auth.json`; only the scratch access-token expiry was forced, and no credential values were printed.

```text
BEFORE symlink=yes source_inode=53251487 followed_inode=53251487
AUTH_REFRESH_PROBE_OK
AFTER rc=0 symlink=yes source_inode=53251487 followed_inode=53251487
ACCESS_TOKEN_REFRESHED=yes
REFRESH_TOKEN_ROTATED=yes
PATHS_CONVERGE=yes
SOURCE_INODE_STABLE=yes
```

The stable target inode and surviving symlink show an in-place rewrite, so per-agent homes use symlinks rather than copy synchronization.

## Config probes

```text
BARE_CONFIG present=no model=gpt-5.6-sol
BARE_MODEL_OK
BARE_MODEL_RESULT rc=0

GENERATED_CONFIG_PARSE rc=0
apps     stable     false
plugins  stable     false
```

The bare-model probe showed no model-alias table is required.

## Validation

- clean-process full suite: `4969 passed, 4 skipped`
- expanded API, registry, and Codex surfaces: `761 passed, 1 skipped`
- hostile ambient `CODEX_HOME` and runtime flags: `119 passed, 1 skipped`
- generated config parsed by Codex CLI 0.144.0 with apps/plugins disabled
- `uv run ruff check .`
- `git diff --check`