### PR TITLE
Harden and scope Codex app-server transport

### DIFF
--- a/src/pinky_daemon/codex_app_server.py
+++ b/src/pinky_daemon/codex_app_server.py
@@ -48,8 +48,6 @@ _STREAM_LIMIT = 10 * 1024 * 1024
 NotificationHandler = Callable[[str, dict], Awaitable[None]]
 # async fn(method: str, params: dict) -> dict (the result payload)
 ServerRequestHandler = Callable[[str, dict], Awaitable[dict | None]]
-
-
 class CodexAppServerError(Exception):
     """A JSON-RPC error frame, or a transport failure (EOF / closed)."""
 
@@ -67,6 +65,11 @@ class CodexAppServerError(Exception):
                 data=err.get("data"),
             )
         return cls(str(err))
+
+
+# Synchronous by design: EOF must be able to wake a higher-layer turn future
+# without making the transport read loop await teardown (or itself).
+TransportClosedHandler = Callable[[CodexAppServerError], None]
 
 
 class CodexAppServerClient:
@@ -93,6 +96,7 @@ class CodexAppServerClient:
         self._stderr = stderr
         self._notification_handler = notification_handler
         self._server_request_handler = server_request_handler
+        self._transport_closed_handler: TransportClosedHandler | None = None
         self._log = log
         self._next_id = 0
         self._pending: dict[int, asyncio.Future] = {}
@@ -108,6 +112,17 @@ class CodexAppServerClient:
         # blocks the child once the OS buffer (~64KiB) fills, wedging every turn.
         if self._stderr is not None and self._stderr_task is None:
             self._stderr_task = asyncio.create_task(self._drain_stderr())
+
+    def set_transport_closed_handler(
+        self, handler: TransportClosedHandler | None
+    ) -> None:
+        """Register a synchronous callback for unexpected read-side closure.
+
+        Deliberate :meth:`close` does not invoke it. Higher layers use this
+        edge to fail work that was accepted after its request future resolved;
+        at that point ``_pending`` alone no longer represents active work.
+        """
+        self._transport_closed_handler = handler
 
     async def request(
         self,
@@ -175,7 +190,13 @@ class CodexAppServerClient:
         except Exception as exc:  # noqa: BLE001 — read loop must not die silently
             self._log(f"codex-app-server: read loop error: {exc}")
         finally:
-            self._fail_pending(CodexAppServerError("connection closed"))
+            close_error = CodexAppServerError("connection closed")
+            self._fail_pending(close_error)
+            if not self._closed and self._transport_closed_handler is not None:
+                try:
+                    self._transport_closed_handler(close_error)
+                except Exception as exc:  # noqa: BLE001 — closure stays terminal
+                    self._log(f"codex-app-server: transport-close handler error: {exc}")
 
     async def _dispatch(self, msg: dict) -> None:
         mid = msg.get("id")

--- a/src/pinky_daemon/codex_app_server.py
+++ b/src/pinky_daemon/codex_app_server.py
@@ -103,9 +103,20 @@ class CodexAppServerClient:
         self._read_task: asyncio.Task | None = None
         self._stderr_task: asyncio.Task | None = None
         self._closed = False
+        self._close_reason: str | None = None
+
+    @property
+    def is_closed(self) -> bool:
+        """Whether either side deliberately closed or the read side died."""
+        return self._closed
+
+    def _raise_if_closed(self) -> None:
+        if self._closed:
+            raise CodexAppServerError(self._close_reason or "client is closed")
 
     def start(self) -> None:
         """Begin consuming the read stream. Idempotent."""
+        self._raise_if_closed()
         if self._read_task is None:
             self._read_task = asyncio.create_task(self._read_loop())
         # Drain stderr continuously: an undrained PIPE on a long-lived process
@@ -133,8 +144,7 @@ class CodexAppServerClient:
     ) -> object:
         """Send a request and await its result. Raises CodexAppServerError on
         an error frame, transport close, or timeout."""
-        if self._closed:
-            raise CodexAppServerError("client is closed")
+        self._raise_if_closed()
         self._next_id += 1
         rid = self._next_id
         fut: asyncio.Future = asyncio.get_running_loop().create_future()
@@ -165,8 +175,7 @@ class CodexAppServerClient:
         )
 
     async def _send(self, msg: dict) -> None:
-        if self._closed:
-            raise CodexAppServerError("client is closed")
+        self._raise_if_closed()
         self._writer.write((json.dumps(msg) + "\n").encode())
         await self._writer.drain()
 
@@ -190,9 +199,16 @@ class CodexAppServerClient:
         except Exception as exc:  # noqa: BLE001 — read loop must not die silently
             self._log(f"codex-app-server: read loop error: {exc}")
         finally:
+            unexpected_close = not self._closed
             close_error = CodexAppServerError("connection closed")
+            if unexpected_close:
+                # Latch read-side death before failing futures or notifying the
+                # session. A live child may retain stdin after closing stdout;
+                # no later request may be registered against that dead reader.
+                self._closed = True
+                self._close_reason = str(close_error)
             self._fail_pending(close_error)
-            if not self._closed and self._transport_closed_handler is not None:
+            if unexpected_close and self._transport_closed_handler is not None:
                 try:
                     self._transport_closed_handler(close_error)
                 except Exception as exc:  # noqa: BLE001 — closure stays terminal
@@ -257,6 +273,8 @@ class CodexAppServerClient:
     async def close(self) -> None:
         """Stop reading and close the write side. Idempotent."""
         self._closed = True
+        if self._close_reason is None:
+            self._close_reason = "client is closed"
         if self._read_task is not None:
             self._read_task.cancel()
             try:

--- a/src/pinky_daemon/codex_app_server.py
+++ b/src/pinky_daemon/codex_app_server.py
@@ -104,6 +104,7 @@ class CodexAppServerClient:
         self._stderr_task: asyncio.Task | None = None
         self._closed = False
         self._close_reason: str | None = None
+        self._closed_event = asyncio.Event()
 
     @property
     def is_closed(self) -> bool:
@@ -149,13 +150,37 @@ class CodexAppServerClient:
         rid = self._next_id
         fut: asyncio.Future = asyncio.get_running_loop().create_future()
         self._pending[rid] = fut
+        send_completed = False
         try:
-            await self._send({"id": rid, "method": method, "params": params or {}})
-            return await asyncio.wait_for(fut, timeout=timeout)
+            # The public timeout is an end-to-end request deadline. In
+            # particular, a backpressured writer.drain() cannot consume an
+            # unbounded pre-response phase before the Future wait starts.
+            async with asyncio.timeout(timeout):
+                await self._send({"id": rid, "method": method, "params": params or {}})
+                send_completed = True
+                return await fut
         except asyncio.TimeoutError as exc:
+            if self._closed:
+                raise CodexAppServerError(
+                    self._close_reason or "connection closed"
+                ) from exc
+            if not send_completed:
+                # A timed-out drain leaves delivery ambiguous at the byte
+                # boundary. Retire the transport so buffered frame remnants
+                # cannot wedge or corrupt a later request on this connection.
+                self._latch_transport_closed(CodexAppServerError("connection closed"))
+                try:
+                    self._writer.close()
+                except Exception:  # noqa: BLE001 — latch is already terminal
+                    pass
             raise CodexAppServerError(f"request {method!r} timed out after {timeout}s") from exc
         finally:
             self._pending.pop(rid, None)
+            # EOF can fail the response Future while request() is still inside
+            # _send. Consume that exception even though it was never awaited,
+            # avoiding a false "Future exception was never retrieved" report.
+            if fut.done() and not fut.cancelled():
+                fut.exception()
 
     async def notify(self, method: str, params: dict | None = None) -> None:
         """Send a notification (no id, no response expected)."""
@@ -176,8 +201,45 @@ class CodexAppServerClient:
 
     async def _send(self, msg: dict) -> None:
         self._raise_if_closed()
-        self._writer.write((json.dumps(msg) + "\n").encode())
-        await self._writer.drain()
+        payload = (json.dumps(msg) + "\n").encode()
+        drain_task: asyncio.Task | None = None
+        closed_task: asyncio.Task | None = None
+        try:
+            self._writer.write(payload)
+            # Cover EOF landing after the first latch check but at the write
+            # edge. If the read loop has already run, never enter drain.
+            self._raise_if_closed()
+            drain_task = asyncio.create_task(self._writer.drain())
+            closed_task = asyncio.create_task(self._closed_event.wait())
+            await asyncio.wait(
+                {drain_task, closed_task},
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            # The close edge wins ties: drain may surface BrokenPipeError at
+            # the same moment stdout EOF latches the connection terminal.
+            if self._closed_event.is_set():
+                if not drain_task.done():
+                    drain_task.cancel()
+                await asyncio.gather(drain_task, return_exceptions=True)
+                self._raise_if_closed()
+            await drain_task
+            self._raise_if_closed()
+        except asyncio.CancelledError:
+            raise
+        except CodexAppServerError:
+            raise
+        except Exception as exc:  # noqa: BLE001 — normalize write-side death
+            close_error = CodexAppServerError("connection closed")
+            self._latch_transport_closed(close_error)
+            raise close_error from exc
+        finally:
+            cleanup = []
+            for task in (drain_task, closed_task):
+                if task is not None and not task.done():
+                    task.cancel()
+                    cleanup.append(task)
+            if cleanup:
+                await asyncio.gather(*cleanup, return_exceptions=True)
 
     async def _read_loop(self) -> None:
         try:
@@ -199,20 +261,8 @@ class CodexAppServerClient:
         except Exception as exc:  # noqa: BLE001 — read loop must not die silently
             self._log(f"codex-app-server: read loop error: {exc}")
         finally:
-            unexpected_close = not self._closed
             close_error = CodexAppServerError("connection closed")
-            if unexpected_close:
-                # Latch read-side death before failing futures or notifying the
-                # session. A live child may retain stdin after closing stdout;
-                # no later request may be registered against that dead reader.
-                self._closed = True
-                self._close_reason = str(close_error)
-            self._fail_pending(close_error)
-            if unexpected_close and self._transport_closed_handler is not None:
-                try:
-                    self._transport_closed_handler(close_error)
-                except Exception as exc:  # noqa: BLE001 — closure stays terminal
-                    self._log(f"codex-app-server: transport-close handler error: {exc}")
+            self._latch_transport_closed(close_error)
 
     async def _dispatch(self, msg: dict) -> None:
         mid = msg.get("id")
@@ -270,11 +320,30 @@ class CodexAppServerClient:
                 fut.set_exception(exc)
         self._pending.clear()
 
+    def _latch_transport_closed(self, exc: CodexAppServerError) -> None:
+        """Publish one terminal transport edge to requests and the session."""
+        unexpected_close = not self._closed
+        if unexpected_close:
+            self._closed = True
+            self._close_reason = str(exc)
+        self._closed_event.set()
+        self._fail_pending(exc)
+        if unexpected_close and self._transport_closed_handler is not None:
+            try:
+                self._transport_closed_handler(exc)
+            except Exception as handler_exc:  # noqa: BLE001 — closure stays terminal
+                self._log(
+                    "codex-app-server: transport-close handler error: "
+                    f"{handler_exc}"
+                )
+
     async def close(self) -> None:
         """Stop reading and close the write side. Idempotent."""
         self._closed = True
         if self._close_reason is None:
             self._close_reason = "client is closed"
+        self._closed_event.set()
+        self._fail_pending(CodexAppServerError("client is closed"))
         if self._read_task is not None:
             self._read_task.cancel()
             try:
@@ -289,7 +358,6 @@ class CodexAppServerClient:
             except (asyncio.CancelledError, Exception):  # noqa: BLE001
                 pass
             self._stderr_task = None
-        self._fail_pending(CodexAppServerError("client is closed"))
         try:
             self._writer.close()
         except Exception:  # noqa: BLE001 — best-effort close

--- a/src/pinky_daemon/codex_app_server.py
+++ b/src/pinky_daemon/codex_app_server.py
@@ -6,7 +6,7 @@ on this to host long-lived *Threads* instead of spawning ``codex exec`` once
 per user message — avoiding per-turn cold-start cost and gaining native
 reconnect (Tier 2 of the Codex modernisation, task #98).
 
-Wire protocol (observed against codex-cli 0.125, ``--listen stdio://``):
+Wire protocol (re-verified against codex-cli 0.144, ``--listen stdio://``):
 
   * One JSON object per line (NDJSON). No ``Content-Length`` framing and no
     ``"jsonrpc"`` version field — the server neither emits nor requires it.
@@ -138,7 +138,16 @@ class CodexAppServerClient:
 
     async def initialize(self, *, name: str = "pinkybot", version: str = "1") -> object:
         """Perform the required ``initialize`` handshake."""
-        return await self.request("initialize", {"clientInfo": {"name": name, "version": version}})
+        return await self.request(
+            "initialize",
+            {
+                "clientInfo": {"name": name, "version": version},
+                # 0.144 added capability negotiation. An empty declaration is
+                # the minimal stable set: do not opt into experimentalApi,
+                # attestation requests, or extended elicitation semantics.
+                "capabilities": {},
+            },
+        )
 
     async def _send(self, msg: dict) -> None:
         if self._closed:

--- a/src/pinky_daemon/codex_session.py
+++ b/src/pinky_daemon/codex_session.py
@@ -19,7 +19,9 @@ from __future__ import annotations
 
 import asyncio
 import json
+import math
 import os
+import shlex
 import time
 from dataclasses import dataclass, field
 
@@ -51,6 +53,43 @@ from pinky_daemon.transport_state import (
 from pinky_daemon.turn_response import TurnResponse
 from pinky_daemon.wake_prompt import WakeReason
 
+APP_SERVER_INIT_TIMEOUT = 20.0
+_APP_SERVER_INIT_TIMEOUT_ENV = "PINKY_CODEX_APP_SERVER_INIT_TIMEOUT"
+_APP_SERVER_AGENTS_ENV = "PINKY_CODEX_APP_SERVER_AGENTS"
+_APP_SERVER_COMMAND_ENV = "PINKY_CODEX_APP_SERVER_CMD"
+
+
+def _select_app_server(agent_name: str) -> tuple[bool, str]:
+    """Return the construction-time app-server decision and its source."""
+    allowlist = {
+        entry.strip()
+        for entry in os.environ.get(_APP_SERVER_AGENTS_ENV, "").split(",")
+        if entry.strip()
+    }
+    if agent_name in allowlist:
+        return True, "allowlist"
+    if os.environ.get("PINKY_CODEX_APP_SERVER") == "1":
+        return True, "global"
+    return False, "off"
+
+
+def _app_server_init_timeout() -> float:
+    """Read the positive finite initialize bound, falling back safely."""
+    raw = os.environ.get(_APP_SERVER_INIT_TIMEOUT_ENV, "").strip()
+    if not raw:
+        return APP_SERVER_INIT_TIMEOUT
+    try:
+        timeout = float(raw)
+    except ValueError:
+        timeout = 0.0
+    if not math.isfinite(timeout) or timeout <= 0:
+        _log(
+            f"app_server_init_timeout_invalid value={raw!r} "
+            f"default={APP_SERVER_INIT_TIMEOUT}"
+        )
+        return APP_SERVER_INIT_TIMEOUT
+    return timeout
+
 
 @dataclass
 class CodexTurnResult:
@@ -68,6 +107,9 @@ class CodexTurnResult:
     reasoning_output_tokens: int = 0
     errors: list[str] = field(default_factory=list)
     failed: bool = False
+    # codex-cli 0.144 reports interruption as a distinct terminal status. It
+    # is an unsuccessful turn, but not a failed app-server substrate.
+    interrupted: bool = False
 
     @property
     def uncached_input_tokens(self) -> int:
@@ -180,13 +222,32 @@ class CodexSession(TransportReplacementMixin):
         # Uses the shared MCP server's streamable HTTP transport
         self._mcp_servers = config.mcp_servers or {}
 
-        # Tier 2 (#98): when PINKY_CODEX_APP_SERVER=1, route turns through a
-        # long-lived ``codex app-server`` JSON-RPC connection instead of
-        # spawning ``codex exec`` per message. Legacy exec stays the default
-        # and the fallback until the soak proves the app-server path. One
-        # app-server process + one thread per session here (chunk 2); a shared
-        # supervisor lands in chunk 3.
-        self._use_app_server = os.environ.get("PINKY_CODEX_APP_SERVER") == "1"
+        # Tier 2 (#98/#582): route only explicitly selected agents through a
+        # long-lived ``codex app-server`` connection. The exact-name allowlist
+        # is the candidate-zero mechanism; the global flag remains a backwards-
+        # compatible fallback. Both default off.
+        self._app_server_requested, self._app_server_source = _select_app_server(
+            self.agent_name
+        )
+        self._use_app_server = self._app_server_requested
+        self._app_server_degraded = False
+        self._app_server_init_timeout = (
+            _app_server_init_timeout()
+            if self._app_server_requested
+            else APP_SERVER_INIT_TIMEOUT
+        )
+        command_override = (
+            os.environ.get(_APP_SERVER_COMMAND_ENV, "").strip()
+            if self._app_server_requested
+            else ""
+        )
+        self._app_server_command = (
+            tuple(shlex.split(command_override)) if command_override else None
+        )
+        _log(
+            f"app_server_mode={'on' if self._use_app_server else 'off'} "
+            f"source={self._app_server_source} agent={self.agent_name}"
+        )
         # #791: when additionally PINKY_CODEX_TMUX_APP_SERVER=1, front the
         # app-server with a tmux-hosted UDS shim (Design A) instead of a daemon
         # child subprocess. Same JSON-RPC client + initialize/thread-resume flow
@@ -206,6 +267,12 @@ class CodexSession(TransportReplacementMixin):
             )
         self._app_client: CodexAppServerClient | None = None
         self._app_proc: asyncio.subprocess.Process | None = None
+        self._appserver_spawn_count = 0
+        self._appserver_counters = {
+            "turns_ok": 0,
+            "turns_failed": 0,
+            "respawns": 0,
+        }
         # Active turn correlation: the read loop dispatches notifications onto
         # a single handler, but turns are processed sequentially by the worker,
         # so a single in-flight result + completion future is sufficient.
@@ -303,6 +370,9 @@ class CodexSession(TransportReplacementMixin):
             )
             return
 
+        if warm_wake_token is not None:
+            self._begin_app_server_reconnect_cycle()
+
         # Bring up the substrate (app-server spawn+initialize for app-server
         # mode; nothing persistent for exec mode). A failure here is structural
         # — terminalize the in-flight transition to DEAD so the broker
@@ -341,13 +411,24 @@ class CodexSession(TransportReplacementMixin):
         """Bring up the structural substrate for a turn-capable session.
 
         App-server mode: spawn + initialize the long-lived ``codex app-server``
-        connection (the persistent transport). Exec mode: nothing persistent —
-        each turn spawns its own ``codex exec``, so there's no substrate to fail
-        on boot. Raises on failure; the caller terminalizes the in-flight
-        transition to DEAD.
+        connection (the persistent transport). An init timeout/error degrades
+        this session instance to exec mode, so it is still turn-capable. Exec
+        mode itself has no persistent substrate. Preflight failures still raise
+        because the same unsafe auth/home would affect both transports.
         """
         if self._use_app_server:
             await self._ensure_app_server()
+
+    def _begin_app_server_reconnect_cycle(self) -> None:
+        """Retry a construction-selected app-server after sticky degradation."""
+        if not self._app_server_requested or not self._app_server_degraded:
+            return
+        self._use_app_server = True
+        self._app_server_degraded = False
+        _log(
+            f"app_server_mode=on source={self._app_server_source} "
+            f"agent={self.agent_name} reconnect_retry=true"
+        )
 
     def _start_worker(self) -> None:
         """Spawn the message-drainer worker if not already running.
@@ -1122,11 +1203,11 @@ class CodexSession(TransportReplacementMixin):
     _APPROVAL_POLICY = "never"  # AskForApproval — full-auto, never prompt
     _SANDBOX_MODE = "danger-full-access"  # SandboxMode — parity with the exec yolo flag
 
-    async def _ensure_app_server(self) -> None:
-        """Spawn + initialise the app-server connection if not already live."""
+    async def _ensure_app_server(self) -> bool:
+        """Spawn + initialise the app-server, or degrade this cycle to exec."""
         if self._app_client is not None and self._app_proc is not None:
             if self._app_proc.returncode is None:
-                return  # still running
+                return True  # still running
 
         # Refuse an unsafe/missing per-agent auth setup before mutating any
         # cached transport. In particular, a dead cached app-server must not be
@@ -1143,39 +1224,81 @@ class CodexSession(TransportReplacementMixin):
             # after the replacement environment passed preparation above.
             await self._teardown_app_server()
 
-        if self._use_tmux_app_server:
-            # #791 Design A: the supervisor spawns the shim under tmux and hands
-            # back an UN-initialized client (accept-readiness only — no probe
-            # initialize, which would burn the child's single-use one). The
-            # single initialize below stays the real end-to-end gate, and its
-            # half-initialized guard covers a dead tmux child (item F).
-            assert self._app_supervisor is not None
-            self._app_client, self._app_proc = await self._app_supervisor.start(
-                notification_handler=self._on_appserver_notification,
-                server_request_handler=self._on_appserver_request,
+        started_at = time.monotonic()
+
+        async def _spawn_and_initialize() -> None:
+            if self._use_tmux_app_server:
+                # #791 Design A: the supervisor spawns the shim under tmux and
+                # hands back an UN-initialized client. The initialize below is
+                # the single end-to-end gate for that child.
+                assert self._app_supervisor is not None
+                self._app_client, self._app_proc = await self._app_supervisor.start(
+                    notification_handler=self._on_appserver_notification,
+                    server_request_handler=self._on_appserver_request,
+                )
+            else:
+                assert direct_env is not None
+                self._app_client, self._app_proc = await spawn_app_server(
+                    command=self._app_server_command,
+                    cwd=self._working_dir,
+                    env=direct_env,
+                    notification_handler=self._on_appserver_notification,
+                    server_request_handler=self._on_appserver_request,
+                    log=_log,
+                )
+
+            self._appserver_spawn_count += 1
+            pid = self._app_proc.pid
+            mode = "tmux" if self._use_tmux_app_server else "subprocess"
+            _log(
+                f"app_server_spawned agent={self.agent_name} mode={mode} pid={pid}"
             )
-        else:
-            assert direct_env is not None
-            self._app_client, self._app_proc = await spawn_app_server(
-                cwd=self._working_dir,
-                env=direct_env,
-                notification_handler=self._on_appserver_notification,
-                server_request_handler=self._on_appserver_request,
-                log=_log,
-            )
-        try:
+            if self._appserver_spawn_count > 1:
+                self._appserver_counters["respawns"] += 1
+                _log(
+                    f"app_server_respawn agent={self.agent_name} "
+                    f"count={self._appserver_counters['respawns']} pid={pid}"
+                )
+
             await self._app_client.initialize(name="pinkybot", version="1")
-        except BaseException:
-            # Spawn succeeded but initialize() failed: never leave a
-            # half-initialized client/proc cached. The early-return guard above
-            # checks only (client is not None and proc still alive), so a
-            # cached-but-uninitialized substrate would make the NEXT reconnect
-            # skip initialization entirely and flip the state machine to
-            # CONNECTED on a dead app-server. Tear down before re-raising so
-            # the next _ensure_app_server() respawns from scratch.
+
+        try:
+            # One bound covers process/supervisor spawn plus initialize. A child
+            # that starts but never answers cannot hold BOOTING for the client's
+            # blanket 600-second request timeout.
+            await asyncio.wait_for(
+                _spawn_and_initialize(), timeout=self._app_server_init_timeout
+            )
+        except asyncio.CancelledError:
             await self._teardown_app_server()
             raise
-        _log(f"codex[{self.agent_name}]: app-server connected (pid={self._app_proc.pid})")
+        except asyncio.TimeoutError:
+            await self._teardown_app_server()
+            self._degrade_app_server(reason="timeout")
+            return False
+        except Exception as exc:  # noqa: BLE001 — any init failure degrades
+            await self._teardown_app_server()
+            self._degrade_app_server(reason="error", error=exc)
+            return False
+
+        elapsed_ms = round((time.monotonic() - started_at) * 1000)
+        _log(
+            f"app_server_initialized agent={self.agent_name} "
+            f"elapsed_ms={elapsed_ms} pid={self._app_proc.pid}"
+        )
+        return True
+
+    def _degrade_app_server(self, *, reason: str, error: Exception | None = None) -> None:
+        """Stick to exec mode until a later reconnect cycle retries."""
+        detail = f" error={str(error)[:200]!r}" if error is not None else ""
+        _log(
+            f"app_server_init_failed reason={reason} agent={self.agent_name}{detail}"
+        )
+        self._use_app_server = False
+        self._app_server_degraded = True
+        _log(
+            f"app_server_degraded_to_exec agent={self.agent_name} reason={reason}"
+        )
 
     async def _teardown_app_server(self) -> None:
         """Close the client and kill the process. Idempotent."""
@@ -1193,6 +1316,14 @@ class CodexSession(TransportReplacementMixin):
             except Exception:
                 pass
             self._app_proc = None
+        # A tmux supervisor may have started its shim but timed out/cancelled
+        # before returning a client/proc adapter. Always run its idempotent
+        # teardown so that partial spawn cannot leak a session or socket.
+        if self._use_tmux_app_server and self._app_supervisor is not None:
+            try:
+                await self._app_supervisor.teardown()
+            except Exception:
+                pass
 
     def _appserver_config(self) -> dict:
         """Build the per-thread ``config`` override for MCP servers.
@@ -1233,7 +1364,7 @@ class CodexSession(TransportReplacementMixin):
         """Run a single turn over the long-lived app-server connection."""
         result = CodexTurnResult()
         try:
-            await self._ensure_app_server()
+            app_server_live = await self._ensure_app_server()
         except Exception as e:  # noqa: BLE001
             # Structural (#206): the persistent app-server substrate failed to
             # come back up mid-life — the session can't process. Terminalize to
@@ -1251,6 +1382,16 @@ class CodexSession(TransportReplacementMixin):
             self._resolve_scheduler_delivery(scheduler_delivery, False)
             return result
 
+        if app_server_live is False:
+            # Initialize failure is a transport selection failure, not an agent
+            # failure. _ensure_app_server made exec mode sticky for this cycle;
+            # immediately deliver the same prompt over the legacy path.
+            return await self._exec_codex(
+                prompt,
+                scheduler_delivery=scheduler_delivery,
+                scheduler_accept=scheduler_accept,
+            )
+
         client = self._app_client
         assert client is not None
         loop = asyncio.get_running_loop()
@@ -1259,10 +1400,10 @@ class CodexSession(TransportReplacementMixin):
         self._appserver_last_usage = {}
 
         config = self._appserver_config()
+        turn_started_at = time.monotonic()
         _log(
-            f"codex[{self.agent_name}]: app-server turn "
-            f"{'resume ' + self.codex_session_id[:12] + ' ' if self.codex_session_id else 'new '}"
-            f"(prompt: {len(prompt)} chars)"
+            f"app_server_turn_start agent={self.agent_name} "
+            f"thread={'resume' if self.codex_session_id else 'new'}"
         )
 
         try:
@@ -1355,6 +1496,19 @@ class CodexSession(TransportReplacementMixin):
             await self._teardown_app_server()
             await self._terminalize_dead("app-server turn exception")
         finally:
+            elapsed_ms = round((time.monotonic() - turn_started_at) * 1000)
+            if result.failed:
+                self._appserver_counters["turns_failed"] += 1
+                reason = "interrupted" if result.interrupted else "failed"
+                _log(
+                    f"app_server_turn_failed agent={self.agent_name} "
+                    f"reason={reason} elapsed_ms={elapsed_ms}"
+                )
+            else:
+                self._appserver_counters["turns_ok"] += 1
+                _log(
+                    f"app_server_turn_ok agent={self.agent_name} elapsed_ms={elapsed_ms}"
+                )
             self._resolve_scheduler_delivery(scheduler_delivery, False)
             self._active_turn_result = None
             self._turn_done = None
@@ -1385,7 +1539,7 @@ class CodexSession(TransportReplacementMixin):
         if event is not None and self._active_turn_result is not None:
             await self._handle_event(event, self._active_turn_result)
 
-        if method == "turn/completed" and self._turn_done is not None:
+        if method in ("turn/completed", "error") and self._turn_done is not None:
             if not self._turn_done.done():
                 self._turn_done.set_result(None)
 
@@ -1405,8 +1559,19 @@ class CodexSession(TransportReplacementMixin):
             return {"decision": "accept"}
         if method == "item/permissions/requestApproval":
             return {"permissions": {}, "scope": "session"}
-        # Elicitations / tool-call / user-input requests: nothing useful to add
-        # under full-auto; an empty result lets the server proceed.
+        # codex-cli 0.144 requires shaped, non-empty result objects for each of
+        # these server requests. Decline or fail safely where this unattended
+        # client cannot supply a real answer/token/tool implementation.
+        if method == "account/chatgptAuthTokens/refresh":
+            return {"accessToken": "", "chatgptAccountId": ""}
+        if method == "item/tool/requestUserInput":
+            return {"answers": {}}
+        if method == "mcpServer/elicitation/request":
+            return {"action": "decline"}
+        if method == "item/tool/call":
+            return {"contentItems": [], "success": False}
+        if method == "attestation/generate":
+            return {"token": ""}
         return {}
 
     def _appserver_to_event(self, method: str, params: dict) -> dict | None:
@@ -1430,13 +1595,26 @@ class CodexSession(TransportReplacementMixin):
             }
         if method == "turn/completed":
             turn = params.get("turn") or {}
-            if turn.get("status") == "failed":
+            status = turn.get("status")
+            if status == "completed":
+                return {"type": "turn.completed", "usage": self._appserver_usage_to_legacy()}
+            if status == "failed":
                 return {"type": "turn.failed", "error": turn.get("error") or {}}
-            return {"type": "turn.completed", "usage": self._appserver_usage_to_legacy()}
+            if status == "interrupted":
+                return {"type": "turn.interrupted"}
+            if status == "inProgress":
+                return {
+                    "type": "turn.failed",
+                    "error": {"message": "turn/completed reported inProgress"},
+                }
+            return {
+                "type": "turn.failed",
+                "error": {"message": f"turn/completed reported unknown status {status!r}"},
+            }
         if method == "error":
             err = params.get("error")
             msg = err.get("message", "unknown error") if isinstance(err, dict) else str(err)
-            return {"type": "error", "message": msg}
+            return {"type": "turn.failed", "error": {"message": msg}}
         return None
 
     def _appserver_usage_to_legacy(self) -> dict:
@@ -1784,6 +1962,18 @@ class CodexSession(TransportReplacementMixin):
                 "error": err_msg,
             })
 
+        elif event_type == "turn.interrupted":
+            result.failed = True
+            result.interrupted = True
+            result.errors.append("turn interrupted")
+            self._analytics_log_activity("turn_interrupted")
+            self._stamp_last_seen()
+            await self._emit_stream_event({
+                "type": "turn_interrupted",
+                "agent": self.agent_name,
+                "session_id": self.id,
+            })
+
         elif event_type == "error":
             err_msg = event.get("message", "unknown error")
             result.errors.append(err_msg)
@@ -1833,6 +2023,7 @@ class CodexSession(TransportReplacementMixin):
             )
             return False
         token = res.owner_token
+        self._begin_app_server_reconnect_cycle()
 
         try:
             # Clear the resume handle (fresh start).
@@ -1960,6 +2151,7 @@ class CodexSession(TransportReplacementMixin):
                 )
             return
         token = res.owner_token
+        self._begin_app_server_reconnect_cycle()
 
         last_error: Exception | None = None
         for attempt_idx, delay in enumerate(self._RECONNECT_BACKOFF, start=1):
@@ -2100,8 +2292,15 @@ class CodexSession(TransportReplacementMixin):
     def stats(self) -> dict:
         state = self.state
         app_server: dict = {}
-        if self._use_app_server:
-            app_server["app_server_mode"] = "tmux" if self._use_tmux_app_server else "subprocess"
+        if self._app_server_requested:
+            if self._app_server_degraded:
+                app_server["app_server_mode"] = "degraded_exec"
+            else:
+                app_server["app_server_mode"] = (
+                    "tmux" if self._use_tmux_app_server else "subprocess"
+                )
+            app_server["app_server_source"] = self._app_server_source
+            app_server["app_server_counters"] = dict(self._appserver_counters)
             if self._app_proc is not None:
                 app_server["child_pid"] = self._app_proc.pid
             if self._app_supervisor is not None:

--- a/src/pinky_daemon/codex_session.py
+++ b/src/pinky_daemon/codex_session.py
@@ -55,6 +55,10 @@ from pinky_daemon.wake_prompt import WakeReason
 
 APP_SERVER_INIT_TIMEOUT = 20.0
 APP_SERVER_TERMINAL_STREAM_TIMEOUT = 5.0
+# Permit one cancellation-resistant survivor while the newest generation runs.
+# Further deliveries are dropped loudly until a retained callback truly exits;
+# otherwise repeated cancellation suppression can grow retained work forever.
+APP_SERVER_TERMINAL_STREAM_MAX_LIVE_CALLBACKS = 2
 _APP_SERVER_INIT_TIMEOUT_ENV = "PINKY_CODEX_APP_SERVER_INIT_TIMEOUT"
 _APP_SERVER_AGENTS_ENV = "PINKY_CODEX_APP_SERVER_AGENTS"
 _APP_SERVER_COMMAND_ENV = "PINKY_CODEX_APP_SERVER_CMD"
@@ -281,6 +285,8 @@ class CodexSession(TransportReplacementMixin):
         self._turn_done: asyncio.Future | None = None
         self._appserver_terminal_stream_tasks: set[asyncio.Task[None]] = set()
         self._appserver_terminal_stream_tail: asyncio.Task[None] | None = None
+        self._appserver_terminal_stream_pending: tuple[int, dict] | None = None
+        self._appserver_terminal_stream_generation = 0
         # Latest per-turn token breakdown from thread/tokenUsage/updated —
         # app-server reports usage out-of-band, not inside turn/completed.
         self._appserver_last_usage: dict = {}
@@ -1733,7 +1739,14 @@ class CodexSession(TransportReplacementMixin):
             {callback_task}, timeout=APP_SERVER_TERMINAL_STREAM_TIMEOUT
         )
         if done:
-            await callback_task
+            try:
+                await callback_task
+            except asyncio.CancelledError:
+                current = asyncio.current_task()
+                if current is not None and current.cancelling():
+                    raise
+                # A callback that cancels itself is a completed best-effort
+                # delivery, not cancellation of the session dispatcher.
             return
 
         _log(
@@ -1741,15 +1754,10 @@ class CodexSession(TransportReplacementMixin):
             f"type={event.get('type', '')} "
             f"timeout_s={APP_SERVER_TERMINAL_STREAM_TIMEOUT}"
         )
-        # The turn and read loop are already independent, so retaining and
-        # awaiting a cancellation-resistant callback here cannot gate turn
-        # completion. Keeping this detached delivery task alive until the
-        # callback truly exits also keeps later terminal deliveries serialized.
+        # Keep cancellation-resistant work strongly retained for truthful
+        # teardown reporting, but do not await the corpse: the dispatcher must
+        # advance to the latest pending generation within this same bound.
         callback_task.cancel()
-        try:
-            await callback_task
-        except asyncio.CancelledError:
-            pass
 
     @staticmethod
     def _consume_background_task(task: asyncio.Task) -> None:
@@ -1781,29 +1789,68 @@ class CodexSession(TransportReplacementMixin):
             )
 
     def _schedule_appserver_terminal_stream_event(self, event: dict) -> None:
-        """Deliver terminal UI output in session order, outside the turn."""
+        """Deliver only the latest not-yet-started terminal generation.
+
+        One dispatcher serializes ordinary callbacks. A callback that exceeds
+        its bound is cancelled and retained, while the dispatcher immediately
+        advances. Intermediate pending generations are coalesced loudly so a
+        resistant callback cannot create an unbounded wrapper-task convoy.
+        """
         if self._stream_event_callback is None:
             return
-        previous = self._appserver_terminal_stream_tail
+        self._appserver_terminal_stream_generation += 1
+        generation = self._appserver_terminal_stream_generation
+        previous_pending = self._appserver_terminal_stream_pending
+        if previous_pending is not None:
+            stale_generation, stale_event = previous_pending
+            _log(
+                f"app_server_stale_terminal_dropped agent={self.agent_name} "
+                f"type={stale_event.get('type', '')} "
+                f"generation={stale_generation} superseded_by={generation}"
+            )
+        self._appserver_terminal_stream_pending = (generation, event)
 
-        async def _deliver_after_previous() -> None:
-            if previous is not None:
-                try:
-                    await asyncio.shield(previous)
-                except asyncio.CancelledError:
-                    # A cancelled predecessor is complete ordering-wise. If
-                    # this task itself was cancelled, preserve that request.
-                    if not previous.done():
-                        raise
-                except Exception:
-                    # Delivery is best effort; ordering survives an earlier
-                    # callback failure and the done callback consumes it.
-                    pass
-            await self._deliver_bounded_appserver_terminal_stream_event(event)
+        if (
+            self._appserver_terminal_stream_tail is not None
+            and not self._appserver_terminal_stream_tail.done()
+        ):
+            return
 
-        task = asyncio.create_task(_deliver_after_previous())
+        async def _deliver_latest() -> None:
+            while self._appserver_terminal_stream_pending is not None:
+                pending_generation, pending_event = (
+                    self._appserver_terminal_stream_pending
+                )
+                self._appserver_terminal_stream_pending = None
+                high_water = self._appserver_terminal_stream_generation
+                if pending_generation != high_water:
+                    _log(
+                        f"app_server_stale_terminal_dropped agent={self.agent_name} "
+                        f"type={pending_event.get('type', '')} "
+                        f"generation={pending_generation} superseded_by={high_water}"
+                    )
+                    continue
+
+                live_callbacks = sum(
+                    not retained.done()
+                    for retained in self._appserver_terminal_stream_tasks
+                )
+                if live_callbacks >= APP_SERVER_TERMINAL_STREAM_MAX_LIVE_CALLBACKS:
+                    _log(
+                        f"app_server_stale_terminal_dropped agent={self.agent_name} "
+                        f"type={pending_event.get('type', '')} "
+                        f"generation={pending_generation} reason=survivor_limit "
+                        f"live_callbacks={live_callbacks}"
+                    )
+                    continue
+
+                await self._deliver_bounded_appserver_terminal_stream_event(
+                    pending_event
+                )
+
+        task = asyncio.create_task(_deliver_latest())
         self._appserver_terminal_stream_tail = task
-        self._retain_appserver_terminal_stream_task(task)
+        task.add_done_callback(self._consume_background_task)
 
         def _clear_tail(done: asyncio.Task[None]) -> None:
             if self._appserver_terminal_stream_tail is done:

--- a/src/pinky_daemon/codex_session.py
+++ b/src/pinky_daemon/codex_session.py
@@ -280,6 +280,7 @@ class CodexSession(TransportReplacementMixin):
         self._active_turn_result: CodexTurnResult | None = None
         self._turn_done: asyncio.Future | None = None
         self._appserver_terminal_stream_tasks: set[asyncio.Task[None]] = set()
+        self._appserver_terminal_stream_tail: asyncio.Task[None] | None = None
         # Latest per-turn token breakdown from thread/tokenUsage/updated —
         # app-server reports usage out-of-band, not inside turn/completed.
         self._appserver_last_usage: dict = {}
@@ -1208,8 +1209,14 @@ class CodexSession(TransportReplacementMixin):
     async def _ensure_app_server(self) -> bool:
         """Spawn + initialise the app-server, or degrade this cycle to exec."""
         if self._app_client is not None and self._app_proc is not None:
-            if self._app_proc.returncode is None:
+            client_closed = bool(getattr(self._app_client, "is_closed", False))
+            if self._app_proc.returncode is None and not client_closed:
                 return True  # still running
+            if self._app_proc.returncode is None and client_closed:
+                _log(
+                    f"app_server_cached_transport_unusable agent={self.agent_name} "
+                    "reason=read_closed process_alive=true"
+                )
 
         # Refuse an unsafe/missing per-agent auth setup before mutating any
         # cached transport. In particular, a dead cached app-server must not be
@@ -1313,6 +1320,7 @@ class CodexSession(TransportReplacementMixin):
 
     async def _teardown_app_server(self) -> None:
         """Close the client and kill the process. Idempotent."""
+        self._report_appserver_terminal_stream_survivors(phase="teardown")
         if self._app_client is not None:
             try:
                 await self._app_client.close()
@@ -1720,6 +1728,7 @@ class CodexSession(TransportReplacementMixin):
         self, event: dict
     ) -> None:
         callback_task = asyncio.create_task(self._emit_stream_event(event))
+        self._retain_appserver_terminal_stream_task(callback_task)
         done, _pending = await asyncio.wait(
             {callback_task}, timeout=APP_SERVER_TERMINAL_STREAM_TIMEOUT
         )
@@ -1732,11 +1741,15 @@ class CodexSession(TransportReplacementMixin):
             f"type={event.get('type', '')} "
             f"timeout_s={APP_SERVER_TERMINAL_STREAM_TIMEOUT}"
         )
-        # Do not await cancellation: a hostile callback can suppress it. The
-        # turn and read loop are already independent, and the done callback
-        # consumes any later exception if the abandoned task eventually exits.
+        # The turn and read loop are already independent, so retaining and
+        # awaiting a cancellation-resistant callback here cannot gate turn
+        # completion. Keeping this detached delivery task alive until the
+        # callback truly exits also keeps later terminal deliveries serialized.
         callback_task.cancel()
-        callback_task.add_done_callback(self._consume_background_task)
+        try:
+            await callback_task
+        except asyncio.CancelledError:
+            pass
 
     @staticmethod
     def _consume_background_task(task: asyncio.Task) -> None:
@@ -1747,15 +1760,56 @@ class CodexSession(TransportReplacementMixin):
         except asyncio.CancelledError:
             pass
 
-    def _schedule_appserver_terminal_stream_event(self, event: dict) -> None:
-        """Deliver terminal UI output without holding the turn/read loop."""
-        if self._stream_event_callback is None:
-            return
-        task = asyncio.create_task(
-            self._deliver_bounded_appserver_terminal_stream_event(event)
-        )
+    def _retain_appserver_terminal_stream_task(
+        self, task: asyncio.Task[None]
+    ) -> None:
+        """Retain detached delivery work until the underlying task is done."""
         self._appserver_terminal_stream_tasks.add(task)
         task.add_done_callback(self._appserver_terminal_stream_tasks.discard)
+        task.add_done_callback(self._consume_background_task)
+
+    def _report_appserver_terminal_stream_survivors(self, *, phase: str) -> None:
+        survivors = [
+            task
+            for task in self._appserver_terminal_stream_tasks
+            if not task.done()
+        ]
+        if survivors:
+            _log(
+                f"app_server_terminal_stream_survivors agent={self.agent_name} "
+                f"phase={phase} count={len(survivors)}"
+            )
+
+    def _schedule_appserver_terminal_stream_event(self, event: dict) -> None:
+        """Deliver terminal UI output in session order, outside the turn."""
+        if self._stream_event_callback is None:
+            return
+        previous = self._appserver_terminal_stream_tail
+
+        async def _deliver_after_previous() -> None:
+            if previous is not None:
+                try:
+                    await asyncio.shield(previous)
+                except asyncio.CancelledError:
+                    # A cancelled predecessor is complete ordering-wise. If
+                    # this task itself was cancelled, preserve that request.
+                    if not previous.done():
+                        raise
+                except Exception:
+                    # Delivery is best effort; ordering survives an earlier
+                    # callback failure and the done callback consumes it.
+                    pass
+            await self._deliver_bounded_appserver_terminal_stream_event(event)
+
+        task = asyncio.create_task(_deliver_after_previous())
+        self._appserver_terminal_stream_tail = task
+        self._retain_appserver_terminal_stream_task(task)
+
+        def _clear_tail(done: asyncio.Task[None]) -> None:
+            if self._appserver_terminal_stream_tail is done:
+                self._appserver_terminal_stream_tail = None
+
+        task.add_done_callback(_clear_tail)
 
     async def _emit_terminal_stream_event(self, event: dict) -> None:
         """Keep legacy ordering; detach only for an active app-server turn."""

--- a/src/pinky_daemon/codex_session.py
+++ b/src/pinky_daemon/codex_session.py
@@ -54,6 +54,7 @@ from pinky_daemon.turn_response import TurnResponse
 from pinky_daemon.wake_prompt import WakeReason
 
 APP_SERVER_INIT_TIMEOUT = 20.0
+APP_SERVER_TERMINAL_STREAM_TIMEOUT = 5.0
 _APP_SERVER_INIT_TIMEOUT_ENV = "PINKY_CODEX_APP_SERVER_INIT_TIMEOUT"
 _APP_SERVER_AGENTS_ENV = "PINKY_CODEX_APP_SERVER_AGENTS"
 _APP_SERVER_COMMAND_ENV = "PINKY_CODEX_APP_SERVER_CMD"
@@ -278,6 +279,7 @@ class CodexSession(TransportReplacementMixin):
         # so a single in-flight result + completion future is sufficient.
         self._active_turn_result: CodexTurnResult | None = None
         self._turn_done: asyncio.Future | None = None
+        self._appserver_terminal_stream_tasks: set[asyncio.Task[None]] = set()
         # Latest per-turn token breakdown from thread/tokenUsage/updated —
         # app-server reports usage out-of-band, not inside turn/completed.
         self._appserver_last_usage: dict = {}
@@ -1247,6 +1249,15 @@ class CodexSession(TransportReplacementMixin):
                     log=_log,
                 )
 
+            # RPC futures only cover requests awaiting responses. Once
+            # turn/start is accepted, the independently awaited _turn_done must
+            # also be failed on EOF/read-loop death or the turn sits for 600s.
+            set_closed_handler = getattr(
+                self._app_client, "set_transport_closed_handler", None
+            )
+            if set_closed_handler is not None:
+                set_closed_handler(self._on_appserver_transport_closed)
+
             self._appserver_spawn_count += 1
             pid = self._app_proc.pid
             mode = "tmux" if self._use_tmux_app_server else "subprocess"
@@ -1374,7 +1385,7 @@ class CodexSession(TransportReplacementMixin):
             result.failed = True
             result.errors.append(f"app-server connect failed: {e}")
             _log(f"codex[{self.agent_name}]: app-server connect failed: {e}")
-            await self._emit_stream_event({
+            self._schedule_appserver_terminal_stream_event({
                 "type": "turn_failed", "agent": self.agent_name,
                 "session_id": self.id, "error": str(e),
             })
@@ -1463,7 +1474,7 @@ class CodexSession(TransportReplacementMixin):
             result.failed = True
             result.errors.append("codex app-server turn timed out after 600s")
             _log(f"codex[{self.agent_name}]: app-server turn timed out")
-            await self._emit_stream_event({
+            self._schedule_appserver_terminal_stream_event({
                 "type": "turn_failed", "agent": self.agent_name,
                 "session_id": self.id, "error": "codex app-server turn timed out after 600s",
             })
@@ -1476,7 +1487,7 @@ class CodexSession(TransportReplacementMixin):
             result.failed = True
             result.errors.append(str(e))
             _log(f"codex[{self.agent_name}]: app-server error: {e}")
-            await self._emit_stream_event({
+            self._schedule_appserver_terminal_stream_event({
                 "type": "turn_failed", "agent": self.agent_name,
                 "session_id": self.id, "error": str(e),
             })
@@ -1489,7 +1500,7 @@ class CodexSession(TransportReplacementMixin):
             result.failed = True
             result.errors.append(str(e))
             _log(f"codex[{self.agent_name}]: app-server turn exception: {e}")
-            await self._emit_stream_event({
+            self._schedule_appserver_terminal_stream_event({
                 "type": "turn_failed", "agent": self.agent_name,
                 "session_id": self.id, "error": str(e),
             })
@@ -1511,9 +1522,32 @@ class CodexSession(TransportReplacementMixin):
                 )
             self._resolve_scheduler_delivery(scheduler_delivery, False)
             self._active_turn_result = None
+            if (
+                self._turn_done is not None
+                and self._turn_done.done()
+                and not self._turn_done.cancelled()
+            ):
+                # If closure raced a still-pending thread/start or turn/start,
+                # that RPC exception wins the catch path. Retrieve the closure
+                # future's exception too so the independently signalled edge
+                # cannot become an unobserved-future warning.
+                self._turn_done.exception()
             self._turn_done = None
 
         return result
+
+    def _on_appserver_transport_closed(self, error: CodexAppServerError) -> None:
+        """Wake an accepted turn immediately when the transport disappears."""
+        active_turn = self._turn_done is not None and not self._turn_done.done()
+        _log(
+            f"app_server_transport_closed agent={self.agent_name} "
+            f"active_turn={str(active_turn).lower()} error={str(error)[:200]!r}"
+        )
+        if active_turn:
+            assert self._turn_done is not None
+            self._turn_done.set_exception(
+                CodexAppServerError(f"app-server transport closed: {error}")
+            )
 
     async def _on_appserver_notification(self, method: str, params: dict) -> None:
         """Translate an app-server notification onto the legacy event path."""
@@ -1538,10 +1572,6 @@ class CodexSession(TransportReplacementMixin):
         event = self._appserver_to_event(method, params)
         if event is not None and self._active_turn_result is not None:
             await self._handle_event(event, self._active_turn_result)
-
-        if method in ("turn/completed", "error") and self._turn_done is not None:
-            if not self._turn_done.done():
-                self._turn_done.set_result(None)
 
     async def _on_appserver_request(self, method: str, params: dict) -> dict:
         """Auto-approve server->client requests (full-auto).
@@ -1680,6 +1710,59 @@ class CodexSession(TransportReplacementMixin):
             await self._stream_event_callback(event)
         except Exception as e:
             _log(f"codex[{self.agent_name}]: stream event callback error: {e}")
+
+    def _resolve_appserver_turn(self) -> None:
+        """Release the app-server turn waiter after terminal result mutation."""
+        if self._turn_done is not None and not self._turn_done.done():
+            self._turn_done.set_result(None)
+
+    async def _deliver_bounded_appserver_terminal_stream_event(
+        self, event: dict
+    ) -> None:
+        callback_task = asyncio.create_task(self._emit_stream_event(event))
+        done, _pending = await asyncio.wait(
+            {callback_task}, timeout=APP_SERVER_TERMINAL_STREAM_TIMEOUT
+        )
+        if done:
+            await callback_task
+            return
+
+        _log(
+            f"app_server_terminal_stream_abandoned agent={self.agent_name} "
+            f"type={event.get('type', '')} "
+            f"timeout_s={APP_SERVER_TERMINAL_STREAM_TIMEOUT}"
+        )
+        # Do not await cancellation: a hostile callback can suppress it. The
+        # turn and read loop are already independent, and the done callback
+        # consumes any later exception if the abandoned task eventually exits.
+        callback_task.cancel()
+        callback_task.add_done_callback(self._consume_background_task)
+
+    @staticmethod
+    def _consume_background_task(task: asyncio.Task) -> None:
+        if task.cancelled():
+            return
+        try:
+            task.exception()
+        except asyncio.CancelledError:
+            pass
+
+    def _schedule_appserver_terminal_stream_event(self, event: dict) -> None:
+        """Deliver terminal UI output without holding the turn/read loop."""
+        if self._stream_event_callback is None:
+            return
+        task = asyncio.create_task(
+            self._deliver_bounded_appserver_terminal_stream_event(event)
+        )
+        self._appserver_terminal_stream_tasks.add(task)
+        task.add_done_callback(self._appserver_terminal_stream_tasks.discard)
+
+    async def _emit_terminal_stream_event(self, event: dict) -> None:
+        """Keep legacy ordering; detach only for an active app-server turn."""
+        if self._turn_done is None:
+            await self._emit_stream_event(event)
+            return
+        self._schedule_appserver_terminal_stream_event(event)
 
     async def _handle_event(self, event: dict, result: CodexTurnResult) -> None:
         """Parse a single JSONL event and update result + activity tracking."""
@@ -1935,7 +2018,10 @@ class CodexSession(TransportReplacementMixin):
                 },
             )
             self._stamp_last_seen()
-            await self._emit_stream_event({
+            # Result + analytics state is now complete. Release the turn before
+            # any external callback; terminal delivery is separately bounded.
+            self._resolve_appserver_turn()
+            await self._emit_terminal_stream_event({
                 "type": "turn_completed",
                 "agent": self.agent_name,
                 "session_id": self.id,
@@ -1955,7 +2041,8 @@ class CodexSession(TransportReplacementMixin):
             result.errors.append(err_msg)
             self._analytics_log_activity("turn_failed", metadata={"error": err_msg})
             self._stamp_last_seen()
-            await self._emit_stream_event({
+            self._resolve_appserver_turn()
+            await self._emit_terminal_stream_event({
                 "type": "turn_failed",
                 "agent": self.agent_name,
                 "session_id": self.id,
@@ -1968,7 +2055,8 @@ class CodexSession(TransportReplacementMixin):
             result.errors.append("turn interrupted")
             self._analytics_log_activity("turn_interrupted")
             self._stamp_last_seen()
-            await self._emit_stream_event({
+            self._resolve_appserver_turn()
+            await self._emit_terminal_stream_event({
                 "type": "turn_interrupted",
                 "agent": self.agent_name,
                 "session_id": self.id,

--- a/tests/_fake_app_server.py
+++ b/tests/_fake_app_server.py
@@ -25,7 +25,12 @@ import os
 import sys
 import time
 
-_PHASE1_MODES = {"happy", "error-notification", "exit-after-turn"}
+_PHASE1_MODES = {
+    "happy",
+    "error-notification",
+    "eof-after-acceptance",
+    "exit-after-turn",
+}
 
 
 def _send(frame: dict) -> None:
@@ -79,6 +84,7 @@ def main(argv: list[str] | None = None) -> int:
             "error-init",
             "die-pre-init",
             "error-notification",
+            "eof-after-acceptance",
             "exit-after-turn",
         ),
         default="echo",
@@ -135,6 +141,10 @@ def main(argv: list[str] | None = None) -> int:
             turn_count += 1
             turn_id = f"fake-turn-{turn_count}"
             _send({"id": mid, "result": {"turn": _turn(turn_id, "inProgress")}})
+            if mode == "eof-after-acceptance":
+                # Exact May-wedge shape: prompt acceptance is positive, then
+                # the child exits cleanly without any terminal notification.
+                return 0
             if mode == "error-notification":
                 _send({
                     "method": "error",

--- a/tests/_fake_app_server.py
+++ b/tests/_fake_app_server.py
@@ -92,6 +92,7 @@ def main(argv: list[str] | None = None) -> int:
             "error-init",
             "die-pre-init",
             "error-notification",
+            "backpressure-eof",
             "eof-between-turns",
             "eof-after-acceptance",
             "eof-after-terminal",
@@ -132,6 +133,16 @@ def main(argv: list[str] | None = None) -> int:
                     "platformOs": "fake",
                 },
             })
+            if mode == "backpressure-eof":
+                # Wait for the first byte of the next request, then stop
+                # reading stdin so the parent's 16 MiB write backpressures.
+                # Close only stdout: the process and stdin stay live until the
+                # test explicitly tears the child down.
+                os.read(sys.stdin.fileno(), 1)
+                time.sleep(0.05)
+                _close_stdout()
+                while True:
+                    time.sleep(3600)
             if mode == "eof-between-turns":
                 _close_stdout()
             if exit_after_init:

--- a/tests/_fake_app_server.py
+++ b/tests/_fake_app_server.py
@@ -9,7 +9,8 @@ end-to-end with no real ``codex`` binary.
     request echoes params (including frames >64 KiB)
   * phase-1 modes exercise the 0.144 lifecycle used by CodexSession: happy
     turns, init hang/error/death, terminal error notification, and exit after
-    a completed turn
+    a completed turn; EOF-only modes close stdout while the process and stdin
+    remain alive
   * notifications (no id)  -> ignored
 
 Env knobs:
@@ -29,6 +30,7 @@ _PHASE1_MODES = {
     "happy",
     "error-notification",
     "eof-after-acceptance",
+    "eof-after-terminal",
     "exit-after-turn",
 }
 
@@ -36,6 +38,12 @@ _PHASE1_MODES = {
 def _send(frame: dict) -> None:
     sys.stdout.write(json.dumps(frame) + "\n")
     sys.stdout.flush()
+
+
+def _close_stdout() -> None:
+    """Emit EOF to the parent while keeping this process and stdin alive."""
+    sys.stdout.flush()
+    os.close(sys.stdout.fileno())
 
 
 def _thread(thread_id: str) -> dict:
@@ -84,7 +92,9 @@ def main(argv: list[str] | None = None) -> int:
             "error-init",
             "die-pre-init",
             "error-notification",
+            "eof-between-turns",
             "eof-after-acceptance",
+            "eof-after-terminal",
             "exit-after-turn",
         ),
         default="echo",
@@ -122,6 +132,8 @@ def main(argv: list[str] | None = None) -> int:
                     "platformOs": "fake",
                 },
             })
+            if mode == "eof-between-turns":
+                _close_stdout()
             if exit_after_init:
                 return 0
             continue
@@ -175,6 +187,8 @@ def main(argv: list[str] | None = None) -> int:
                     "turn": _turn(turn_id, "completed"),
                 },
             })
+            if mode == "eof-after-terminal":
+                _close_stdout()
             if mode == "exit-after-turn":
                 return 0
             continue

--- a/tests/_fake_app_server.py
+++ b/tests/_fake_app_server.py
@@ -5,9 +5,11 @@ codex_app_server.py): one JSON object per line, requests carry ``id`` +
 ``method``, responses carry ``id`` + ``result``. Lets the bridge be exercised
 end-to-end with no real ``codex`` binary.
 
-  * ``initialize``         -> {"id", "result": {"userAgent": "fake/1", ...}}
-  * any other request      -> {"id", "result": {"echo": <params>}}  (round-trips
-                              arbitrary payloads, incl. frames >64 KiB)
+  * default mode: ``initialize`` returns a small success and every other
+    request echoes params (including frames >64 KiB)
+  * phase-1 modes exercise the 0.144 lifecycle used by CodexSession: happy
+    turns, init hang/error/death, terminal error notification, and exit after
+    a completed turn
   * notifications (no id)  -> ignored
 
 Env knobs:
@@ -17,13 +19,74 @@ Env knobs:
 
 from __future__ import annotations
 
+import argparse
 import json
 import os
 import sys
+import time
+
+_PHASE1_MODES = {"happy", "error-notification", "exit-after-turn"}
 
 
-def main() -> int:
+def _send(frame: dict) -> None:
+    sys.stdout.write(json.dumps(frame) + "\n")
+    sys.stdout.flush()
+
+
+def _thread(thread_id: str) -> dict:
+    """Minimal 0.144-shaped Thread object for scripted responses."""
+    now = int(time.time())
+    return {
+        "id": thread_id,
+        "preview": "",
+        "ephemeral": False,
+        "modelProvider": "openai",
+        "createdAt": now,
+        "updatedAt": now,
+        "status": {"type": "idle"},
+        "cwd": os.getcwd(),
+        "cliVersion": "0.144.0-fake",
+        "source": "appServer",
+        "sessionId": thread_id,
+        "turns": [],
+    }
+
+
+def _thread_response(thread_id: str) -> dict:
+    return {
+        "thread": _thread(thread_id),
+        "model": "gpt-5",
+        "modelProvider": "openai",
+        "cwd": os.getcwd(),
+        "approvalPolicy": "never",
+        "approvalsReviewer": "user",
+        "sandbox": {"type": "dangerFullAccess"},
+    }
+
+
+def _turn(turn_id: str, status: str) -> dict:
+    return {"id": turn_id, "items": [], "status": status, "error": None}
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--mode",
+        choices=(
+            "echo",
+            "happy",
+            "hang-init",
+            "error-init",
+            "die-pre-init",
+            "error-notification",
+            "exit-after-turn",
+        ),
+        default="echo",
+    )
+    mode = parser.parse_args(argv).mode
     exit_after_init = os.environ.get("FAKE_AS_EXIT_AFTER_INIT") == "1"
+    thread_id = f"fake-thread-{os.getpid()}"
+    turn_count = 0
     for raw in sys.stdin.buffer:
         line = raw.strip()
         if not line:
@@ -37,13 +100,76 @@ def main() -> int:
         if mid is None:
             continue  # notification — ignore
         if method == "initialize":
-            resp = {"id": mid, "result": {"userAgent": "fake/1", "ok": True}}
-        else:
-            resp = {"id": mid, "result": {"echo": msg.get("params")}}
-        sys.stdout.write(json.dumps(resp) + "\n")
-        sys.stdout.flush()
-        if method == "initialize" and exit_after_init:
-            return 0
+            if mode == "hang-init":
+                continue
+            if mode == "error-init":
+                _send({"id": mid, "error": {"code": -32000, "message": "init refused"}})
+                continue
+            if mode == "die-pre-init":
+                return 7
+            _send({
+                "id": mid,
+                "result": {
+                    "userAgent": "fake/1",
+                    "codexHome": os.getcwd(),
+                    "platformFamily": "unix",
+                    "platformOs": "fake",
+                },
+            })
+            if exit_after_init:
+                return 0
+            continue
+
+        if mode not in _PHASE1_MODES:
+            _send({"id": mid, "result": {"echo": msg.get("params")}})
+            continue
+
+        if method == "thread/start":
+            _send({"id": mid, "result": _thread_response(thread_id)})
+            continue
+        if method == "thread/resume":
+            thread_id = (msg.get("params") or {}).get("threadId", thread_id)
+            _send({"id": mid, "result": _thread_response(thread_id)})
+            continue
+        if method == "turn/start":
+            turn_count += 1
+            turn_id = f"fake-turn-{turn_count}"
+            _send({"id": mid, "result": {"turn": _turn(turn_id, "inProgress")}})
+            if mode == "error-notification":
+                _send({
+                    "method": "error",
+                    "params": {
+                        "threadId": thread_id,
+                        "turnId": turn_id,
+                        "willRetry": False,
+                        "error": {"message": "scripted terminal error"},
+                    },
+                })
+                continue
+            _send({
+                "method": "item/completed",
+                "params": {
+                    "threadId": thread_id,
+                    "turnId": turn_id,
+                    "item": {
+                        "id": "item-1",
+                        "type": "agentMessage",
+                        "text": "fake app-server reply",
+                    },
+                },
+            })
+            _send({
+                "method": "turn/completed",
+                "params": {
+                    "threadId": thread_id,
+                    "turn": _turn(turn_id, "completed"),
+                },
+            })
+            if mode == "exit-after-turn":
+                return 0
+            continue
+
+        _send({"id": mid, "result": {}})
     return 0
 
 

--- a/tests/test_codex_app_server.py
+++ b/tests/test_codex_app_server.py
@@ -267,6 +267,29 @@ class TestFramingAndLifecycle:
         assert len(closed) == 1
 
     @pytest.mark.asyncio
+    async def test_eof_latches_closed_before_any_later_request_is_registered(self):
+        closed: list[CodexAppServerError] = []
+        client, reader, writer = make_client()
+        client.set_transport_closed_handler(closed.append)
+
+        reader.feed_eof()
+        await _settle()
+
+        frames_before = writer.frames()
+        assert client.is_closed is True
+        next_id_before = client._next_id
+        for method in ("after-eof-1", "after-eof-2"):
+            with pytest.raises(CodexAppServerError, match="connection closed"):
+                await asyncio.wait_for(client.request(method), timeout=0.05)
+
+        assert client._pending == {}
+        assert client._next_id == next_id_before
+        assert writer.frames() == frames_before
+        assert len(closed) == 1
+        await client.close()
+        assert len(closed) == 1
+
+    @pytest.mark.asyncio
     async def test_deliberate_close_does_not_signal_transport_failure(self):
         closed: list[CodexAppServerError] = []
         client, _reader, _writer = make_client()

--- a/tests/test_codex_app_server.py
+++ b/tests/test_codex_app_server.py
@@ -35,6 +35,19 @@ class FakeWriter:
         return [json.loads(ln) for ln in self.buffer.split(b"\n") if ln.strip()]
 
 
+class BackpressuredWriter(FakeWriter):
+    """Writer whose drain never completes until the test releases it."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.drain_started = asyncio.Event()
+        self.release_drain = asyncio.Event()
+
+    async def drain(self) -> None:
+        self.drain_started.set()
+        await self.release_drain.wait()
+
+
 def make_client(**kwargs) -> tuple[CodexAppServerClient, asyncio.StreamReader, FakeWriter]:
     reader = asyncio.StreamReader()
     writer = FakeWriter()
@@ -105,10 +118,85 @@ class TestRequestResponse:
 
     @pytest.mark.asyncio
     async def test_request_timeout(self):
-        client, _reader, _writer = make_client()
+        client, _reader, writer = make_client()
         with pytest.raises(CodexAppServerError, match="timed out"):
             await client.request("slow", timeout=0.05)
+        assert client.is_closed is False
+        assert writer.closed is False
         await client.close()
+
+    @pytest.mark.asyncio
+    async def test_request_timeout_covers_backpressured_send_closed_by_eof(self):
+        reader = asyncio.StreamReader()
+        writer = BackpressuredWriter()
+        client = CodexAppServerClient(reader, writer)
+        client.start()
+        timeout = 0.05
+        task = asyncio.create_task(
+            client.request(
+                "backpressured",
+                {"payload": "x" * (16 * 1024 * 1024)},
+                timeout=timeout,
+            )
+        )
+        await asyncio.wait_for(writer.drain_started.wait(), timeout=1)
+
+        # stdout closes while the peer process and stdin can remain live. The
+        # pending Future is failed by EOF, but request() must also escape drain.
+        reader.feed_eof()
+        try:
+            with pytest.raises(CodexAppServerError, match="connection closed"):
+                await asyncio.wait_for(task, timeout=timeout * 4)
+            assert client._pending == {}
+        finally:
+            writer.release_drain.set()
+            await client.close()
+
+    @pytest.mark.asyncio
+    async def test_request_timeout_covers_backpressured_send_without_eof(self):
+        reader = asyncio.StreamReader()
+        writer = BackpressuredWriter()
+        client = CodexAppServerClient(reader, writer)
+        client.start()
+        timeout = 0.02
+        task = asyncio.create_task(client.request("send-timeout", timeout=timeout))
+        await asyncio.wait_for(writer.drain_started.wait(), timeout=1)
+
+        try:
+            with pytest.raises(CodexAppServerError, match="timed out"):
+                await asyncio.wait_for(task, timeout=timeout * 4)
+            assert client._pending == {}
+            assert client.is_closed is True
+            assert writer.closed is True
+        finally:
+            writer.release_drain.set()
+            await client.close()
+
+    @pytest.mark.asyncio
+    async def test_eof_at_write_edge_interrupts_backpressured_send(self):
+        reader = asyncio.StreamReader()
+
+        class EofAtWriteWriter(BackpressuredWriter):
+            def write(self, data: bytes) -> None:
+                # Exact close edge: request's closed-latch check passed, then
+                # EOF lands as the write begins. Do not accept a partial frame.
+                reader.feed_eof()
+
+        writer = EofAtWriteWriter()
+        client = CodexAppServerClient(reader, writer)
+        client.start()
+        timeout = 0.05
+        task = asyncio.create_task(client.request("write-edge", timeout=timeout))
+        await asyncio.wait_for(writer.drain_started.wait(), timeout=1)
+
+        try:
+            with pytest.raises(CodexAppServerError, match="connection closed"):
+                await asyncio.wait_for(task, timeout=timeout * 4)
+            assert client._pending == {}
+            assert writer.buffer == b""
+        finally:
+            writer.release_drain.set()
+            await client.close()
 
     @pytest.mark.asyncio
     async def test_request_on_closed_client_raises(self):

--- a/tests/test_codex_app_server.py
+++ b/tests/test_codex_app_server.py
@@ -253,6 +253,30 @@ class TestFramingAndLifecycle:
         await client.close()
 
     @pytest.mark.asyncio
+    async def test_eof_signals_transport_closed_after_requests_are_empty(self):
+        closed: list[CodexAppServerError] = []
+        client, reader, _writer = make_client()
+        client.set_transport_closed_handler(closed.append)
+
+        reader.feed_eof()
+        await _settle()
+
+        assert len(closed) == 1
+        assert str(closed[0]) == "connection closed"
+        await client.close()
+        assert len(closed) == 1
+
+    @pytest.mark.asyncio
+    async def test_deliberate_close_does_not_signal_transport_failure(self):
+        closed: list[CodexAppServerError] = []
+        client, _reader, _writer = make_client()
+        client.set_transport_closed_handler(closed.append)
+
+        await client.close()
+
+        assert closed == []
+
+    @pytest.mark.asyncio
     async def test_close_is_idempotent(self):
         client, _reader, writer = make_client()
         await client.close()

--- a/tests/test_codex_app_server.py
+++ b/tests/test_codex_app_server.py
@@ -124,7 +124,10 @@ class TestRequestResponse:
         await _settle()
         frame = writer.frames()[0]
         assert frame["method"] == "initialize"
-        assert frame["params"] == {"clientInfo": {"name": "pinkybot", "version": "9"}}
+        assert frame["params"] == {
+            "clientInfo": {"name": "pinkybot", "version": "9"},
+            "capabilities": {},
+        }
 
         _feed(reader, {"id": frame["id"], "result": {"codexHome": "/x"}})
         assert await asyncio.wait_for(task, timeout=1) == {"codexHome": "/x"}

--- a/tests/test_codex_app_server_phase1.py
+++ b/tests/test_codex_app_server_phase1.py
@@ -208,6 +208,64 @@ async def test_error_notification_terminally_resolves_turn(monkeypatch, tmp_path
 
 
 @pytest.mark.asyncio
+async def test_child_eof_after_acceptance_fails_promptly_and_respawns(
+    monkeypatch, tmp_path
+):
+    logs: list[str] = []
+    monkeypatch.setattr("pinky_daemon.codex_session._log", logs.append)
+    session = _session(monkeypatch, tmp_path, mode="eof-after-acceptance")
+    receipt = asyncio.get_running_loop().create_future()
+    acceptance_order: list[bool] = []
+
+    def persist_exact_fire() -> bool:
+        acceptance_order.append(receipt.done())
+        return True
+
+    started = time.monotonic()
+    first = await asyncio.wait_for(
+        session._exec_codex_app_server(
+            "accepted then eof",
+            scheduler_delivery=receipt,
+            scheduler_accept=persist_exact_fire,
+        ),
+        timeout=1,
+    )
+    elapsed = time.monotonic() - started
+
+    assert elapsed < 1
+    assert first.failed is True
+    assert first.errors == ["app-server transport closed: connection closed"]
+    assert acceptance_order == [False]
+    assert await receipt is True
+    assert session._app_client is None
+    assert session._app_proc is None
+    assert any(
+        "app_server_transport_closed agent=phase1-agent active_turn=true" in line
+        for line in logs
+    )
+
+    # The failed transport was fully cleared. A later turn gets a fresh child
+    # and retains the existing respawn-on-next-turn behavior.
+    session._app_server_command = (
+        sys.executable,
+        str(_FAKE),
+        "--mode",
+        "happy",
+    )
+    second = await asyncio.wait_for(
+        session._exec_codex_app_server("fresh child"), timeout=1
+    )
+    assert second.failed is False
+    assert second.text_parts == ["fake app-server reply"]
+    assert session.stats["app_server_counters"] == {
+        "turns_ok": 1,
+        "turns_failed": 1,
+        "respawns": 1,
+    }
+    await session._teardown_app_server()
+
+
+@pytest.mark.asyncio
 async def test_child_exit_after_turn_respawns_on_next_turn(monkeypatch, tmp_path):
     session = _session(monkeypatch, tmp_path, mode="exit-after-turn")
     try:

--- a/tests/test_codex_app_server_phase1.py
+++ b/tests/test_codex_app_server_phase1.py
@@ -309,6 +309,40 @@ async def test_stdout_eof_between_turns_with_live_process_respawns(
 
 
 @pytest.mark.asyncio
+async def test_backpressured_16mib_request_fails_on_eof_while_child_stays_live(
+    monkeypatch, tmp_path
+):
+    session = _session(monkeypatch, tmp_path, mode="backpressure-eof")
+    assert await session._ensure_app_server() is True
+    client = session._app_client
+    proc = session._app_proc
+    assert client is not None
+    assert proc is not None
+    # Leave headroom for serializing the 16 MiB JSON frame; the close still
+    # has to win well before this documented end-to-end deadline.
+    timeout = 0.5
+    started = time.monotonic()
+
+    try:
+        with pytest.raises(CodexAppServerError, match="connection closed"):
+            await asyncio.wait_for(
+                client.request(
+                    "backpressured",
+                    {"payload": "x" * (16 * 1024 * 1024)},
+                    timeout=timeout,
+                ),
+                timeout=timeout * 2,
+            )
+        elapsed = time.monotonic() - started
+
+        assert elapsed < timeout
+        assert proc.returncode is None
+        assert client._pending == {}
+    finally:
+        await session._teardown_app_server()
+
+
+@pytest.mark.asyncio
 async def test_stdout_eof_after_terminal_notification_respawns(
     monkeypatch, tmp_path
 ):

--- a/tests/test_codex_app_server_phase1.py
+++ b/tests/test_codex_app_server_phase1.py
@@ -1,0 +1,256 @@
+"""Phase-1 app-server safety regressions through the command-override fake."""
+
+from __future__ import annotations
+
+import asyncio
+import shlex
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+from pinky_daemon.codex_session import CodexSession, CodexTurnResult
+from pinky_daemon.streaming_session import StreamingSessionConfig
+from pinky_daemon.transport_state import SessionState
+
+_FAKE = Path(__file__).with_name("_fake_app_server.py")
+
+
+async def _noop() -> None:
+    return None
+
+
+def _session(
+    monkeypatch,
+    tmp_path: Path,
+    *,
+    mode: str,
+    agent_name: str = "phase1-agent",
+    init_timeout: float = 0.2,
+) -> CodexSession:
+    working_dir = tmp_path / agent_name
+    working_dir.mkdir()
+    monkeypatch.delenv("PINKY_CODEX_APP_SERVER", raising=False)
+    monkeypatch.setenv("PINKY_CODEX_APP_SERVER_AGENTS", agent_name)
+    monkeypatch.setenv("PINKY_CODEX_APP_SERVER_INIT_TIMEOUT", str(init_timeout))
+    monkeypatch.setenv(
+        "PINKY_CODEX_APP_SERVER_CMD",
+        shlex.join([sys.executable, str(_FAKE), "--mode", mode]),
+    )
+    session = CodexSession(
+        StreamingSessionConfig(
+            agent_name=agent_name,
+            label="main",
+            working_dir=str(working_dir),
+            provider_url="codex_cli",
+            provider_key="test-key",
+        )
+    )
+    # connect() should exercise only substrate/state behavior in these tests.
+    session._start_worker = lambda: None  # type: ignore[assignment]
+    session._enqueue_wake = _noop  # type: ignore[assignment]
+    session._analytics_session_started = lambda: None  # type: ignore[assignment]
+    return session
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("mode", "reason"),
+    [
+        ("hang-init", "timeout"),
+        ("error-init", "error"),
+        ("die-pre-init", "error"),
+    ],
+)
+async def test_init_failure_degrades_to_exec_without_terminalizing(
+    monkeypatch, tmp_path, mode, reason
+):
+    logs: list[str] = []
+    monkeypatch.setattr("pinky_daemon.codex_session._log", logs.append)
+    session = _session(monkeypatch, tmp_path, mode=mode)
+
+    await asyncio.wait_for(session.connect(), timeout=1)
+
+    assert session.state == SessionState.CONNECTED
+    assert session._use_app_server is False
+    assert session._app_server_degraded is True
+    assert session._app_client is None
+    assert session._app_proc is None
+    assert session.stats["app_server_mode"] == "degraded_exec"
+    assert any(
+        f"app_server_init_failed reason={reason} agent=phase1-agent" in line
+        for line in logs
+    )
+    assert any("app_server_degraded_to_exec agent=phase1-agent" in line for line in logs)
+
+
+@pytest.mark.asyncio
+async def test_init_failure_delivers_same_turn_via_exec(monkeypatch, tmp_path):
+    session = _session(
+        monkeypatch, tmp_path, mode="hang-init", init_timeout=0.1
+    )
+    legacy_prompts: list[str] = []
+
+    async def fake_exec(prompt: str, **_kwargs) -> CodexTurnResult:
+        legacy_prompts.append(prompt)
+        return CodexTurnResult(text_parts=["legacy reply"])
+
+    session._exec_codex = fake_exec  # type: ignore[assignment]
+    result = await asyncio.wait_for(
+        session._exec_codex_app_server("keep working"), timeout=1
+    )
+
+    assert legacy_prompts == ["keep working"]
+    assert result.text_parts == ["legacy reply"]
+    assert result.failed is False
+    assert session._use_app_server is False
+    assert session._app_server_degraded is True
+
+
+@pytest.mark.asyncio
+async def test_hung_init_does_not_convoy_a_second_session(monkeypatch, tmp_path):
+    slow = _session(
+        monkeypatch,
+        tmp_path,
+        mode="hang-init",
+        agent_name="slow-agent",
+        init_timeout=0.4,
+    )
+    slow_task = asyncio.create_task(slow.connect())
+    for _ in range(100):
+        if slow._app_proc is not None:
+            break
+        await asyncio.sleep(0.005)
+    assert slow._app_proc is not None
+
+    fast = _session(
+        monkeypatch,
+        tmp_path,
+        mode="happy",
+        agent_name="fast-agent",
+        init_timeout=0.4,
+    )
+    started = time.monotonic()
+    await asyncio.wait_for(fast.connect(), timeout=1)
+    elapsed = time.monotonic() - started
+
+    assert elapsed < 0.4
+    assert fast.state == SessionState.CONNECTED
+    assert fast._use_app_server is True
+    await asyncio.wait_for(slow_task, timeout=1)
+    assert slow.state == SessionState.CONNECTED
+    assert slow._app_server_degraded is True
+    await fast._teardown_app_server()
+
+
+@pytest.mark.asyncio
+async def test_serialized_boot_convoy_is_capped_by_init_bound(monkeypatch, tmp_path):
+    slow = _session(
+        monkeypatch,
+        tmp_path,
+        mode="hang-init",
+        agent_name="serialized-slow",
+        init_timeout=0.15,
+    )
+    fast = _session(
+        monkeypatch,
+        tmp_path,
+        mode="happy",
+        agent_name="serialized-fast",
+        init_timeout=0.15,
+    )
+
+    started = time.monotonic()
+    await slow.connect()
+    await fast.connect()
+    elapsed = time.monotonic() - started
+
+    assert elapsed < 0.5
+    assert slow._app_server_degraded is True
+    assert fast.state == SessionState.CONNECTED
+    await fast._teardown_app_server()
+
+
+@pytest.mark.asyncio
+async def test_happy_0144_turn_and_counters(monkeypatch, tmp_path):
+    session = _session(monkeypatch, tmp_path, mode="happy")
+    try:
+        assert await session._ensure_app_server() is True
+        result = await asyncio.wait_for(
+            session._exec_codex_app_server("hello"), timeout=1
+        )
+        assert result.failed is False
+        assert result.text_parts == ["fake app-server reply"]
+        assert session.codex_session_id.startswith("fake-thread-")
+        assert session.stats["app_server_counters"] == {
+            "turns_ok": 1,
+            "turns_failed": 0,
+            "respawns": 0,
+        }
+    finally:
+        await session._teardown_app_server()
+
+
+@pytest.mark.asyncio
+async def test_error_notification_terminally_resolves_turn(monkeypatch, tmp_path):
+    session = _session(monkeypatch, tmp_path, mode="error-notification")
+    try:
+        assert await session._ensure_app_server() is True
+        result = await asyncio.wait_for(
+            session._exec_codex_app_server("fail tightly"), timeout=1
+        )
+        assert result.failed is True
+        assert result.errors == ["scripted terminal error"]
+        assert session.stats["app_server_counters"]["turns_failed"] == 1
+    finally:
+        await session._teardown_app_server()
+
+
+@pytest.mark.asyncio
+async def test_child_exit_after_turn_respawns_on_next_turn(monkeypatch, tmp_path):
+    session = _session(monkeypatch, tmp_path, mode="exit-after-turn")
+    try:
+        first = await asyncio.wait_for(
+            session._exec_codex_app_server("first"), timeout=1
+        )
+        assert first.failed is False
+        first_proc = session._app_proc
+        assert first_proc is not None
+        await asyncio.wait_for(first_proc.wait(), timeout=1)
+
+        second = await asyncio.wait_for(
+            session._exec_codex_app_server("second"), timeout=1
+        )
+        assert second.failed is False
+        assert session.stats["app_server_counters"] == {
+            "turns_ok": 2,
+            "turns_failed": 0,
+            "respawns": 1,
+        }
+    finally:
+        await session._teardown_app_server()
+
+
+@pytest.mark.asyncio
+async def test_flag_off_never_enters_app_server_bringup(monkeypatch, tmp_path):
+    monkeypatch.delenv("PINKY_CODEX_APP_SERVER", raising=False)
+    monkeypatch.delenv("PINKY_CODEX_APP_SERVER_AGENTS", raising=False)
+    # Malformed app-server-only knobs must be inert while selection is off.
+    monkeypatch.setenv("PINKY_CODEX_APP_SERVER_INIT_TIMEOUT", "not-a-number")
+    monkeypatch.setenv("PINKY_CODEX_APP_SERVER_CMD", "'unterminated")
+    session = CodexSession(
+        StreamingSessionConfig(
+            agent_name="off-agent",
+            working_dir=str(tmp_path),
+            provider_url="codex_cli",
+        )
+    )
+
+    async def forbidden() -> bool:  # pragma: no cover - must stay untouched
+        raise AssertionError("flag-off path touched app-server")
+
+    session._ensure_app_server = forbidden  # type: ignore[assignment]
+    await session._bring_up_substrate()
+    assert session._use_app_server is False
+    assert "app_server_mode" not in session.stats

--- a/tests/test_codex_app_server_phase1.py
+++ b/tests/test_codex_app_server_phase1.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 import pytest
 
+from pinky_daemon.codex_app_server import CodexAppServerError
 from pinky_daemon.codex_session import CodexSession, CodexTurnResult
 from pinky_daemon.streaming_session import StreamingSessionConfig
 from pinky_daemon.transport_state import SessionState
@@ -260,6 +261,94 @@ async def test_child_eof_after_acceptance_fails_promptly_and_respawns(
     assert session.stats["app_server_counters"] == {
         "turns_ok": 1,
         "turns_failed": 1,
+        "respawns": 1,
+    }
+    await session._teardown_app_server()
+
+
+@pytest.mark.asyncio
+async def test_stdout_eof_between_turns_with_live_process_respawns(
+    monkeypatch, tmp_path
+):
+    logs: list[str] = []
+    monkeypatch.setattr("pinky_daemon.codex_session._log", logs.append)
+    session = _session(monkeypatch, tmp_path, mode="eof-between-turns")
+
+    assert await session._ensure_app_server() is True
+    old_client = session._app_client
+    old_proc = session._app_proc
+    assert old_client is not None
+    assert old_proc is not None
+    for _ in range(100):
+        if old_client.is_closed:
+            break
+        await asyncio.sleep(0.005)
+
+    assert old_client.is_closed is True
+    assert old_proc.returncode is None
+    with pytest.raises(CodexAppServerError, match="connection closed"):
+        await asyncio.wait_for(old_client.request("thread/start"), timeout=0.05)
+    assert old_client._pending == {}
+    assert sum("app_server_transport_closed" in line for line in logs) == 1
+    assert any("active_turn=false" in line for line in logs)
+
+    session._app_server_command = (
+        sys.executable,
+        str(_FAKE),
+        "--mode",
+        "happy",
+    )
+    result = await asyncio.wait_for(
+        session._exec_codex_app_server("replacement succeeds"), timeout=1
+    )
+    assert result.failed is False
+    assert result.text_parts == ["fake app-server reply"]
+    assert session._app_client is not old_client
+    assert session.stats["app_server_counters"]["respawns"] == 1
+    await session._teardown_app_server()
+
+
+@pytest.mark.asyncio
+async def test_stdout_eof_after_terminal_notification_respawns(
+    monkeypatch, tmp_path
+):
+    logs: list[str] = []
+    monkeypatch.setattr("pinky_daemon.codex_session._log", logs.append)
+    session = _session(monkeypatch, tmp_path, mode="eof-after-terminal")
+
+    first = await asyncio.wait_for(
+        session._exec_codex_app_server("complete then eof"), timeout=1
+    )
+    assert first.failed is False
+    old_client = session._app_client
+    old_proc = session._app_proc
+    assert old_client is not None
+    assert old_proc is not None
+    for _ in range(100):
+        if old_client.is_closed:
+            break
+        await asyncio.sleep(0.005)
+
+    assert old_client.is_closed is True
+    assert old_proc.returncode is None
+    assert sum("app_server_transport_closed" in line for line in logs) == 1
+    assert any("active_turn=false" in line for line in logs)
+
+    session._app_server_command = (
+        sys.executable,
+        str(_FAKE),
+        "--mode",
+        "happy",
+    )
+    second = await asyncio.wait_for(
+        session._exec_codex_app_server("fresh after terminal eof"), timeout=1
+    )
+    assert second.failed is False
+    assert second.text_parts == ["fake app-server reply"]
+    assert session._app_client is not old_client
+    assert session.stats["app_server_counters"] == {
+        "turns_ok": 2,
+        "turns_failed": 0,
         "respawns": 1,
     }
     await session._teardown_app_server()

--- a/tests/test_codex_session.py
+++ b/tests/test_codex_session.py
@@ -1499,6 +1499,113 @@ class TestCodexAppServerTurn:
         assert result.interrupted is False
         assert result.errors == ["turn/completed reported inProgress"]
 
+    @pytest.mark.parametrize(
+        ("notifications", "expected_failed", "expected_errors", "expected_tokens"),
+        [
+            (
+                [("error", {
+                    "threadId": "thr-1",
+                    "turnId": "t1",
+                    "willRetry": False,
+                    "error": {"message": "scripted terminal error"},
+                })],
+                True,
+                ["scripted terminal error"],
+                0,
+            ),
+            (
+                [
+                    ("thread/tokenUsage/updated", {"tokenUsage": {"last": {
+                        "inputTokens": 7,
+                        "outputTokens": 3,
+                        "cachedInputTokens": 2,
+                        "reasoningOutputTokens": 1,
+                    }}}),
+                    ("turn/completed", {
+                        "threadId": "thr-1",
+                        "turn": {"id": "t1", "status": "completed"},
+                    }),
+                ],
+                False,
+                [],
+                3,
+            ),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_terminal_turn_does_not_wait_for_blocked_stream_callback(
+        self,
+        notifications,
+        expected_failed,
+        expected_errors,
+        expected_tokens,
+    ):
+        s = _appserver_session()
+        callback_started = asyncio.Event()
+        release_callback = asyncio.Event()
+        callback_completed = asyncio.Event()
+
+        async def blocked_terminal_callback(event: dict) -> None:
+            if event["type"] not in {"turn_failed", "turn_completed"}:
+                return
+            callback_started.set()
+            await release_callback.wait()
+            callback_completed.set()
+
+        s._stream_event_callback = blocked_terminal_callback
+        fake = _FakeAppClient(s, notifications)
+        _patch_ensure(s, fake)
+
+        result = await asyncio.wait_for(
+            s._exec_codex_app_server("terminal callback must not gate"),
+            timeout=0.25,
+        )
+
+        assert result.failed is expected_failed
+        assert result.errors == expected_errors
+        assert result.output_tokens == expected_tokens
+        await asyncio.wait_for(callback_started.wait(), timeout=0.25)
+        assert callback_completed.is_set() is False
+
+        release_callback.set()
+        await asyncio.wait_for(callback_completed.wait(), timeout=0.25)
+
+    @pytest.mark.asyncio
+    async def test_stuck_terminal_stream_callback_is_loudly_abandoned(
+        self, monkeypatch
+    ):
+        logs: list[str] = []
+        monkeypatch.setattr("pinky_daemon.codex_session._log", logs.append)
+        monkeypatch.setattr(
+            "pinky_daemon.codex_session.APP_SERVER_TERMINAL_STREAM_TIMEOUT",
+            0.01,
+        )
+        s = _appserver_session()
+        callback_cancelled = asyncio.Event()
+
+        async def stuck_callback(_event: dict) -> None:
+            try:
+                await asyncio.Event().wait()
+            finally:
+                callback_cancelled.set()
+
+        s._stream_event_callback = stuck_callback
+        fake = _FakeAppClient(
+            s, [("turn/completed", {"turn": {"status": "completed"}})]
+        )
+        _patch_ensure(s, fake)
+
+        result = await asyncio.wait_for(
+            s._exec_codex_app_server("abandon stuck callback"), timeout=0.25
+        )
+        assert result.failed is False
+        await asyncio.wait_for(callback_cancelled.wait(), timeout=0.25)
+        assert any(
+            "app_server_terminal_stream_abandoned "
+            "agent=test-agent type=turn_completed timeout_s=0.01" in line
+            for line in logs
+        )
+
     @pytest.mark.asyncio
     async def test_connect_failure_returns_failed_result(self):
         s = _appserver_session()
@@ -1741,6 +1848,9 @@ class TestCodexStateMachine:
             def __init__(self):
                 self.closed = False
 
+            def set_transport_closed_handler(self, handler):
+                self.transport_closed_handler = handler
+
             async def initialize(self, **kw):
                 raise RuntimeError("initialize boom")
 
@@ -1775,6 +1885,9 @@ class TestCodexStateMachine:
         init_calls: list = []
 
         class _OkClient:
+            def set_transport_closed_handler(self, handler):
+                self.transport_closed_handler = handler
+
             async def initialize(self, **kw):
                 init_calls.append(True)
 

--- a/tests/test_codex_session.py
+++ b/tests/test_codex_session.py
@@ -1724,6 +1724,157 @@ class TestCodexAppServerTurn:
         assert s._appserver_terminal_stream_tasks == set()
 
     @pytest.mark.asyncio
+    async def test_terminal_generation_churn_drops_stale_without_waiting_for_survivor(
+        self, monkeypatch
+    ):
+        logs: list[str] = []
+        monkeypatch.setattr("pinky_daemon.codex_session._log", logs.append)
+        monkeypatch.setattr(
+            "pinky_daemon.codex_session.APP_SERVER_TERMINAL_STREAM_TIMEOUT",
+            0.01,
+        )
+        s = _appserver_session()
+        old_started = asyncio.Event()
+        cancellation_seen = asyncio.Event()
+        release_old = asyncio.Event()
+        old_finished = asyncio.Event()
+        newest_started = asyncio.Event()
+        repeated_newest_started = asyncio.Event()
+        starts: list[int] = []
+
+        async def terminal_callback(event: dict) -> None:
+            sequence = event["sequence"]
+            starts.append(sequence)
+            if sequence == 0:
+                old_started.set()
+                try:
+                    await asyncio.Event().wait()
+                except asyncio.CancelledError:
+                    cancellation_seen.set()
+                    await release_old.wait()
+                finally:
+                    old_finished.set()
+            elif sequence == 5:
+                newest_started.set()
+            elif sequence == 12:
+                repeated_newest_started.set()
+
+        s._stream_event_callback = terminal_callback
+        s._schedule_appserver_terminal_stream_event(
+            {"type": "turn_completed", "sequence": 0}
+        )
+        await asyncio.wait_for(old_started.wait(), timeout=0.25)
+        try:
+            for sequence in range(1, 6):
+                s._schedule_appserver_terminal_stream_event(
+                    {"type": "turn_completed", "sequence": sequence}
+                )
+
+            # One dispatcher/current callback plus one resistant survivor is the
+            # ceiling; queued wrapper chains must not grow with event churn.
+            assert len(s._appserver_terminal_stream_tasks) <= 2
+            await asyncio.wait_for(cancellation_seen.wait(), timeout=0.25)
+            await asyncio.wait_for(newest_started.wait(), timeout=0.05)
+            assert starts == [0, 5]
+
+            for sequence in range(6, 13):
+                s._schedule_appserver_terminal_stream_event(
+                    {"type": "turn_completed", "sequence": sequence}
+                )
+
+            assert len(s._appserver_terminal_stream_tasks) <= 2
+            await asyncio.wait_for(repeated_newest_started.wait(), timeout=0.05)
+            assert starts == [0, 5, 12]
+            assert sum("app_server_stale_terminal_dropped" in line for line in logs) >= 10
+
+            s._report_appserver_terminal_stream_survivors(phase="generation-test")
+            assert any(
+                "app_server_terminal_stream_survivors "
+                "agent=test-agent phase=generation-test count=1" in line
+                for line in logs
+            )
+        finally:
+            release_old.set()
+            await asyncio.wait_for(old_finished.wait(), timeout=0.25)
+            for _ in range(20):
+                if not s._appserver_terminal_stream_tasks:
+                    break
+                await asyncio.sleep(0)
+
+        assert s._appserver_terminal_stream_tasks == set()
+
+    @pytest.mark.asyncio
+    async def test_terminal_survivor_limit_caps_resistant_callback_churn(
+        self, monkeypatch
+    ):
+        logs: list[str] = []
+        monkeypatch.setattr("pinky_daemon.codex_session._log", logs.append)
+        monkeypatch.setattr(
+            "pinky_daemon.codex_session.APP_SERVER_TERMINAL_STREAM_TIMEOUT",
+            0.01,
+        )
+        s = _appserver_session()
+        release_all = asyncio.Event()
+        two_cancelled = asyncio.Event()
+        starts: list[int] = []
+        cancelled: list[int] = []
+
+        async def resistant_callback(event: dict) -> None:
+            sequence = event["sequence"]
+            starts.append(sequence)
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                cancelled.append(sequence)
+                if len(cancelled) == 2:
+                    two_cancelled.set()
+                await release_all.wait()
+
+        s._stream_event_callback = resistant_callback
+        try:
+            s._schedule_appserver_terminal_stream_event(
+                {"type": "turn_completed", "sequence": 0}
+            )
+            for _ in range(20):
+                if starts:
+                    break
+                await asyncio.sleep(0)
+
+            for sequence in range(1, 6):
+                s._schedule_appserver_terminal_stream_event(
+                    {"type": "turn_completed", "sequence": sequence}
+                )
+
+            await asyncio.wait_for(two_cancelled.wait(), timeout=0.1)
+            assert starts == [0, 5]
+            assert len(s._appserver_terminal_stream_tasks) == 2
+
+            for sequence in range(6, 13):
+                s._schedule_appserver_terminal_stream_event(
+                    {"type": "turn_completed", "sequence": sequence}
+                )
+            for _ in range(20):
+                await asyncio.sleep(0)
+
+            # Two truthfully retained survivors are the hard ceiling. The next
+            # high-water generation is dropped immediately and loudly.
+            assert starts == [0, 5]
+            assert len(s._appserver_terminal_stream_tasks) == 2
+            assert any(
+                "app_server_stale_terminal_dropped " in line
+                and "generation=13 reason=survivor_limit live_callbacks=2" in line
+                for line in logs
+            )
+        finally:
+            release_all.set()
+            for _ in range(20):
+                if not s._appserver_terminal_stream_tasks:
+                    break
+                await asyncio.sleep(0)
+
+        assert s._appserver_terminal_stream_tasks == set()
+
+    @pytest.mark.asyncio
     async def test_connect_failure_returns_failed_result(self):
         s = _appserver_session()
 

--- a/tests/test_codex_session.py
+++ b/tests/test_codex_session.py
@@ -1111,6 +1111,7 @@ def _patch_ensure(session, fake):
 class TestCodexAppServerFlag:
     def test_flag_off_by_default(self, monkeypatch):
         monkeypatch.delenv("PINKY_CODEX_APP_SERVER", raising=False)
+        monkeypatch.delenv("PINKY_CODEX_APP_SERVER_AGENTS", raising=False)
         config = StreamingSessionConfig(
             agent_name="a", working_dir="/tmp", provider_url="codex_cli",
         )
@@ -1122,6 +1123,42 @@ class TestCodexAppServerFlag:
             agent_name="a", working_dir="/tmp", provider_url="codex_cli",
         )
         assert CodexSession(config)._use_app_server is True
+
+    def test_allowlist_member_is_on(self, monkeypatch):
+        monkeypatch.delenv("PINKY_CODEX_APP_SERVER", raising=False)
+        monkeypatch.setenv("PINKY_CODEX_APP_SERVER_AGENTS", " other, a ")
+        config = StreamingSessionConfig(
+            agent_name="a", working_dir="/tmp", provider_url="codex_cli",
+        )
+        session = CodexSession(config)
+        assert session._use_app_server is True
+        assert session._app_server_source == "allowlist"
+
+    def test_allowlist_nonmember_is_off(self, monkeypatch):
+        monkeypatch.delenv("PINKY_CODEX_APP_SERVER", raising=False)
+        monkeypatch.setenv("PINKY_CODEX_APP_SERVER_AGENTS", "other")
+        config = StreamingSessionConfig(
+            agent_name="a", working_dir="/tmp", provider_url="codex_cli",
+        )
+        assert CodexSession(config)._use_app_server is False
+
+    def test_allowlist_match_is_case_sensitive(self, monkeypatch):
+        monkeypatch.delenv("PINKY_CODEX_APP_SERVER", raising=False)
+        monkeypatch.setenv("PINKY_CODEX_APP_SERVER_AGENTS", "A")
+        config = StreamingSessionConfig(
+            agent_name="a", working_dir="/tmp", provider_url="codex_cli",
+        )
+        assert CodexSession(config)._use_app_server is False
+
+    def test_global_fallback_still_enables_nonmember(self, monkeypatch):
+        monkeypatch.setenv("PINKY_CODEX_APP_SERVER", "1")
+        monkeypatch.setenv("PINKY_CODEX_APP_SERVER_AGENTS", "other")
+        config = StreamingSessionConfig(
+            agent_name="a", working_dir="/tmp", provider_url="codex_cli",
+        )
+        session = CodexSession(config)
+        assert session._use_app_server is True
+        assert session._app_server_source == "global"
 
     @pytest.mark.asyncio
     async def test_exec_dispatches_to_app_server_when_flagged(self):
@@ -1203,9 +1240,24 @@ class TestCodexAppServerTranslation:
         )
         assert ev == {"type": "turn.failed", "error": {"message": "boom"}}
 
-    def test_error_notification(self):
+    def test_error_notification_maps_to_terminal_failure(self):
         ev = self._s()._appserver_to_event("error", {"error": {"message": "rate limited"}})
-        assert ev == {"type": "error", "message": "rate limited"}
+        assert ev == {"type": "turn.failed", "error": {"message": "rate limited"}}
+
+    def test_turn_completed_interrupted_is_distinct(self):
+        ev = self._s()._appserver_to_event(
+            "turn/completed", {"turn": {"status": "interrupted"}}
+        )
+        assert ev == {"type": "turn.interrupted"}
+
+    def test_turn_completed_in_progress_is_not_success(self):
+        ev = self._s()._appserver_to_event(
+            "turn/completed", {"turn": {"status": "inProgress"}}
+        )
+        assert ev == {
+            "type": "turn.failed",
+            "error": {"message": "turn/completed reported inProgress"},
+        }
 
     def test_unknown_method_returns_none(self):
         assert self._s()._appserver_to_event("thread/status/changed", {}) is None
@@ -1241,9 +1293,28 @@ class TestCodexAppServerApprovals:
         out = await self._s()._on_appserver_request("item/permissions/requestApproval", {})
         assert out == {"permissions": {}, "scope": "session"}
 
+    @pytest.mark.parametrize(
+        ("method", "expected"),
+        [
+            (
+                "account/chatgptAuthTokens/refresh",
+                {"accessToken": "", "chatgptAccountId": ""},
+            ),
+            ("item/tool/requestUserInput", {"answers": {}}),
+            ("mcpServer/elicitation/request", {"action": "decline"}),
+            ("item/tool/call", {"contentItems": [], "success": False}),
+            ("attestation/generate", {"token": ""}),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_0144_server_requests_return_schema_shaped_results(
+        self, method, expected
+    ):
+        assert await self._s()._on_appserver_request(method, {}) == expected
+
     @pytest.mark.asyncio
     async def test_unknown_request_returns_empty(self):
-        assert await self._s()._on_appserver_request("mcpServer/elicitation/request", {}) == {}
+        assert await self._s()._on_appserver_request("future/method", {}) == {}
 
 
 class TestCodexAppServerEffortAndConfig:
@@ -1396,6 +1467,37 @@ class TestCodexAppServerTurn:
         result = await s._exec_codex_app_server("boom")
         assert result.failed
         assert "rate limited" in result.errors[0]
+
+    @pytest.mark.asyncio
+    async def test_interrupted_turn_is_distinct_and_keeps_substrate(self):
+        s = _appserver_session()
+        notifications = [
+            ("thread/started", {"thread": {"id": "thr-1"}}),
+            ("turn/completed", {"turn": {"status": "interrupted"}}),
+        ]
+        fake = _FakeAppClient(s, notifications)
+        _patch_ensure(s, fake)
+
+        result = await s._exec_codex_app_server("stop")
+        assert result.failed is True
+        assert result.interrupted is True
+        assert result.errors == ["turn interrupted"]
+        assert s._app_client is fake
+
+    @pytest.mark.asyncio
+    async def test_in_progress_completion_resolves_as_failure(self):
+        s = _appserver_session()
+        fake = _FakeAppClient(
+            s, [("turn/completed", {"turn": {"status": "inProgress"}})]
+        )
+        _patch_ensure(s, fake)
+
+        result = await asyncio.wait_for(
+            s._exec_codex_app_server("do not hang"), timeout=1
+        )
+        assert result.failed is True
+        assert result.interrupted is False
+        assert result.errors == ["turn/completed reported inProgress"]
 
     @pytest.mark.asyncio
     async def test_connect_failure_returns_failed_result(self):
@@ -1593,31 +1695,24 @@ class TestCodexStateMachine:
         assert s.state == SessionState.CONNECTED
 
     @pytest.mark.asyncio
-    async def test_cold_connect_appserver_init_failure_dies_no_leak(self):
-        # App-server initialize failure during BOOT → BOOTING completes to DEAD,
-        # and the owner token is NOT leaked (a later resurrection can proceed).
+    async def test_cold_connect_appserver_init_failure_degrades_without_dead(self):
+        # An app-server initialize failure is bounded and degrades this session
+        # to legacy exec; it must not terminalize the agent.
         s = _appserver_session()
 
         async def failing_ensure():
-            raise RuntimeError("app-server init boom")
+            s._degrade_app_server(reason="error", error=RuntimeError("init boom"))
+            return False
 
         s._ensure_app_server = failing_ensure  # type: ignore[assignment]
-
-        with pytest.raises(RuntimeError):
-            await s.connect()
-        assert s.state == SessionState.DEAD
-        assert s._state_machine._in_flight is None, "owner token leaked on BOOT failure"
-
-        # No leak → resurrection works: DEAD → RECONNECTING → CONNECTED.
-        async def ok_ensure():
-            s._app_client = object()
-
-        s._ensure_app_server = ok_ensure  # type: ignore[assignment]
         s._start_worker = lambda: None  # type: ignore[assignment]
         s._enqueue_wake = _noop  # type: ignore[assignment]
         s._analytics_session_started = lambda: None  # type: ignore[assignment]
         await s.connect()
         assert s.state == SessionState.CONNECTED
+        assert s._use_app_server is False
+        assert s._app_server_degraded is True
+        assert s._state_machine._in_flight is None
 
     @pytest.mark.asyncio
     async def test_ensure_app_server_init_failure_is_atomic(self, monkeypatch):
@@ -1665,17 +1760,18 @@ class TestCodexStateMachine:
             "pinky_daemon.codex_session.spawn_app_server", fake_spawn_boom
         )
 
-        with pytest.raises(RuntimeError, match="initialize boom"):
-            await s._ensure_app_server()
+        assert await s._ensure_app_server() is False
 
         # Half-initialized substrate must be torn down, not cached.
         assert s._app_client is None
         assert s._app_proc is None
+        assert s._use_app_server is False
+        assert s._app_server_degraded is True
         assert boom_clients[0].closed is True, "client not closed on init failure"
         assert boom_procs[0].killed is True, "proc not killed on init failure"
 
-        # A later attempt must respawn AND re-run initialize — the guard must
-        # not short-circuit on the cleared (None) fields.
+        # A later reconnect cycle must re-enable, respawn, and re-run initialize.
+        s._begin_app_server_reconnect_cycle()
         init_calls: list = []
 
         class _OkClient:
@@ -1691,7 +1787,7 @@ class TestCodexStateMachine:
         monkeypatch.setattr(
             "pinky_daemon.codex_session.spawn_app_server", fake_spawn_ok
         )
-        await s._ensure_app_server()
+        assert await s._ensure_app_server() is True
         assert init_calls == [True], "initialization was skipped on reconnect"
         assert s._app_client is not None
         assert s._app_proc is not None

--- a/tests/test_codex_session.py
+++ b/tests/test_codex_session.py
@@ -1607,6 +1607,123 @@ class TestCodexAppServerTurn:
         )
 
     @pytest.mark.asyncio
+    async def test_terminal_stream_delivery_is_serialized_across_respawn(self):
+        s = _appserver_session()
+        old_started = asyncio.Event()
+        release_old = asyncio.Event()
+        both_delivered = asyncio.Event()
+        delivery_order: list[str] = []
+        callback_count = 0
+
+        async def terminal_callback(event: dict) -> None:
+            nonlocal callback_count
+            if event["type"] != "turn_completed":
+                return
+            callback_count += 1
+            generation = "old" if callback_count == 1 else "new"
+            if generation == "old":
+                old_started.set()
+                await release_old.wait()
+            delivery_order.append(generation)
+            if len(delivery_order) == 2:
+                both_delivered.set()
+
+        s._stream_event_callback = terminal_callback
+        clients = [
+            _FakeAppClient(
+                s, [("turn/completed", {"turn": {"status": "completed"}})]
+            ),
+            _FakeAppClient(
+                s, [("turn/completed", {"turn": {"status": "completed"}})]
+            ),
+        ]
+        ensure_calls = 0
+
+        async def replace_client() -> bool:
+            nonlocal ensure_calls
+            s._app_client = clients[ensure_calls]
+            ensure_calls += 1
+            return True
+
+        s._ensure_app_server = replace_client  # type: ignore[assignment]
+
+        first = await asyncio.wait_for(
+            s._exec_codex_app_server("old generation"), timeout=0.25
+        )
+        assert first.failed is False
+        await asyncio.wait_for(old_started.wait(), timeout=0.25)
+
+        second = await asyncio.wait_for(
+            s._exec_codex_app_server("new generation"), timeout=0.25
+        )
+        assert second.failed is False
+        await asyncio.sleep(0)
+        assert delivery_order != ["new"]
+
+        release_old.set()
+        await asyncio.wait_for(both_delivered.wait(), timeout=0.25)
+        assert delivery_order == ["old", "new"]
+
+    @pytest.mark.asyncio
+    async def test_cancellation_resistant_terminal_callback_remains_retained(
+        self, monkeypatch
+    ):
+        logs: list[str] = []
+        monkeypatch.setattr("pinky_daemon.codex_session._log", logs.append)
+        monkeypatch.setattr(
+            "pinky_daemon.codex_session.APP_SERVER_TERMINAL_STREAM_TIMEOUT",
+            0.01,
+        )
+        s = _appserver_session()
+        cancellation_seen = asyncio.Event()
+        release_cleanup = asyncio.Event()
+        callback_finished = asyncio.Event()
+
+        async def cancellation_resistant_callback(_event: dict) -> None:
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                cancellation_seen.set()
+                await release_cleanup.wait()
+            finally:
+                callback_finished.set()
+
+        s._stream_event_callback = cancellation_resistant_callback
+        fake = _FakeAppClient(
+            s, [("turn/completed", {"turn": {"status": "completed"}})]
+        )
+        _patch_ensure(s, fake)
+
+        result = await asyncio.wait_for(
+            s._exec_codex_app_server("do not gate on cleanup"), timeout=0.25
+        )
+        assert result.failed is False
+        await asyncio.wait_for(cancellation_seen.wait(), timeout=0.25)
+        assert any(
+            not task.done() for task in s._appserver_terminal_stream_tasks
+        )
+
+        await asyncio.wait_for(s._teardown_app_server(), timeout=0.05)
+        assert any(
+            "app_server_terminal_stream_survivors "
+            "agent=test-agent phase=teardown" in line
+            for line in logs
+        )
+        assert any(
+            "app_server_terminal_stream_abandoned "
+            "agent=test-agent type=turn_completed timeout_s=0.01" in line
+            for line in logs
+        )
+
+        release_cleanup.set()
+        await asyncio.wait_for(callback_finished.wait(), timeout=0.25)
+        for _ in range(10):
+            if not s._appserver_terminal_stream_tasks:
+                break
+            await asyncio.sleep(0)
+        assert s._appserver_terminal_stream_tasks == set()
+
+    @pytest.mark.asyncio
     async def test_connect_failure_returns_failed_result(self):
         s = _appserver_session()
 


### PR DESCRIPTION
## What

- gate app-server use by an exact per-agent allowlist while preserving the legacy global fallback; all flags remain default-off
- bound spawn plus initialize as one unit and degrade initialization failures to the existing exec path until the next reconnect cycle
- align the client with codex-cli 0.144 turn statuses, required server-request response shapes, and terminal error notifications
- add grep-stable lifecycle markers, counters on the existing session stats surface, and subprocess-fake regressions for initialization wedges, convoy bounds, lifecycle recovery, and flag-off invariance

## Why

The app-server path had two independent 600-second seams: an unbounded initialize during session bring-up and an error notification that did not resolve the active turn. The former could convoy serialized startup; the latter could strand an accepted turn. The global-only flag also did not support a controlled candidate rollout.

## Validation

- `212 passed` focused Codex transport/home slice
- `5046 passed, 4 skipped, 1 deselected` full locked suite; the sole deselection is the pre-existing real-transport test tracked in #1072
- `ruff check .`
- `python -m compileall -q src tests`
- `git diff --check`
- regenerated and audited the codex-cli 0.144.0 JSON schemas for every used request, response, and notification shape

Fixes #582
