### PR TITLE
Suppress implicit turn-final console delivery

### DIFF
--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -3195,12 +3195,6 @@ def create_api(
     async def _make_streaming_response_callback():
         """Create a response callback that routes through the broker."""
         async def _on_response(turn_result):
-            # #279: agent-to-agent reply auto-routing. If this completed turn was
-            # an injected agent message (platform == "agent"), deliver its text to
-            # the requesting agent via a one-way live inject and stop. Must run
-            # BEFORE the empty-chat_id early-return.
-            if await broker.route_agent_reply(comms, turn_result):
-                return
             if not turn_result.chat_id:
                 return
             agent = agents.get(turn_result.agent_name)
@@ -3759,7 +3753,6 @@ def create_api(
                 "transport-recovery",
                 target_agent,
                 instruction,
-                route_reply=False,
             )
             return outcome.delivered
 

--- a/src/pinky_daemon/broker.py
+++ b/src/pinky_daemon/broker.py
@@ -49,16 +49,6 @@ _APPROVAL_NOTIFY_RETRY_MAX_SEC = 30 * 60
 _APPROVAL_NOTIFY_MAX_ATTEMPTS = 5
 _APPROVAL_NOTIFY_POLL_SEC = 5
 
-# #279: agent-to-agent reply auto-routing. ``inject_agent_message`` stamps an
-# injected turn with ``platform == AGENT_REPLY_PLATFORM`` and ``chat_id`` = the
-# requester agent name; when that turn completes, ``route_agent_reply`` performs
-# a one-way live injection back to the requester. The return injection disables
-# reply routing so the exchange cannot ping-pong.
-AGENT_REPLY_PLATFORM = "agent"
-_AGENT_REPLY_ROUTING_ENABLED = os.environ.get(
-    "PINKY_AGENT_REPLY_ROUTING", "1"
-).strip().lower() not in ("0", "false", "no", "off")
-
 def _log(msg: str) -> None:
     print(msg, file=sys.stderr, flush=True)
 
@@ -1814,10 +1804,8 @@ class MessageBroker:
         from_agent: str,
         to_agent: str,
         message: str,
-        *,
-        route_reply: bool = True,
     ) -> InjectResult:
-        """Inject a message from one agent into another's streaming session.
+        """Explicitly inject one agent message into another live session.
 
         Returns an :class:`InjectResult`. ``confirmed`` is computed HERE, on
         the exact session object that performed the inject, in the same call:
@@ -1826,11 +1814,13 @@ class MessageBroker:
         This closes both halves of Murzik's #853 P1: a transport-static
         capability can't overrule a failed handoff (e.g. StreamingSession's
         swallowed ``client.query`` exception now returns handoff=False), and
-        there is no second session lookup that could race a session swap.
-        ``route_reply=False`` makes the injection one-way by omitting the
-        agent-reply routing sentinel. A transport that doesn't advertise the
-        confirmation capability never confirms, but a truthy per-call handoff
-        still counts as live delivery.
+        there is no second session lookup that could race a session swap. A
+        transport that doesn't advertise the confirmation capability never
+        confirms, but a truthy per-call handoff still counts as live delivery.
+
+        #1074: this operation is deliberately one-way. The recipient must use
+        an explicit ``send_to_agent`` call to reply; turn-final console text is
+        web-render-only and never receives route-back metadata here.
         """
         streaming = self._get_streaming_session(to_agent)
         if not streaming or streaming.state != SessionState.CONNECTED:
@@ -1842,17 +1832,7 @@ class MessageBroker:
         from datetime import timezone as tz
         ts = datetime.now(tz.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
         prompt = f"[agent | {from_agent} | internal | {ts}]\n{message}"
-        if _AGENT_REPLY_ROUTING_ENABLED and route_reply:
-            # #279: encode the requester as the route-back target so the
-            # recipient's completed turn auto-delivers live to the requester
-            # (see ``route_agent_reply``). The ``platform="agent"`` sentinel is
-            # intercepted in the response callback before normal platform
-            # routing; ``chat_id`` carries the requester agent name.
-            handoff = await streaming.send(
-                prompt, platform=AGENT_REPLY_PLATFORM, chat_id=from_agent
-            )
-        else:
-            handoff = await streaming.send(prompt)
+        handoff = await streaming.send(prompt)
         confirmed = bool(handoff) and bool(
             getattr(streaming, "injection_confirms_consumption", False)
         )
@@ -1892,7 +1872,14 @@ class MessageBroker:
         used_outreach: bool = False,
         fallback_enabled: bool = False,
     ) -> None:
-        """Deliver plain-text fallback for a completed turn when appropriate."""
+        """Finish per-chat bookkeeping without delivering turn-final text.
+
+        #1074 full suppression: completed-turn console prose is persisted by
+        the session's conversation store and rendered by the web UI. External
+        and internal chat delivery both require an explicit outreach tool.
+        ``fallback_enabled`` remains accepted for configuration compatibility,
+        but it can no longer authorize delivery.
+        """
         stripped = response.strip()
         _log(
             f"broker: route_response for {agent_name} ({platform}/{chat_id}): "
@@ -1902,101 +1889,21 @@ class MessageBroker:
         # Always stop the typing indicator when a turn completes
         if chat_id:
             self._stop_typing(agent_name, chat_id)
+            # A voice-origin marker is scoped to this completed turn. With
+            # implicit voice/plain-text replies removed it must still be
+            # retired here so it cannot bleed into a later explicit action.
+            self._voice_pending.pop((agent_name, chat_id), None)
 
         if used_outreach:
             _log(f"broker: {agent_name} handled turn via outreach tools")
             return
-        if not stripped or not fallback_enabled or not chat_id:
+        if not stripped:
             return
-
-        # Plain-text fallback is for INTERNAL / owner surfaces only — the web UI,
-        # API, and console. Owner rule (Brad, 2026-06-22): never auto-deliver an
-        # agent's bare plain text to an outreach channel (telegram/discord/slack),
-        # not even a 1:1 owner DM. When an agent stays silent it often "thinks
-        # out loud" (emits reasoning text without calling an outreach tool);
-        # pushing that to a real channel leaks internal deliberation (the
-        # Chekov-on-Slack leak) and trains lazy non-tool replies. To reach any
-        # external channel the agent MUST call an explicit pinky-messaging tool
-        # (send/thread). Errors still surface — they route back on their own
-        # paths (API-error content is suppressed upstream so raw error JSON never
-        # reaches chat; auth failures fire the operator alert), not through this
-        # fallback. (Supersedes the #810 1:1-DM allowance with a stricter
-        # fail-closed rule; the group-leak guard is subsumed — groups are
-        # external, so they're suppressed here too.)
-        _internal_surfaces = {"web", "api", ""}
-        if platform not in _internal_surfaces:
-            _log(
-                f"broker: suppressed plain-text fallback for {agent_name} on "
-                f"{platform}/{chat_id} — outreach channels are tool-only "
-                f"(fallback delivers to web UI / internal surfaces only)"
-            )
-            return
-
-        voice_key = (agent_name, chat_id)
-        if self._voice_pending.pop(voice_key, False):
-            sent_voice = await self._try_voice_reply(agent_name, platform, chat_id, stripped)
-            if not sent_voice:
-                await self._send_message(agent_name, platform, chat_id, stripped)
-        else:
-            await self._send_message(agent_name, platform, chat_id, stripped)
-
-    async def route_agent_reply(self, comms, turn_result) -> bool:
-        """Auto-deliver a completed agent-to-agent turn live to the requester.
-
-        #279: ``inject_agent_message`` stamps injected turns with
-        ``platform == AGENT_REPLY_PLATFORM`` and ``chat_id`` = the requester
-        agent name. When such a turn finishes, the recipient's turn text is
-        delivered by a one-way live injection. The reply is also stored in the
-        comms messages table for audit/thread history, with only read recipient
-        bookkeeping and no unread inbox state. The return injection sets
-        ``route_reply=False``, so it cannot trigger another auto-routed reply
-        and the exchange terminates.
-
-        Returns True when the turn was an agent reply (handled here, caller
-        should stop); False for normal platform turns so the caller falls
-        through to ``route_response``.
-        """
-        if not turn_result or turn_result.platform != AGENT_REPLY_PLATFORM:
-            return False
-        requester = (turn_result.chat_id or "").strip()
-        responder = (turn_result.agent_name or "").strip()
-        text = (turn_result.response_text or "").strip()
-        if not requester or not responder:
-            _log(
-                "broker: agent reply missing requester/responder "
-                f"(requester={requester!r} responder={responder!r}); dropping"
-            )
-            return True
-        if not text:
-            # A pure tool-call turn with no final text — nothing to relay.
-            _log(f"broker: agent reply {responder} -> {requester} had no text")
-            return True
-        try:
-            comms.send(responder, requester, text, metadata={"auto_routed": True})
-            delivered, _confirmed = await self.inject_agent_message(
-                responder, requester, text, route_reply=False
-            )
-            if not delivered:
-                _log(
-                    f"broker: auto-route agent reply {responder} -> {requester} "
-                    "failed: requester has no accepting live session"
-                )
-                return True
-            _log(
-                f"broker: auto-routed agent reply {responder} -> {requester} "
-                f"live ({len(text)} chars)"
-            )
-        except Exception as e:
-            # Delivery failed — count it so dropped replies are monitorable
-            # (the whole point of #279 is that agent replies don't vanish
-            # silently). Still return True: this WAS an agent-reply turn, so it
-            # must not fall through to route_response / get re-injected.
-            self._stats["routed_failed"] += 1
-            _log(
-                f"broker: auto-route agent reply {responder} -> {requester} "
-                f"failed: {e}"
-            )
-        return True
+        _log(
+            f"broker: SUPPRESSED_TURN_FINAL_TEXT for {agent_name} on "
+            f"{platform}/{chat_id} ({len(stripped)} chars) — web render only; "
+            "use an explicit outreach tool for delivery"
+        )
 
     # "file" is what Slack and Discord tag every inbound attachment as; the
     # rest are Telegram's media kinds. (Voice is handled separately.)

--- a/src/pinky_daemon/streaming_session.py
+++ b/src/pinky_daemon/streaming_session.py
@@ -655,10 +655,7 @@ class StreamingSession(TransportReplacementMixin):
 
         async def _send_wake_prompt() -> None:
             try:
-                await self._client.query(wake_prompt)
-                # Keep ResultMessage pops 1:1 with queries: the wake turn
-                # has no routing target, so enqueue an unrouted sentinel.
-                self._pending_chats.append(("", "", ""))
+                await self._query_unrouted(wake_prompt)
                 _log(
                     f"streaming[{self.agent_name}]: sent wake prompt "
                     f"(reason={wake_reason.value})"
@@ -762,6 +759,28 @@ class StreamingSession(TransportReplacementMixin):
             # Try to reconnect
             await self.attempt_reconnect()
             return False
+
+    async def _query_unrouted(self, prompt: str) -> None:
+        """Submit an internal prompt with boundary-safe bookkeeping.
+
+        The reservation must exist before ``query()`` makes its write visible
+        to the reader; otherwise a fast ResultMessage can complete first and
+        the subsequently appended sentinel becomes stale state for the next
+        turn. Failure removes only this exact reservation because concurrent
+        internal prompts have identical tuple values.
+        """
+        if not self._client:
+            raise RuntimeError("streaming client is unavailable")
+        reservation = ("", "", "")
+        self._pending_chats.append(reservation)
+        try:
+            await self._client.query(prompt)
+        except Exception:
+            for index, pending in enumerate(self._pending_chats):
+                if pending is reservation:
+                    self._pending_chats.pop(index)
+                    break
+            raise
 
     async def _reader_loop(self) -> None:
         """Background loop that reads responses and fires callbacks."""
@@ -919,11 +938,36 @@ class StreamingSession(TransportReplacementMixin):
                     if msg.num_turns and msg.num_turns > 0:
                         _log(f"streaming[{self.agent_name}]: result — turns={msg.num_turns}, cost=${msg.total_cost_usd or 0:.4f}, model_usage={msg.model_usage}")
 
-                    # Get the routing info for this response
-                    if self._pending_chats:
-                        resp_platform, resp_chat_id, resp_message_id = self._pending_chats.pop(0)
+                    # Snapshot and drain every reservation visible when this
+                    # turn boundary starts. The SDK may coalesce several
+                    # queued prompts into one turn/ResultMessage; pop-one left
+                    # the surplus route at the head for an unrelated later
+                    # turn (#1074). There is no await between the high-water
+                    # capture and deletion, so a reservation submitted after
+                    # boundary processing begins survives for the next turn.
+                    boundary_high_water = len(self._pending_chats)
+                    boundary_routes = self._pending_chats[:boundary_high_water]
+                    del self._pending_chats[:boundary_high_water]
+                    routed_boundary_routes = [
+                        route for route in boundary_routes if route[1]
+                    ]
+                    stale_route_count = max(0, boundary_high_water - 1)
+                    if stale_route_count:
+                        _log(
+                            f"streaming[{self.agent_name}]: "
+                            "TURN_BOUNDARY_STALE_ROUTE_DRAIN "
+                            f"stale_entries={stale_route_count} "
+                            f"total_entries={boundary_high_water} "
+                            f"routed_entries={len(routed_boundary_routes)}"
+                        )
+
+                    # A single reservation is unambiguous conversation-source
+                    # metadata. A coalesced turn is not; persist it without a
+                    # platform/chat attribution rather than choosing a lie.
+                    if boundary_high_water == 1:
+                        resp_platform, resp_chat_id, _ = boundary_routes[0]
                     else:
-                        resp_platform, resp_chat_id, resp_message_id = ("", "", "")
+                        resp_platform, resp_chat_id = ("", "")
 
                     # If the SDK reports an error result, discard _last_response — it may
                     # contain raw API error JSON (e.g. content filter, rate limit) that must
@@ -999,25 +1043,30 @@ class StreamingSession(TransportReplacementMixin):
                         # stop in broker.route_response) still runs. The
                         # suppressed content is never forwarded -- route_response
                         # no-ops on empty text.
-                        if self._response_callback and resp_chat_id:
-                            try:
-                                await self._response_callback(TurnResponse(
-                                    agent_name=self.agent_name,
-                                    session_id=self.id,
-                                    platform=resp_platform,
-                                    chat_id=resp_chat_id,
-                                    message_id=resp_message_id,
-                                    text="",
-                                    tool_uses=list(turn_tool_uses),
-                                    used_outreach_tools=any(
-                                        _is_outreach_tool(tool_use.get("tool", ""))
-                                        for tool_use in turn_tool_uses
-                                    ),
-                                    usage=msg.usage or {},
-                                    num_turns=msg.num_turns or 0,
-                                ))
-                            except Exception as e:
-                                _log(f"streaming[{self.agent_name}]: callback error: {e}")
+                        if self._response_callback:
+                            for (
+                                callback_platform,
+                                callback_chat_id,
+                                callback_message_id,
+                            ) in routed_boundary_routes:
+                                try:
+                                    await self._response_callback(TurnResponse(
+                                        agent_name=self.agent_name,
+                                        session_id=self.id,
+                                        platform=callback_platform,
+                                        chat_id=callback_chat_id,
+                                        message_id=callback_message_id,
+                                        text="",
+                                        tool_uses=list(turn_tool_uses),
+                                        used_outreach_tools=any(
+                                            _is_outreach_tool(tool_use.get("tool", ""))
+                                            for tool_use in turn_tool_uses
+                                        ),
+                                        usage=msg.usage or {},
+                                        num_turns=msg.num_turns or 0,
+                                    ))
+                                except Exception as e:
+                                    _log(f"streaming[{self.agent_name}]: callback error: {e}")
                         self._last_response = ""
                         self._current_activity = ""
                         self._activity_log = []
@@ -1036,35 +1085,44 @@ class StreamingSession(TransportReplacementMixin):
                             _notify_turn_idle(self._config, self.agent_name)
                         continue
 
-                    # Turn complete — fire response callback
-                    turn_result = TurnResponse(
-                        agent_name=self.agent_name,
-                        session_id=self.id,
-                        platform=resp_platform,
-                        chat_id=resp_chat_id,
-                        message_id=resp_message_id,
-                        text=self._last_response,
-                        tool_uses=list(turn_tool_uses),
-                        used_outreach_tools=any(
-                            _is_outreach_tool(tool_use.get("tool", ""))
-                            for tool_use in turn_tool_uses
-                        ),
-                        usage=msg.usage or {},
-                        total_cost_usd=msg.total_cost_usd or 0.0,
-                        num_turns=msg.num_turns or 0,
-                        model_usage=msg.model_usage or {},
-                    )
-
-                    # Fire whenever there's content OR a routing target: a
-                    # routed turn with no text/tools must still reach
-                    # broker.route_response so the typing indicator stops.
-                    if self._response_callback and (
-                        turn_result.response_text or turn_result.tool_uses or resp_chat_id
-                    ):
-                        try:
-                            await self._response_callback(turn_result)
-                        except Exception as e:
-                            _log(f"streaming[{self.agent_name}]: callback error: {e}")
+                    # Fire once per routed reservation so every typing/voice
+                    # marker is retired. With no route, fire one web-only
+                    # result when the turn has content/tools. route_response is
+                    # delivery-suppressed; explicit outreach tools have already
+                    # performed any authorized delivery.
+                    callback_routes = routed_boundary_routes or [("", "", "")]
+                    if self._response_callback:
+                        for (
+                            callback_platform,
+                            callback_chat_id,
+                            callback_message_id,
+                        ) in callback_routes:
+                            turn_result = TurnResponse(
+                                agent_name=self.agent_name,
+                                session_id=self.id,
+                                platform=callback_platform,
+                                chat_id=callback_chat_id,
+                                message_id=callback_message_id,
+                                text=self._last_response,
+                                tool_uses=list(turn_tool_uses),
+                                used_outreach_tools=any(
+                                    _is_outreach_tool(tool_use.get("tool", ""))
+                                    for tool_use in turn_tool_uses
+                                ),
+                                usage=msg.usage or {},
+                                total_cost_usd=msg.total_cost_usd or 0.0,
+                                num_turns=msg.num_turns or 0,
+                                model_usage=msg.model_usage or {},
+                            )
+                            if (
+                                turn_result.response_text
+                                or turn_result.tool_uses
+                                or callback_chat_id
+                            ):
+                                try:
+                                    await self._response_callback(turn_result)
+                                except Exception as e:
+                                    _log(f"streaming[{self.agent_name}]: callback error: {e}")
 
                     # A successful (non-errored) turn proves Claude auth is
                     # working again — clear any auth-fail tracking for this
@@ -1247,9 +1305,7 @@ class StreamingSession(TransportReplacementMixin):
                     f"or call context_restart when ready."
                 )
                 try:
-                    await self._client.query(warn_msg)
-                    # Unrouted system turn -- keep ResultMessage pops 1:1
-                    self._pending_chats.append(("", "", ""))
+                    await self._query_unrouted(warn_msg)
                     self._context_warned = True
                     _log(f"streaming[{self.agent_name}]: warned agent at {pct}% context")
                 except Exception as e:
@@ -1289,9 +1345,7 @@ class StreamingSession(TransportReplacementMixin):
             f"{detail} Use save_my_context() now, then retry once you've saved your latest work."
         )
         try:
-            await self._client.query(warn_msg)
-            # Unrouted system turn -- keep ResultMessage pops 1:1
-            self._pending_chats.append(("", "", ""))
+            await self._query_unrouted(warn_msg)
         except Exception:
             pass
 
@@ -1384,9 +1438,7 @@ class StreamingSession(TransportReplacementMixin):
         sends_before = self._stats["messages_sent"]
         try:
             self._turn_done.clear()
-            await self._client.query(build_idle_sleep_prompt())
-            # Unrouted system turn -- keep ResultMessage pops 1:1
-            self._pending_chats.append(("", "", ""))
+            await self._query_unrouted(build_idle_sleep_prompt())
             _log(f"streaming[{self.agent_name}]: memory save prompt sent before idle sleep")
             # query() returns as soon as the prompt hits the transport; it
             # does NOT wait for the turn. Give the save turn a bounded

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -414,9 +414,9 @@ class TestMessageBrokerRouting:
             tmpdir.cleanup()
 
     @pytest.mark.asyncio
-    async def test_route_response_allows_fallback_on_api_surface(self):
-        # Internal surfaces (web/api/console) keep the fallback convenience and
-        # need no message context — they're owner-only, never public channels.
+    async def test_route_response_suppresses_fallback_on_api_surface(self):
+        # #1074: turn-final console prose is already persisted for the web UI;
+        # route_response is bookkeeping-only even for internal/API surfaces.
         tmpdir, _, broker, sent_messages, _ = self._make_broker()
         try:
             await broker.route_response(
@@ -428,9 +428,7 @@ class TestMessageBrokerRouting:
                 fallback_enabled=True,
             )
 
-            assert sent_messages == [
-                ("barsik", "api", "api", "api console reply via fallback"),
-            ]
+            assert sent_messages == []
         finally:
             tmpdir.cleanup()
 
@@ -490,9 +488,9 @@ class TestMessageBrokerRouting:
             tmpdir.cleanup()
 
     @pytest.mark.asyncio
-    async def test_route_response_allows_fallback_on_web_without_context(self):
-        # Owner-only surfaces (web/api/internal) are never public channels and
-        # carry no message context — the fallback convenience is preserved.
+    async def test_route_response_suppresses_fallback_on_web_without_context(self):
+        # #1074: the conversation store is the web render path. Sending the
+        # same console prose through the broker would create a second delivery.
         tmpdir, _, broker, sent_messages, _ = self._make_broker()
         try:
             await broker.route_response(
@@ -504,9 +502,41 @@ class TestMessageBrokerRouting:
                 fallback_enabled=True,
             )
 
-            assert sent_messages == [
-                ("barsik", "web", "web", "web console reply via fallback"),
-            ]
+            assert sent_messages == []
+        finally:
+            tmpdir.cleanup()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "platform",
+        ["telegram", "discord", "slack", "ferry", "agent", "api", "web", ""],
+    )
+    async def test_route_response_never_delivers_turn_final_console_text(
+        self, platform
+    ):
+        """#1074: explicit outreach tools are the only delivery path.
+
+        The turn-completion callback must still stop typing and retire voice
+        bookkeeping, but it must not send console prose on any surface.
+        """
+        tmpdir, _, broker, sent_messages, _ = self._make_broker()
+        try:
+            stopped: list[tuple[str, str]] = []
+            broker._stop_typing = lambda agent, chat: stopped.append((agent, chat))
+            broker._voice_pending[("barsik", "chat-1")] = True
+
+            await broker.route_response(
+                "barsik",
+                platform,
+                "chat-1",
+                "turn-final console narration",
+                used_outreach=False,
+                fallback_enabled=True,
+            )
+
+            assert sent_messages == []
+            assert stopped == [("barsik", "chat-1")]
+            assert ("barsik", "chat-1") not in broker._voice_pending
         finally:
             tmpdir.cleanup()
 
@@ -550,9 +580,9 @@ class TestMessageBrokerRouting:
             tmpdir.cleanup()
 
     @pytest.mark.asyncio
-    async def test_inject_agent_message_stamps_reply_routing_metadata(self):
-        """#279: an injected agent message carries platform='agent' + chat_id=
-        the requester, so the recipient's completed turn can route back."""
+    async def test_inject_agent_message_is_explicit_one_way(self):
+        """#1074: explicit agent packets remain live, but never stamp a route
+        for the recipient's later console text to travel back on."""
         tmpdir, registry, broker, _, _ = self._make_broker()
         try:
             from pinky_daemon.transport_state import SessionState
@@ -569,17 +599,15 @@ class TestMessageBrokerRouting:
             broker.register_streaming("barsik", _FakeStreaming(), label="main")
             delivered, _ = await broker.inject_agent_message("pushok", "barsik", "review please")
             assert delivered is True
-            assert recorded == [("agent", "pushok")]
+            assert recorded == [("", "")]
         finally:
             tmpdir.cleanup()
 
     @pytest.mark.asyncio
-    async def test_inject_agent_message_respects_routing_killswitch(self, monkeypatch):
-        """With PINKY_AGENT_REPLY_ROUTING off, no route-back metadata is stamped —
-        reverts to the legacy (drop-on-empty-chat_id) behavior."""
-        import pinky_daemon.broker as broker_mod
-
-        monkeypatch.setattr(broker_mod, "_AGENT_REPLY_ROUTING_ENABLED", False)
+    async def test_inject_agent_message_has_no_auto_route_opt_in(self, monkeypatch):
+        """Full suppression has no environment switch that can resurrect the
+        removed auto-route channel."""
+        monkeypatch.setenv("PINKY_AGENT_REPLY_ROUTING", "1")
         tmpdir, registry, broker, _, _ = self._make_broker()
         try:
             from pinky_daemon.transport_state import SessionState
@@ -722,151 +750,13 @@ class TestMessageBrokerRouting:
             tmpdir.cleanup()
 
     @pytest.mark.asyncio
-    async def test_route_agent_reply_is_one_way_live_injection(self):
-        """The return leg is live, audited, and cannot trigger another reply."""
-        from pinky_daemon.transport_state import SessionState
-        from pinky_daemon.turn_response import TurnResponse
-
-        tmpdir, registry, broker, _, _ = self._make_broker()
+    async def test_agent_reply_auto_route_channel_is_absent(self):
+        """#1074 removes the callable that could deliver turn-final text to a
+        peer. Agent-to-agent delivery remains available only via an explicit
+        send_to_agent/inject_agent_message call."""
+        tmpdir, _, broker, _, _ = self._make_broker()
         try:
-            sent: list = []
-            injected: list = []
-
-            class _FakeComms:
-                def send(self, frm, to, content, **kw):
-                    sent.append((frm, to, content, kw.get("metadata")))
-
-            class _FakeStreaming:
-                state = SessionState.CONNECTED
-                injection_confirms_consumption = True
-
-                async def send(self, prompt, *, platform="", chat_id="", message_id=""):
-                    injected.append((prompt, platform, chat_id))
-                    return True
-
-            broker.register_streaming("barsik", _FakeStreaming(), label="main")
-            tr = TurnResponse(
-                agent_name="murzik",
-                platform="agent",
-                chat_id="barsik",
-                text="LGTM - ship it",
-            )
-            handled = await broker.route_agent_reply(_FakeComms(), tr)
-            assert handled is True
-            assert sent == [("murzik", "barsik", "LGTM - ship it", {"auto_routed": True})]
-            assert len(injected) == 1
-            assert "LGTM - ship it" in injected[0][0]
-            assert injected[0][1:] == ("", "")
-        finally:
-            tmpdir.cleanup()
-
-    @pytest.mark.asyncio
-    async def test_route_agent_reply_ignores_normal_platform_turns(self):
-        """A telegram turn is not an agent reply: returns False (caller falls
-        through to normal routing) and nothing is agent-routed."""
-        from pinky_daemon.turn_response import TurnResponse
-
-        tmpdir, registry, broker, _, _ = self._make_broker()
-        try:
-            sent: list = []
-
-            class _FakeComms:
-                def send(self, *a, **k):
-                    sent.append((a, k))
-
-            tr = TurnResponse(
-                agent_name="barsik", platform="telegram", chat_id="123", text="hi"
-            )
-            handled = await broker.route_agent_reply(_FakeComms(), tr)
-            assert handled is False
-            assert sent == []
-        finally:
-            tmpdir.cleanup()
-
-    @pytest.mark.asyncio
-    async def test_route_agent_reply_skips_empty_text(self):
-        """A pure tool-call agent turn (no final text) is consumed but nothing is
-        delivered."""
-        from pinky_daemon.turn_response import TurnResponse
-
-        tmpdir, registry, broker, _, _ = self._make_broker()
-        try:
-            sent: list = []
-
-            class _FakeComms:
-                def send(self, *a, **k):
-                    sent.append((a, k))
-
-            tr = TurnResponse(
-                agent_name="murzik", platform="agent", chat_id="barsik", text="   "
-            )
-            handled = await broker.route_agent_reply(_FakeComms(), tr)
-            assert handled is True
-            assert sent == []
-        finally:
-            tmpdir.cleanup()
-
-    @pytest.mark.asyncio
-    async def test_route_agent_reply_counts_failed_delivery(self):
-        """If audit storage raises, the turn is still consumed (handled True, never
-        re-injected) and the failure is counted so dropped replies are visible."""
-        from pinky_daemon.turn_response import TurnResponse
-
-        tmpdir, registry, broker, _, _ = self._make_broker()
-        try:
-            class _BoomComms:
-                def send(self, *a, **k):
-                    raise RuntimeError("audit down")
-
-            tr = TurnResponse(
-                agent_name="murzik", platform="agent", chat_id="barsik", text="x"
-            )
-            before = broker._stats["routed_failed"]
-            handled = await broker.route_agent_reply(_BoomComms(), tr)
-            assert handled is True  # loop-safe: never falls through / re-injects
-            assert broker._stats["routed_failed"] == before + 1
-        finally:
-            tmpdir.cleanup()
-
-    @pytest.mark.asyncio
-    async def test_route_agent_reply_real_comms_is_audited_and_live(self):
-        """End-to-end return leg is live and retained only in audit history."""
-        from pinky_daemon.agent_comms import AgentComms
-        from pinky_daemon.transport_state import SessionState
-        from pinky_daemon.turn_response import TurnResponse
-
-        tmpdir, registry, broker, _, _ = self._make_broker()
-        try:
-            comms = AgentComms(db_path=f"{tmpdir.name}/comms.db")
-            injected: list = []
-
-            class _FakeStreaming:
-                state = SessionState.CONNECTED
-                injection_confirms_consumption = True
-
-                async def send(self, prompt, *, platform="", chat_id="", message_id=""):
-                    injected.append((prompt, platform, chat_id))
-                    return True
-
-            broker.register_streaming("barsik", _FakeStreaming(), label="main")
-            tr = TurnResponse(
-                agent_name="murzik",
-                platform="agent",
-                chat_id="barsik",
-                text="LGTM - ship it",
-            )
-            handled = await broker.route_agent_reply(comms, tr)
-            assert handled is True
-            assert comms.get_inbox("barsik") == []
-            assert comms.unread_count("barsik") == 0
-            messages, total = comms.get_all_messages()
-            assert total == 1
-            assert messages[0].from_session == "murzik"
-            assert messages[0].content == "LGTM - ship it"
-            assert messages[0].metadata.get("auto_routed") is True
-            assert len(injected) == 1
-            assert "LGTM - ship it" in injected[0][0]
-            assert injected[0][1:] == ("", "")
+            assert not hasattr(broker, "route_agent_reply")
         finally:
             tmpdir.cleanup()
 

--- a/tests/test_streaming_session.py
+++ b/tests/test_streaming_session.py
@@ -248,6 +248,19 @@ def _make_result_message(
     )
 
 
+def _make_text_assistant_message(text: str):
+    """Build a successful AssistantMessage carrying visible console text."""
+    from claude_agent_sdk.types import AssistantMessage, TextBlock
+
+    return AssistantMessage(
+        content=[TextBlock(text=text)],
+        model="claude-opus-4-7",
+        error=None,
+        usage={"input_tokens": 0, "output_tokens": 1},
+        stop_reason="end_turn",
+    )
+
+
 async def _run_reader_against_stream(ss: StreamingSession, messages: list) -> None:
     """Wire up a fake client whose receive_messages() yields the given list,
     then run the reader_loop until the iterator drains."""
@@ -944,15 +957,11 @@ async def test_billing_error_assistant_does_not_block_subsequent_auth_alert() ->
     assert args == (ss.agent_name, "authentication_failed")
 
 
-# -- _pending_chats routing-queue 1:1 invariant -------------------------------
+# -- _pending_chats turn-boundary drain invariant -----------------------------
 #
-# Response routing relies on FIFO correlation: one _pending_chats entry per
-# query, one pop per ResultMessage. System-initiated queries (wake prompt,
-# context warn, restart-blocked notice, idle-sleep save prompt) used to skip
-# the enqueue, so their ResultMessages consumed USER routing tuples and the
-# real user turn popped ("", "", "") -- silently dropping the reply (or
-# delivering a system turn's text to the user's chat). The queue also
-# survived disconnect(), leaking stale chat_ids into a resumed session.
+# The SDK may coalesce several submitted messages into one turn and emit one
+# ResultMessage. Every reservation visible at the start of that boundary must
+# be drained together; pop-one leaves stale route state for an unrelated turn.
 
 
 @pytest.mark.asyncio
@@ -1013,6 +1022,41 @@ async def test_send_books_turn_before_fast_result_can_emit_idle(
 
     release_query.set()
     assert await send_task is True
+    await reader_task
+    assert ss._pending_chats == []
+
+
+@pytest.mark.asyncio
+async def test_unrouted_query_books_before_fast_result_boundary() -> None:
+    """Notification/system queries use the same reserve-before-write rule as
+    send(), so a fast Result cannot leave a late sentinel behind."""
+    ss = _make_session()
+    write_visible = asyncio.Event()
+    release_query = asyncio.Event()
+    result_consumed = asyncio.Event()
+
+    async def held_query(prompt: str) -> None:
+        del prompt
+        write_visible.set()
+        await release_query.wait()
+
+    async def receive_messages():
+        await write_visible.wait()
+        yield _make_result_message()
+        result_consumed.set()
+
+    ss._client.query = held_query
+    ss._client.receive_messages = receive_messages
+
+    query_task = asyncio.create_task(ss._query_unrouted("notification prompt"))
+    reader_task = asyncio.create_task(ss._reader_loop())
+
+    await result_consumed.wait()
+    assert not query_task.done()
+    assert ss._pending_chats == []
+
+    release_query.set()
+    await query_task
     await reader_task
     assert ss._pending_chats == []
 
@@ -1090,31 +1134,64 @@ async def test_disconnect_fires_empty_callback_for_routed_pending_entries() -> N
 
 
 @pytest.mark.asyncio
-async def test_system_turn_does_not_consume_user_routing() -> None:
-    """A system turn (sentinel entry) completing before a user turn must pop
-    its own sentinel, leaving the user tuple for the user turn."""
+async def test_coalesced_turn_boundary_drains_all_pending_routes_loudly(
+    capsys,
+) -> None:
+    """N>1 queued messages may share one SDK result; no reservation survives
+    and the stale count is operator-visible."""
     ss = _make_session()
-    routed: list[tuple[str, str]] = []
+    routed: list[tuple[str, str, str]] = []
 
     async def capture(turn_result):
-        routed.append((turn_result.platform, turn_result.chat_id))
+        routed.append(
+            (turn_result.platform, turn_result.chat_id, turn_result.response_text)
+        )
 
     ss._response_callback = capture
-    # System turn queued first (e.g. wake prompt), then a user message.
+    # Two explicit agent packets plus a notification-origin prompt coalesced
+    # into the same live SDK turn. Agent injects are deliberately unrouted.
     ss._pending_chats.append(("", "", ""))
-    ss._pending_chats.append(("telegram", "123", "9"))
+    ss._pending_chats.append(("", "", ""))
+    ss._pending_chats.append(("", "", ""))
 
     await _run_reader_against_stream(
         ss,
         [
-            _make_result_message(),  # system turn -- pops the sentinel
-            _make_result_message(),  # user turn -- pops the user tuple
+            _make_text_assistant_message("web-only turn-final narration"),
+            _make_result_message(),
         ],
     )
 
-    assert routed == [("telegram", "123")], (
-        f"user turn must route to the user's chat, got {routed}"
+    assert ss._pending_chats == []
+    assert routed == [("", "", "web-only turn-final narration")]
+    assert "TURN_BOUNDARY_STALE_ROUTE_DRAIN" in capsys.readouterr().err
+
+
+@pytest.mark.asyncio
+async def test_notification_after_agent_inbound_is_web_record_only(tmp_path) -> None:
+    """A notification-origin completion after an earlier agent inbound is
+    retained in the web conversation store without retaining either route."""
+    from pinky_daemon.conversation_store import ConversationStore
+
+    store = ConversationStore(db_path=str(tmp_path / "conversations.db"))
+    ss = _make_session()
+    ss._conversation_store = store
+    ss._pending_chats.append(("agent", "requester", "agent-message"))
+    ss._pending_chats.append(("", "", ""))
+
+    await _run_reader_against_stream(
+        ss,
+        [
+            _make_text_assistant_message("notification turn console text"),
+            _make_result_message(),
+        ],
     )
+
+    assert ss._pending_chats == []
+    assistant = [m for m in store.get_history(ss.id) if m.role == "assistant"]
+    assert len(assistant) == 1
+    assert assistant[0].content == "notification turn console text"
+    assert (assistant[0].platform, assistant[0].chat_id) == ("", "")
 
 
 # -- Typing-indicator leak: callback must fire for every routed turn ----------


### PR DESCRIPTION
## Change contract

Fixes #1074.

Turn-final console text is now web-render-only. It is never auto-delivered to an agent peer or to Telegram, Discord, Slack, ferry, API, or web chat adapters. `send`, `thread`, `send_to_agent`, `broadcast`, and the other explicit outreach tools remain the only delivery path.

An agent that answers an inbound platform message only with console prose will now appear silent on that platform by design; the text remains in the web conversation store. The existing `plain_text_fallback` setting is accepted for compatibility but cannot authorize delivery.

## Root cause

`inject_agent_message()` stamped a `platform="agent"` route-back sentinel. The SDK can coalesce multiple submitted prompts into one turn, while ResultMessage handling popped only one pending route. That left stale FIFO entries for later notification, heartbeat, or third-agent turns. `route_agent_reply()` then delivered unrelated turn-final console text to the stale requester. `route_response()` also retained an internal-surface plain-text send path.

## What changed

- Removed the agent reply sentinel, its environment opt-in, and `route_agent_reply()`; explicit agent packets are one-way until the recipient explicitly calls `send_to_agent`.
- Reduced `route_response()` to typing/voice bookkeeping and explicit-outreach accounting; it has no turn-final send path on any surface.
- At each ResultMessage boundary, atomically snapshot and drain every reservation visible at boundary start. Coalesced source attribution fails closed to empty platform/chat metadata, and surplus entries emit `TURN_BOUNDARY_STALE_ROUTE_DRAIN` with counts.
- Fire bookkeeping callbacks for every routed reservation so all typing indicators are stopped without delivering console text.
- Route wake, context-warning, restart-blocked, and idle-sleep prompts through reserve-before-write/identity-rollback bookkeeping so a fast Result cannot leave a late sentinel.

## Caller audit

- `api.py` transport recovery inject: one-way wake instruction; no reply dependency.
- `api.py` direct agent-message endpoint: explicit `send_to_agent` packet; replies must also be explicit.
- `pollers.py` Slack purchase approval: injected instruction explicitly requires the responder to post through its Slack/purchasing outreach path.
- `routes/presentations.py` generation request: completion is performed by the presentation creation tool; the endpoint already returns `queued` and does not rely on console text.

## Scope and lineage

- Frozen base / merge-base: `779f5c41a31eacb20d325d3b51aad7911d6d3477` (the #1073 squash merge)
- Changed files: `src/pinky_daemon/api.py`, `src/pinky_daemon/broker.py`, `src/pinky_daemon/streaming_session.py`, `tests/test_broker.py`, `tests/test_streaming_session.py`
- The local untracked `scripts/console-leak-1074-fix-spec.md` and all other untracked scripts are intentionally excluded.

## Validation

- Pre-fix proof on frozen base: 15/15 new cases failed (`/tmp/pinkybot-1074-prefixed-proof.log`).
- New suppression/drain shapes: 15 passed.
- Core broker/streaming suite after boundary follow-up: 128 passed.
- Focused broker/session/API/messaging/agent-comms compatibility: 863 passed.
- Locked full suite: 5089 passed, 1 skipped, 1 approved #1072 node deselected.
- Ruff, compileall, `git diff --check`, source auto-route grep, and caller audit: clean.
