### PR TITLE
feat(codex): deliver souls to isolated homes

### DIFF
--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -11556,6 +11556,38 @@ npm run build</pre>
         except Exception as exc:  # never let hardening abort startup
             _log(f"startup: db permission sweep skipped ({exc})")
 
+        # R10/#580: a spawn that failed before broker registration may have
+        # retained a durable, possibly-live tmux child. Reconcile every record
+        # at daemon boot, including debts for dormant/disabled agents that the
+        # normal streaming-session loop below would never instantiate.
+        try:
+            from pinky_daemon.tmux_session import (
+                reconcile_tmux_spawn_cleanup_debts,
+            )
+
+            reaped_debts, outstanding_debts = (
+                await reconcile_tmux_spawn_cleanup_debts(
+                    Path(db_path).resolve().parent
+                )
+            )
+            if reaped_debts:
+                _log(
+                    f"startup: reaped {reaped_debts} retained tmux spawn "
+                    "cleanup debt(s)"
+                )
+            if outstanding_debts:
+                _log(
+                    f"ERROR startup: {outstanding_debts} retained tmux spawn "
+                    "cleanup debt(s) remain outstanding"
+                )
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            _log(
+                f"ERROR startup: tmux spawn cleanup debt reconciliation "
+                f"failed ({type(exc).__name__}: {exc})"
+            )
+
         # #863: resume durable owner-approval notification retries before
         # pollers can accept more inbound messages.
         app.state.approval_notification_retry_task = (

--- a/src/pinky_daemon/codex_app_server_tmux.py
+++ b/src/pinky_daemon/codex_app_server_tmux.py
@@ -107,12 +107,14 @@ class CodexAppServerSupervisor:
         working_dir: str,
         openai_api_key: str = "",
         agent_config: object | None = None,
+        soul_version_store: object | None = None,
         log: Callable[[str], None] = _log,
     ) -> None:
         self.agent_name = agent_name
         self._log = log
         self._openai_api_key = openai_api_key
         self._agent_config = agent_config
+        self._soul_version_store = soul_version_store
         self._sock_dir, self._sock_dir_is_tmp = self._resolve_sock_dir(agent_name, working_dir)
         self.sock_path = os.path.join(self._sock_dir, "app.sock")
         self._tmux = _TmuxControl(self.session_name, command_runner=LocalCommandRunner())
@@ -232,7 +234,11 @@ class CodexAppServerSupervisor:
                     "per-agent Codex home requires app-server agent config"
                 )
             env["CODEX_HOME"] = str(
-                prepare_agent_codex_home(self._agent_config, log=self._log)
+                prepare_agent_codex_home(
+                    self._agent_config,
+                    log=self._log,
+                    soul_version_store=self._soul_version_store,
+                )
             )
         return env
 

--- a/src/pinky_daemon/codex_app_server_tmux.py
+++ b/src/pinky_daemon/codex_app_server_tmux.py
@@ -97,6 +97,13 @@ class _TmuxAppServerProc:
             self.returncode = -9
         return self.returncode
 
+    async def wait_strict(self) -> int:
+        """Wait for replacement cleanup, propagating any failed tmux kill."""
+        await self._sup.teardown(strict=True)
+        if self.returncode is None:
+            self.returncode = -9
+        return self.returncode
+
 
 class CodexAppServerSupervisor:
     """Owns the tmux session + socket lifecycle for one agent's app-server."""
@@ -170,7 +177,7 @@ class CodexAppServerSupervisor:
 
         # Idempotent pre-start cleanup: a crashed predecessor can leave a live
         # tmux session and/or a stale socket; either would wedge a fresh start.
-        await self._tmux.kill_session()
+        await self._kill_tmux_session(strict=True)
         self._unlink_sock()
 
         self._ensure_sock_dir_secure()
@@ -302,12 +309,38 @@ class CodexAppServerSupervisor:
     def request_kill(self) -> None:
         self._kill_requested = True
 
-    async def teardown(self) -> None:
-        """Idempotent: kill the tmux session and unlink the socket."""
+    async def _kill_tmux_session(self, *, strict: bool) -> bool:
+        """Kill the owned tmux session, optionally making failure terminal."""
         try:
-            await self._tmux.kill_session()
-        except Exception as exc:  # noqa: BLE001 — teardown is best-effort
-            self._log(f"codex[{self.agent_name}]: tmux app-server kill_session failed: {exc}")
+            result = await self._tmux.kill_session()
+        except Exception as exc:
+            message = (
+                f"codex app-server tmux kill-session failed for "
+                f"{self.agent_name}: {exc}"
+            )
+            self._log(message)
+            if strict:
+                raise RuntimeError(message) from exc
+            return False
+        if result.ok:
+            return True
+        message = (
+            f"codex app-server tmux kill-session failed for {self.agent_name}: "
+            f"rc={result.returncode} stderr={result.stderr.strip()!r}"
+        )
+        self._log(message)
+        if strict:
+            raise RuntimeError(message)
+        return False
+
+    async def teardown(self, *, strict: bool = False) -> None:
+        """Kill the tmux session and unlink its socket.
+
+        Terminal shutdown remains best-effort. Replacement cleanup passes
+        ``strict=True`` so a known failed kill aborts before any new child's
+        environment is prepared or published.
+        """
+        await self._kill_tmux_session(strict=strict)
         self._unlink_sock()
 
     def stats(self) -> dict:

--- a/src/pinky_daemon/codex_app_server_tmux.py
+++ b/src/pinky_daemon/codex_app_server_tmux.py
@@ -49,6 +49,7 @@ from pinky_daemon.codex_app_server import (
 from pinky_daemon.codex_home import (
     per_agent_codex_home_enabled,
     prepare_agent_codex_home,
+    validate_agent_codex_home,
 )
 from pinky_daemon.command_runner import LocalCommandRunner
 from pinky_daemon.streaming_session import _log
@@ -152,13 +153,20 @@ class CodexAppServerSupervisor:
         *,
         notification_handler: NotificationHandler | None = None,
         server_request_handler: ServerRequestHandler | None = None,
-        prepared_codex_home: str | None = None,
     ) -> tuple[CodexAppServerClient, _TmuxAppServerProc]:
         """Launch the shim under tmux and return a started, UN-initialized
         client plus its process adapter. Raises on tmux failure or readiness
         timeout. The caller (CodexSession) performs the single ``initialize``."""
         self._kill_requested = False
-        env = self._build_env(prepared_codex_home=prepared_codex_home)
+        if per_agent_codex_home_enabled():
+            if self._agent_config is None:
+                raise RuntimeError(
+                    "per-agent Codex home requires app-server agent config"
+                )
+            validate_agent_codex_home(
+                self._agent_config,
+                soul_version_store=self._soul_version_store,
+            )
 
         # Idempotent pre-start cleanup: a crashed predecessor can leave a live
         # tmux session and/or a stale socket; either would wedge a fresh start.
@@ -166,6 +174,7 @@ class CodexAppServerSupervisor:
         self._unlink_sock()
 
         self._ensure_sock_dir_secure()
+        env = self._build_env()
 
         command = " ".join(
             shlex.quote(p)
@@ -200,7 +209,7 @@ class CodexAppServerSupervisor:
     # tmux-internal vars that must not leak into a nested session's children.
     _ENV_DROP = frozenset({"TMUX", "TMUX_PANE"})
 
-    def _build_env(self, *, prepared_codex_home: str | None = None) -> dict[str, str]:
+    def _build_env(self) -> dict[str, str]:
         """Full daemon-env parity for the tmux session — NOT just PATH.
 
         tmux ``new-session`` drops the parent process env (only ``-e KEY=VAL``
@@ -234,15 +243,13 @@ class CodexAppServerSupervisor:
                 raise RuntimeError(
                     "per-agent Codex home requires app-server agent config"
                 )
-            if prepared_codex_home is None:
-                prepared_codex_home = str(
-                    prepare_agent_codex_home(
-                        self._agent_config,
-                        log=self._log,
-                        soul_version_store=self._soul_version_store,
-                    )
+            env["CODEX_HOME"] = str(
+                prepare_agent_codex_home(
+                    self._agent_config,
+                    log=self._log,
+                    soul_version_store=self._soul_version_store,
                 )
-            env["CODEX_HOME"] = prepared_codex_home
+            )
         return env
 
     async def _await_accept(self) -> tuple[asyncio.StreamReader, asyncio.StreamWriter]:

--- a/src/pinky_daemon/codex_app_server_tmux.py
+++ b/src/pinky_daemon/codex_app_server_tmux.py
@@ -152,12 +152,13 @@ class CodexAppServerSupervisor:
         *,
         notification_handler: NotificationHandler | None = None,
         server_request_handler: ServerRequestHandler | None = None,
+        prepared_codex_home: str | None = None,
     ) -> tuple[CodexAppServerClient, _TmuxAppServerProc]:
         """Launch the shim under tmux and return a started, UN-initialized
         client plus its process adapter. Raises on tmux failure or readiness
         timeout. The caller (CodexSession) performs the single ``initialize``."""
         self._kill_requested = False
-        env = self._build_env()
+        env = self._build_env(prepared_codex_home=prepared_codex_home)
 
         # Idempotent pre-start cleanup: a crashed predecessor can leave a live
         # tmux session and/or a stale socket; either would wedge a fresh start.
@@ -199,7 +200,7 @@ class CodexAppServerSupervisor:
     # tmux-internal vars that must not leak into a nested session's children.
     _ENV_DROP = frozenset({"TMUX", "TMUX_PANE"})
 
-    def _build_env(self) -> dict[str, str]:
+    def _build_env(self, *, prepared_codex_home: str | None = None) -> dict[str, str]:
         """Full daemon-env parity for the tmux session — NOT just PATH.
 
         tmux ``new-session`` drops the parent process env (only ``-e KEY=VAL``
@@ -233,13 +234,15 @@ class CodexAppServerSupervisor:
                 raise RuntimeError(
                     "per-agent Codex home requires app-server agent config"
                 )
-            env["CODEX_HOME"] = str(
-                prepare_agent_codex_home(
-                    self._agent_config,
-                    log=self._log,
-                    soul_version_store=self._soul_version_store,
+            if prepared_codex_home is None:
+                prepared_codex_home = str(
+                    prepare_agent_codex_home(
+                        self._agent_config,
+                        log=self._log,
+                        soul_version_store=self._soul_version_store,
+                    )
                 )
-            )
+            env["CODEX_HOME"] = prepared_codex_home
         return env
 
     async def _await_accept(self) -> tuple[asyncio.StreamReader, asyncio.StreamWriter]:

--- a/src/pinky_daemon/codex_home.py
+++ b/src/pinky_daemon/codex_home.py
@@ -167,7 +167,11 @@ def _write_agent_soul(
         )
 
     agents_path = codex_home / "AGENTS.md"
-    if _path_entry_exists(agents_path):
+    try:
+        agents_stat = agents_path.lstat()
+    except FileNotFoundError:
+        agents_stat = None
+    if agents_stat is not None and not stat.S_ISLNK(agents_stat.st_mode):
         try:
             existing = agents_path.read_text(encoding="utf-8")
         except (OSError, UnicodeError) as exc:
@@ -183,6 +187,7 @@ def _write_agent_soul(
     )
     temp_path = Path(temp_name)
     try:
+        os.fchmod(fd, 0o600)
         with os.fdopen(fd, "w", encoding="utf-8") as handle:
             fd = -1
             handle.write(content)

--- a/src/pinky_daemon/codex_home.py
+++ b/src/pinky_daemon/codex_home.py
@@ -142,6 +142,65 @@ def _write_managed_config(codex_home: Path, working_dir: Path, log: LogFn) -> No
     config_path.chmod(0o600)
 
 
+def _write_agent_soul(
+    codex_home: Path,
+    agent: object,
+    soul_version_store: object | None,
+) -> None:
+    """Atomically install the compiled agent soul in an isolated Codex home.
+
+    The caller has already proved that ``codex_home`` is not the shared home.
+    Replacing the directory entry from a same-directory temporary file also
+    prevents a linked ``AGENTS.md`` from redirecting the write outside the
+    isolated home. Existing content is versioned before replacement; the
+    installed content is versioned after publication.
+    """
+    content = getattr(agent, "system_prompt", "")
+    if not isinstance(content, str) or not content:
+        return
+
+    agent_name = (getattr(agent, "agent_name", "") or "").strip()
+    save_version = getattr(soul_version_store, "save_soul_version", None)
+    if not agent_name or not callable(save_version):
+        raise RuntimeError(
+            "refusing Codex spawn: compiled agent soul cannot be versioned"
+        )
+
+    agents_path = codex_home / "AGENTS.md"
+    if _path_entry_exists(agents_path):
+        try:
+            existing = agents_path.read_text(encoding="utf-8")
+        except (OSError, UnicodeError) as exc:
+            raise RuntimeError(
+                f"refusing Codex spawn: existing agent soul cannot be read: {agents_path}"
+            ) from exc
+        save_version(agent_name, existing, source="agent")
+
+    fd, temp_name = tempfile.mkstemp(
+        dir=codex_home,
+        prefix=".AGENTS.md-",
+        suffix=".tmp",
+    )
+    temp_path = Path(temp_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            fd = -1
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temp_path, agents_path)
+        _fsync_directory(codex_home)
+    finally:
+        if fd >= 0:
+            os.close(fd)
+        try:
+            temp_path.unlink()
+        except FileNotFoundError:
+            pass
+
+    save_version(agent_name, content, source="spawn")
+
+
 def _ensure_auth_link(codex_home: Path, auth_source: Path) -> None:
     auth_path = codex_home / "auth.json"
     auth_target = auth_source.resolve(strict=True)
@@ -1536,12 +1595,18 @@ def _run_initial_rollout_migration(
         return result.moved
 
 
-def prepare_agent_codex_home(agent: object, *, log: LogFn) -> Path:
+def prepare_agent_codex_home(
+    agent: object,
+    *,
+    log: LogFn,
+    soul_version_store: object | None = None,
+) -> Path:
     """Prepare the isolated home before a Codex process is spawned.
 
     With the flag disabled this function performs no filesystem work. With it
     enabled, auth absence is a hard error before launch, config generation is
-    non-destructive, and cwd-matched rollouts move into the isolated store.
+    non-destructive, the compiled soul is installed with version snapshots,
+    and cwd-matched rollouts move into the isolated store.
     """
     codex_home = codex_home_for(agent)
     if not per_agent_codex_home_enabled():
@@ -1566,6 +1631,7 @@ def prepare_agent_codex_home(agent: object, *, log: LogFn) -> Path:
     sessions.chmod(0o700)
     _write_managed_config(resolved_home, working_dir, log)
     _ensure_auth_link(resolved_home, auth_source)
+    _write_agent_soul(resolved_home, agent, soul_version_store)
 
     moved = _run_initial_rollout_migration(
         shared_home,

--- a/src/pinky_daemon/codex_home.py
+++ b/src/pinky_daemon/codex_home.py
@@ -155,29 +155,16 @@ def _write_agent_soul(
     isolated home. Existing content is versioned before replacement; the
     installed content is versioned after publication.
     """
-    content = getattr(agent, "system_prompt", "")
-    if not isinstance(content, str) or not content:
+    publication = _validate_agent_soul_publication(
+        codex_home,
+        agent,
+        soul_version_store,
+    )
+    if publication is None:
         return
-
-    agent_name = (getattr(agent, "agent_name", "") or "").strip()
-    save_version = getattr(soul_version_store, "save_soul_version", None)
-    if not agent_name or not callable(save_version):
-        raise RuntimeError(
-            "refusing Codex spawn: compiled agent soul cannot be versioned"
-        )
-
+    content, agent_name, save_version, existing = publication
     agents_path = codex_home / "AGENTS.md"
-    try:
-        agents_stat = agents_path.lstat()
-    except FileNotFoundError:
-        agents_stat = None
-    if agents_stat is not None and not stat.S_ISLNK(agents_stat.st_mode):
-        try:
-            existing = agents_path.read_text(encoding="utf-8")
-        except (OSError, UnicodeError) as exc:
-            raise RuntimeError(
-                f"refusing Codex spawn: existing agent soul cannot be read: {agents_path}"
-            ) from exc
+    if existing is not None:
         save_version(agent_name, existing, source="agent")
 
     fd, temp_name = tempfile.mkstemp(
@@ -204,6 +191,39 @@ def _write_agent_soul(
             pass
 
     save_version(agent_name, content, source="spawn")
+
+
+def _validate_agent_soul_publication(
+    codex_home: Path,
+    agent: object,
+    soul_version_store: object | None,
+) -> tuple[str, str, Callable[..., object], str | None] | None:
+    """Return validated publication inputs without changing persistent state."""
+    content = getattr(agent, "system_prompt", "")
+    if not isinstance(content, str) or not content:
+        return None
+
+    agent_name = (getattr(agent, "agent_name", "") or "").strip()
+    save_version = getattr(soul_version_store, "save_soul_version", None)
+    if not agent_name or not callable(save_version):
+        raise RuntimeError(
+            "refusing Codex spawn: compiled agent soul cannot be versioned"
+        )
+
+    agents_path = codex_home / "AGENTS.md"
+    try:
+        agents_stat = agents_path.lstat()
+    except FileNotFoundError:
+        agents_stat = None
+    existing: str | None = None
+    if agents_stat is not None and not stat.S_ISLNK(agents_stat.st_mode):
+        try:
+            existing = agents_path.read_text(encoding="utf-8")
+        except (OSError, UnicodeError) as exc:
+            raise RuntimeError(
+                f"refusing Codex spawn: existing agent soul cannot be read: {agents_path}"
+            ) from exc
+    return content, agent_name, save_version, existing
 
 
 def _ensure_auth_link(codex_home: Path, auth_source: Path) -> None:
@@ -1600,24 +1620,23 @@ def _run_initial_rollout_migration(
         return result.moved
 
 
-def prepare_agent_codex_home(
+def validate_agent_codex_home(
     agent: object,
     *,
-    log: LogFn,
     soul_version_store: object | None = None,
 ) -> Path:
-    """Prepare the isolated home before a Codex process is spawned.
+    """Validate an isolated home before teardown without changing the filesystem.
 
-    With the flag disabled this function performs no filesystem work. With it
-    enabled, auth absence is a hard error before launch, config generation is
-    non-destructive, the compiled soul is installed with version snapshots,
-    and cwd-matched rollouts move into the isolated store.
+    This is the retained-transport preflight seam. Publication deliberately
+    does not happen here: a later task may inherit async context from the
+    replacement operation, while every actual process spawn must snapshot and
+    publish the soul for the state that exists at that exact boundary.
     """
     codex_home = codex_home_for(agent)
     if not per_agent_codex_home_enabled():
         return codex_home
 
-    working_dir = _agent_working_dir(agent)
+    _agent_working_dir(agent)
     shared_home = shared_codex_home().expanduser().resolve()
     resolved_home = codex_home.expanduser().resolve()
     if resolved_home == shared_home:
@@ -1629,6 +1648,48 @@ def prepare_agent_codex_home(
             f"refusing Codex spawn: shared auth file is absent or unreadable: {auth_source}"
         )
 
+    auth_path = resolved_home / "auth.json"
+    try:
+        auth_stat = auth_path.lstat()
+    except FileNotFoundError:
+        auth_stat = None
+    if auth_stat is not None and not stat.S_ISLNK(auth_stat.st_mode):
+        raise RuntimeError(
+            f"refusing Codex spawn: {auth_path} is not the managed auth symlink"
+        )
+
+    _validate_agent_soul_publication(
+        resolved_home,
+        agent,
+        soul_version_store,
+    )
+    _migration_lock_timeout_seconds()
+    return resolved_home
+
+
+def prepare_agent_codex_home(
+    agent: object,
+    *,
+    log: LogFn,
+    soul_version_store: object | None = None,
+) -> Path:
+    """Prepare the isolated home at the actual Codex process-spawn boundary.
+
+    With the flag disabled this function performs no filesystem work. With it
+    enabled, auth absence is a hard error before launch, config generation is
+    non-destructive, the compiled soul is installed with version snapshots,
+    and cwd-matched rollouts move into the isolated store.
+    """
+    resolved_home = validate_agent_codex_home(
+        agent,
+        soul_version_store=soul_version_store,
+    )
+    if not per_agent_codex_home_enabled():
+        return resolved_home
+
+    working_dir = _agent_working_dir(agent)
+    shared_home = shared_codex_home().expanduser().resolve()
+    auth_source = shared_home / "auth.json"
     resolved_home.mkdir(parents=True, exist_ok=True)
     resolved_home.chmod(0o700)
     sessions = resolved_home / "sessions"

--- a/src/pinky_daemon/codex_session.py
+++ b/src/pinky_daemon/codex_session.py
@@ -1250,8 +1250,10 @@ class CodexSession(TransportReplacementMixin):
 
         if self._app_client is not None or self._app_proc is not None:
             # Process died under us — drop the stale client and respawn only
-            # after the replacement environment passed preparation above.
-            await self._teardown_app_server()
+            # after strict replacement cleanup succeeds. A tmux kill can fail
+            # as a non-ok command result rather than an exception; that known
+            # failure must abort before the spawn boundary publishes a soul.
+            await self._teardown_app_server(strict=True)
 
         started_at = time.monotonic()
 
@@ -1337,31 +1339,57 @@ class CodexSession(TransportReplacementMixin):
             f"app_server_degraded_to_exec agent={self.agent_name} reason={reason}"
         )
 
-    async def _teardown_app_server(self) -> None:
-        """Close the client and kill the process. Idempotent."""
+    async def _teardown_app_server(self, *, strict: bool = False) -> None:
+        """Close the client and kill the process.
+
+        Ordinary shutdown is best-effort. Replacement uses ``strict=True`` so
+        a failed kill/wait remains observable, cached handles remain available
+        for a later cleanup attempt, and no replacement spawn can continue.
+        """
         self._report_appserver_terminal_stream_survivors(phase="teardown")
-        if self._app_client is not None:
+        client = self._app_client
+        proc = self._app_proc
+        if client is not None:
             try:
-                await self._app_client.close()
+                await client.close()
             except Exception:
                 pass
-            self._app_client = None
-        if self._app_proc is not None:
+            if not strict:
+                self._app_client = None
+        supervisor_cleaned = False
+        proc_cleaned = proc is None or proc.returncode is not None
+        if proc is not None:
             try:
-                if self._app_proc.returncode is None:
-                    self._app_proc.kill()
-                    await asyncio.wait_for(self._app_proc.wait(), timeout=5)
+                if proc.returncode is None:
+                    proc.kill()
+                    strict_wait = getattr(proc, "wait_strict", None)
+                    if strict and strict_wait is not None:
+                        await asyncio.wait_for(strict_wait(), timeout=5)
+                        supervisor_cleaned = True
+                    else:
+                        await asyncio.wait_for(proc.wait(), timeout=5)
+                    proc_cleaned = True
             except Exception:
-                pass
-            self._app_proc = None
+                if strict:
+                    raise
+            if not strict and proc_cleaned:
+                self._app_proc = None
         # A tmux supervisor may have started its shim but timed out/cancelled
         # before returning a client/proc adapter. Always run its idempotent
         # teardown so that partial spawn cannot leak a session or socket.
-        if self._use_tmux_app_server and self._app_supervisor is not None:
+        if (
+            self._use_tmux_app_server
+            and self._app_supervisor is not None
+            and not supervisor_cleaned
+        ):
             try:
-                await self._app_supervisor.teardown()
+                await self._app_supervisor.teardown(strict=strict)
             except Exception:
-                pass
+                if strict:
+                    raise
+        if strict:
+            self._app_client = None
+            self._app_proc = None
 
     def _appserver_config(self) -> dict:
         """Build the per-thread ``config`` override for MCP servers.

--- a/src/pinky_daemon/codex_session.py
+++ b/src/pinky_daemon/codex_session.py
@@ -1236,8 +1236,9 @@ class CodexSession(TransportReplacementMixin):
         # closed/cleared (and a tmux supervisor must not be started) before the
         # replacement spawn proves its Codex home can be prepared safely.
         direct_env: dict[str, str] | None = None
+        prepared_tmux_home: str | None = None
         if self._use_tmux_app_server:
-            self._preflight_agent_codex_home()
+            prepared_tmux_home = self._preflight_agent_codex_home()
         else:
             direct_env = self._build_codex_env()
 
@@ -1254,9 +1255,14 @@ class CodexSession(TransportReplacementMixin):
                 # hands back an UN-initialized client. The initialize below is
                 # the single end-to-end gate for that child.
                 assert self._app_supervisor is not None
+                start_kwargs = {
+                    "notification_handler": self._on_appserver_notification,
+                    "server_request_handler": self._on_appserver_request,
+                }
+                if prepared_tmux_home is not None:
+                    start_kwargs["prepared_codex_home"] = prepared_tmux_home
                 self._app_client, self._app_proc = await self._app_supervisor.start(
-                    notification_handler=self._on_appserver_notification,
-                    server_request_handler=self._on_appserver_request,
+                    **start_kwargs
                 )
             else:
                 assert direct_env is not None

--- a/src/pinky_daemon/codex_session.py
+++ b/src/pinky_daemon/codex_session.py
@@ -34,6 +34,7 @@ from pinky_daemon.codex_app_server_tmux import CodexAppServerSupervisor
 from pinky_daemon.codex_home import (
     per_agent_codex_home_enabled,
     prepare_agent_codex_home,
+    validate_agent_codex_home,
 )
 from pinky_daemon.context_estimator import ContextTextEstimator
 from pinky_daemon.sessions import SessionUsage
@@ -1016,19 +1017,30 @@ class CodexSession(TransportReplacementMixin):
         env = {**os.environ}
         if self._openai_api_key:
             env["OPENAI_API_KEY"] = self._openai_api_key
-        prepared_home = self._preflight_agent_codex_home()
+        prepared_home = self._prepare_agent_codex_home()
         if prepared_home is not None:
             env["CODEX_HOME"] = prepared_home
         return env
 
-    def _preflight_agent_codex_home(self) -> str | None:
-        """Validate and prepare replacement-home state before teardown/spawn."""
+    def _prepare_agent_codex_home(self) -> str | None:
+        """Snapshot and publish isolated-home state for an actual spawn."""
         if not per_agent_codex_home_enabled():
             return None
         return str(
             prepare_agent_codex_home(
                 self._config,
                 log=_log,
+                soul_version_store=self._registry,
+            )
+        )
+
+    def _preflight_agent_codex_home(self) -> str | None:
+        """Validate replacement-home state without publishing before teardown."""
+        if not per_agent_codex_home_enabled():
+            return None
+        return str(
+            validate_agent_codex_home(
+                self._config,
                 soul_version_store=self._registry,
             )
         )
@@ -1232,15 +1244,9 @@ class CodexSession(TransportReplacementMixin):
                 )
 
         # Refuse an unsafe/missing per-agent auth setup before mutating any
-        # cached transport. In particular, a dead cached app-server must not be
-        # closed/cleared (and a tmux supervisor must not be started) before the
-        # replacement spawn proves its Codex home can be prepared safely.
-        direct_env: dict[str, str] | None = None
-        prepared_tmux_home: str | None = None
-        if self._use_tmux_app_server:
-            prepared_tmux_home = self._preflight_agent_codex_home()
-        else:
-            direct_env = self._build_codex_env()
+        # cached transport. Soul snapshot/publication stays at the actual spawn
+        # below, after this non-mutating validation and any stale teardown.
+        self._preflight_agent_codex_home()
 
         if self._app_client is not None or self._app_proc is not None:
             # Process died under us — drop the stale client and respawn only
@@ -1255,21 +1261,15 @@ class CodexSession(TransportReplacementMixin):
                 # hands back an UN-initialized client. The initialize below is
                 # the single end-to-end gate for that child.
                 assert self._app_supervisor is not None
-                start_kwargs = {
-                    "notification_handler": self._on_appserver_notification,
-                    "server_request_handler": self._on_appserver_request,
-                }
-                if prepared_tmux_home is not None:
-                    start_kwargs["prepared_codex_home"] = prepared_tmux_home
                 self._app_client, self._app_proc = await self._app_supervisor.start(
-                    **start_kwargs
+                    notification_handler=self._on_appserver_notification,
+                    server_request_handler=self._on_appserver_request,
                 )
             else:
-                assert direct_env is not None
                 self._app_client, self._app_proc = await spawn_app_server(
                     command=self._app_server_command,
                     cwd=self._working_dir,
-                    env=direct_env,
+                    env=self._build_codex_env(),
                     notification_handler=self._on_appserver_notification,
                     server_request_handler=self._on_appserver_request,
                     log=_log,

--- a/src/pinky_daemon/codex_session.py
+++ b/src/pinky_daemon/codex_session.py
@@ -268,6 +268,7 @@ class CodexSession(TransportReplacementMixin):
                 working_dir=self._working_dir,
                 openai_api_key=self._openai_api_key,
                 agent_config=config,
+                soul_version_store=registry,
                 log=_log,
             )
         self._app_client: CodexAppServerClient | None = None
@@ -1024,7 +1025,13 @@ class CodexSession(TransportReplacementMixin):
         """Validate and prepare replacement-home state before teardown/spawn."""
         if not per_agent_codex_home_enabled():
             return None
-        return str(prepare_agent_codex_home(self._config, log=_log))
+        return str(
+            prepare_agent_codex_home(
+                self._config,
+                log=_log,
+                soul_version_store=self._registry,
+            )
+        )
 
     def _preflight_transport_replacement(self) -> None:
         """Keep retained-session replacement refusal ahead of teardown."""

--- a/src/pinky_daemon/codex_tmux_session.py
+++ b/src/pinky_daemon/codex_tmux_session.py
@@ -50,16 +50,14 @@ import re
 import shlex
 import time
 from collections import deque
-from collections.abc import Awaitable
-from contextvars import ContextVar
 from pathlib import Path
-from typing import TypeVar
 
 from pinky_daemon.codex_home import (
     MANAGED_CONFIG_SENTINEL,
     codex_home_for,
     per_agent_codex_home_enabled,
     prepare_agent_codex_home,
+    validate_agent_codex_home,
 )
 from pinky_daemon.codex_tmux_transcript import (
     CodexTmuxTranscriptTailer,
@@ -73,10 +71,6 @@ from pinky_daemon.tmux_session import (
     _SchedulerDeliveryCancelled,
     _TmuxControl,
 )
-from pinky_daemon.transport import ReplacementConnectWrapper, ReplacementStep
-from pinky_daemon.transport_state import Trigger
-
-_T = TypeVar("_T")
 
 # Codex's inline composer renders slower than claude's REPL; the bracketed-paste
 # needs a longer settle before the submit Enter or the Enter lands before the
@@ -172,11 +166,6 @@ class CodexTmuxSession(TmuxSession):
         self._reasoning_effort = config.thinking_effort or "medium"
         self._codex_mcp_servers = config.mcp_servers or {}
         self._codex_last_scheduler_gate_signature: tuple[bool, ...] | None = None
-        self._codex_replacement_transaction: ContextVar[object | None] = ContextVar(
-            f"codex_replacement_transaction_{id(self)}",
-            default=None,
-        )
-        self._preflighted_codex_homes: dict[object, Path] = {}
 
     # ── seam: session name ──────────────────────────────────────────────────
     def _build_session_name(self) -> str:
@@ -577,75 +566,20 @@ class CodexTmuxSession(TmuxSession):
         super()._on_transcript_entry(entry)
 
     # ── seam: cold-start (codex trust pre-seed + NUX dismissal + readiness) ──
-    async def _run_codex_replacement_transaction(
-        self,
-        operation: Awaitable[_T],
-    ) -> _T:
-        """Keep a prepared-home handoff inside one replacement operation."""
-        transaction = object()
-        reset_token = self._codex_replacement_transaction.set(transaction)
-        try:
-            return await operation
-        finally:
-            # A successful spawn consumes this entry itself. Every other exit
-            # (guard refusal, transition rejection, configure/disconnect error,
-            # cancellation, or exhausted reconnect) discards it here so an
-            # unrelated later spawn cannot skip its own soul publication.
-            self._preflighted_codex_homes.pop(transaction, None)
-            self._codex_replacement_transaction.reset(reset_token)
-
-    async def restart_transport(
-        self,
-        *,
-        configure: ReplacementStep | None = None,
-        bring_up: ReplacementStep | None = None,
-        connect_wrapper: ReplacementConnectWrapper | None = None,
-        suppress_teardown_errors: bool = False,
-    ) -> None:
-        await self._run_codex_replacement_transaction(
-            super().restart_transport(
-                configure=configure,
-                bring_up=bring_up,
-                connect_wrapper=connect_wrapper,
-                suppress_teardown_errors=suppress_teardown_errors,
-            )
-        )
-
-    async def force_restart(self, *, bypass_guard: bool = False) -> bool:
-        return await self._run_codex_replacement_transaction(
-            super().force_restart(bypass_guard=bypass_guard)
-        )
-
-    async def attempt_reconnect(self, *, trigger: Trigger = Trigger.BROKER) -> None:
-        await self._run_codex_replacement_transaction(
-            super().attempt_reconnect(trigger=trigger)
-        )
-
     def _preflight_transport_replacement(self) -> None:
-        """Prove the isolated Codex home before an inherited tmux teardown."""
-        prepared_home = prepare_agent_codex_home(
+        """Validate the isolated Codex home before inherited tmux teardown."""
+        validate_agent_codex_home(
+            self._config,
+            soul_version_store=self._registry,
+        )
+
+    async def _spawn_tmux_repl(self) -> None:
+        cwd = str(Path(self._config.working_dir or ".").resolve())
+        prepare_agent_codex_home(
             self._config,
             log=_log,
             soul_version_store=self._registry,
         )
-        transaction = self._codex_replacement_transaction.get()
-        if transaction is not None:
-            self._preflighted_codex_homes[transaction] = prepared_home
-
-    async def _spawn_tmux_repl(self) -> None:
-        cwd = str(Path(self._config.working_dir or ".").resolve())
-        transaction = self._codex_replacement_transaction.get()
-        prepared_home = (
-            self._preflighted_codex_homes.pop(transaction, None)
-            if transaction is not None
-            else None
-        )
-        if prepared_home is None:
-            prepare_agent_codex_home(
-                self._config,
-                log=_log,
-                soul_version_store=self._registry,
-            )
         self._seed_codex_trust(cwd)
         await super()._spawn_tmux_repl()
         await self._codex_dismiss_nux_and_ready()

--- a/src/pinky_daemon/codex_tmux_session.py
+++ b/src/pinky_daemon/codex_tmux_session.py
@@ -50,7 +50,10 @@ import re
 import shlex
 import time
 from collections import deque
+from collections.abc import Awaitable
+from contextvars import ContextVar
 from pathlib import Path
+from typing import TypeVar
 
 from pinky_daemon.codex_home import (
     MANAGED_CONFIG_SENTINEL,
@@ -70,6 +73,10 @@ from pinky_daemon.tmux_session import (
     _SchedulerDeliveryCancelled,
     _TmuxControl,
 )
+from pinky_daemon.transport import ReplacementConnectWrapper, ReplacementStep
+from pinky_daemon.transport_state import Trigger
+
+_T = TypeVar("_T")
 
 # Codex's inline composer renders slower than claude's REPL; the bracketed-paste
 # needs a longer settle before the submit Enter or the Enter lands before the
@@ -165,7 +172,11 @@ class CodexTmuxSession(TmuxSession):
         self._reasoning_effort = config.thinking_effort or "medium"
         self._codex_mcp_servers = config.mcp_servers or {}
         self._codex_last_scheduler_gate_signature: tuple[bool, ...] | None = None
-        self._preflighted_codex_home: Path | None = None
+        self._codex_replacement_transaction: ContextVar[object | None] = ContextVar(
+            f"codex_replacement_transaction_{id(self)}",
+            default=None,
+        )
+        self._preflighted_codex_homes: dict[object, Path] = {}
 
     # ── seam: session name ──────────────────────────────────────────────────
     def _build_session_name(self) -> str:
@@ -566,18 +577,69 @@ class CodexTmuxSession(TmuxSession):
         super()._on_transcript_entry(entry)
 
     # ── seam: cold-start (codex trust pre-seed + NUX dismissal + readiness) ──
+    async def _run_codex_replacement_transaction(
+        self,
+        operation: Awaitable[_T],
+    ) -> _T:
+        """Keep a prepared-home handoff inside one replacement operation."""
+        transaction = object()
+        reset_token = self._codex_replacement_transaction.set(transaction)
+        try:
+            return await operation
+        finally:
+            # A successful spawn consumes this entry itself. Every other exit
+            # (guard refusal, transition rejection, configure/disconnect error,
+            # cancellation, or exhausted reconnect) discards it here so an
+            # unrelated later spawn cannot skip its own soul publication.
+            self._preflighted_codex_homes.pop(transaction, None)
+            self._codex_replacement_transaction.reset(reset_token)
+
+    async def restart_transport(
+        self,
+        *,
+        configure: ReplacementStep | None = None,
+        bring_up: ReplacementStep | None = None,
+        connect_wrapper: ReplacementConnectWrapper | None = None,
+        suppress_teardown_errors: bool = False,
+    ) -> None:
+        await self._run_codex_replacement_transaction(
+            super().restart_transport(
+                configure=configure,
+                bring_up=bring_up,
+                connect_wrapper=connect_wrapper,
+                suppress_teardown_errors=suppress_teardown_errors,
+            )
+        )
+
+    async def force_restart(self, *, bypass_guard: bool = False) -> bool:
+        return await self._run_codex_replacement_transaction(
+            super().force_restart(bypass_guard=bypass_guard)
+        )
+
+    async def attempt_reconnect(self, *, trigger: Trigger = Trigger.BROKER) -> None:
+        await self._run_codex_replacement_transaction(
+            super().attempt_reconnect(trigger=trigger)
+        )
+
     def _preflight_transport_replacement(self) -> None:
         """Prove the isolated Codex home before an inherited tmux teardown."""
-        self._preflighted_codex_home = prepare_agent_codex_home(
+        prepared_home = prepare_agent_codex_home(
             self._config,
             log=_log,
             soul_version_store=self._registry,
         )
+        transaction = self._codex_replacement_transaction.get()
+        if transaction is not None:
+            self._preflighted_codex_homes[transaction] = prepared_home
 
     async def _spawn_tmux_repl(self) -> None:
         cwd = str(Path(self._config.working_dir or ".").resolve())
-        prepared_home = self._preflighted_codex_home
-        self._preflighted_codex_home = None
+        transaction = self._codex_replacement_transaction.get()
+        prepared_home = (
+            self._preflighted_codex_homes.pop(transaction, None)
+            if transaction is not None
+            else None
+        )
         if prepared_home is None:
             prepare_agent_codex_home(
                 self._config,

--- a/src/pinky_daemon/codex_tmux_session.py
+++ b/src/pinky_daemon/codex_tmux_session.py
@@ -573,14 +573,17 @@ class CodexTmuxSession(TmuxSession):
             soul_version_store=self._registry,
         )
 
-    async def _spawn_tmux_repl(self) -> None:
-        cwd = str(Path(self._config.working_dir or ".").resolve())
+    def _prepare_tmux_spawn(self) -> None:
+        """Snapshot and publish only after inherited strict stale cleanup."""
         prepare_agent_codex_home(
             self._config,
             log=_log,
             soul_version_store=self._registry,
         )
+        cwd = str(Path(self._config.working_dir or ".").resolve())
         self._seed_codex_trust(cwd)
+
+    async def _spawn_tmux_repl(self) -> None:
         await super()._spawn_tmux_repl()
         await self._codex_dismiss_nux_and_ready()
 

--- a/src/pinky_daemon/codex_tmux_session.py
+++ b/src/pinky_daemon/codex_tmux_session.py
@@ -158,6 +158,7 @@ class CodexTmuxSession(TmuxSession):
                 self._session_name,
                 tmux_binary=self._tmux.tmux_binary,
                 socket_name=self._tmux.socket_name,
+                socket_path=self._tmux.socket_path,
                 command_runner=self._tmux._runner,
             )
         # codex identity/config (mirrors CodexSession.__init__).

--- a/src/pinky_daemon/codex_tmux_session.py
+++ b/src/pinky_daemon/codex_tmux_session.py
@@ -567,11 +567,19 @@ class CodexTmuxSession(TmuxSession):
     # ── seam: cold-start (codex trust pre-seed + NUX dismissal + readiness) ──
     def _preflight_transport_replacement(self) -> None:
         """Prove the isolated Codex home before an inherited tmux teardown."""
-        prepare_agent_codex_home(self._config, log=_log)
+        prepare_agent_codex_home(
+            self._config,
+            log=_log,
+            soul_version_store=self._registry,
+        )
 
     async def _spawn_tmux_repl(self) -> None:
         cwd = str(Path(self._config.working_dir or ".").resolve())
-        prepare_agent_codex_home(self._config, log=_log)
+        prepare_agent_codex_home(
+            self._config,
+            log=_log,
+            soul_version_store=self._registry,
+        )
         self._seed_codex_trust(cwd)
         await super()._spawn_tmux_repl()
         await self._codex_dismiss_nux_and_ready()

--- a/src/pinky_daemon/codex_tmux_session.py
+++ b/src/pinky_daemon/codex_tmux_session.py
@@ -165,6 +165,7 @@ class CodexTmuxSession(TmuxSession):
         self._reasoning_effort = config.thinking_effort or "medium"
         self._codex_mcp_servers = config.mcp_servers or {}
         self._codex_last_scheduler_gate_signature: tuple[bool, ...] | None = None
+        self._preflighted_codex_home: Path | None = None
 
     # ── seam: session name ──────────────────────────────────────────────────
     def _build_session_name(self) -> str:
@@ -567,7 +568,7 @@ class CodexTmuxSession(TmuxSession):
     # ── seam: cold-start (codex trust pre-seed + NUX dismissal + readiness) ──
     def _preflight_transport_replacement(self) -> None:
         """Prove the isolated Codex home before an inherited tmux teardown."""
-        prepare_agent_codex_home(
+        self._preflighted_codex_home = prepare_agent_codex_home(
             self._config,
             log=_log,
             soul_version_store=self._registry,
@@ -575,11 +576,14 @@ class CodexTmuxSession(TmuxSession):
 
     async def _spawn_tmux_repl(self) -> None:
         cwd = str(Path(self._config.working_dir or ".").resolve())
-        prepare_agent_codex_home(
-            self._config,
-            log=_log,
-            soul_version_store=self._registry,
-        )
+        prepared_home = self._preflighted_codex_home
+        self._preflighted_codex_home = None
+        if prepared_home is None:
+            prepare_agent_codex_home(
+                self._config,
+                log=_log,
+                soul_version_store=self._registry,
+            )
         self._seed_codex_trust(cwd)
         await super()._spawn_tmux_repl()
         await self._codex_dismiss_nux_and_ready()

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -1125,6 +1125,17 @@ _RECONNECT_BACKOFF = (2, 8, 30)
 # to authenticate / fetch first turn / load CLAUDE.md.
 _COLD_START_TIMEOUT_SEC = 60.0
 
+# Spawn rollback is deliberately tighter than the normal tmux command bound.
+# Local tmux IPC should complete in well under 100ms; two seconds per command
+# still leaves ample headroom while ensuring cancellation cannot park forever
+# behind cleanup. Two attempts let a transient permission/socket race clear,
+# and the outer ceiling is the hard guarantee that preserving the original
+# spawn exception remains bounded.
+_SPAWN_ROLLBACK_ATTEMPTS = 2
+_SPAWN_ROLLBACK_COMMAND_TIMEOUT_SEC = 2.0
+_SPAWN_ROLLBACK_RETRY_DELAY_SEC = 0.05
+_SPAWN_ROLLBACK_TIMEOUT_SEC = 9.0
+
 # A detached tmux session can reap itself just after ``new-session`` reports
 # success when the in-pane command exits immediately. Give that failure time
 # to surface, then verify the session still exists before starting the tailer
@@ -2932,6 +2943,124 @@ class TmuxSession(TransportReplacementMixin):
     def _prepare_tmux_spawn(self) -> None:
         """Publish transport-specific state at the final spawn boundary."""
 
+    async def _rollback_spawned_session(self, *, site: str) -> str | None:
+        """Strictly and boundedly roll back a possibly-created tmux session.
+
+        A returned non-ok kill enters the same verification path as a raise:
+        ``has_session() is False`` is the only clean fallback, while ``True``
+        or an exception remains possibly-live and is retried. A successful
+        kill is already positive proof because ``_TmuxControl.kill_session``
+        only reduces a failed raw command to success after verifying absence.
+
+        Cleanup runs in a shielded task so cancellation cannot strand the
+        just-created REPL. The per-command and outer ceilings keep waiting for
+        cleanup bounded while the caller preserves the original exception.
+        Returns ``None`` when teardown is proven, otherwise a loud diagnostic
+        that the caller must attach to the original exception.
+        """
+
+        async def _attempts() -> str | None:
+            diagnostics: list[str] = []
+            for attempt in range(1, _SPAWN_ROLLBACK_ATTEMPTS + 1):
+                try:
+                    kill_result = await asyncio.wait_for(
+                        self._tmux.kill_session(),
+                        timeout=_SPAWN_ROLLBACK_COMMAND_TIMEOUT_SEC,
+                    )
+                except BaseException as exc:
+                    diagnostics.append(
+                        f"attempt {attempt} kill raised "
+                        f"{type(exc).__name__}: {exc}"
+                    )
+                else:
+                    if kill_result.ok:
+                        _log(
+                            f"tmux[{self.agent_name}]: spawn rollback at "
+                            f"{site} proved teardown on kill attempt {attempt}"
+                        )
+                        return None
+                    diagnostics.append(
+                        f"attempt {attempt} kill returned "
+                        f"rc={kill_result.returncode} "
+                        f"stderr={kill_result.stderr.strip()!r}"
+                    )
+
+                # False is verified absence; True is live; a raise is
+                # couldn't-answer. Only the first state is clean.
+                try:
+                    live = await asyncio.wait_for(
+                        self._tmux.has_session(),
+                        timeout=_SPAWN_ROLLBACK_COMMAND_TIMEOUT_SEC,
+                    )
+                except BaseException as exc:
+                    diagnostics.append(
+                        f"attempt {attempt} verify couldn't answer "
+                        f"({type(exc).__name__}: {exc})"
+                    )
+                else:
+                    if not live:
+                        _log(
+                            f"tmux[{self.agent_name}]: spawn rollback at "
+                            f"{site} verified absence after failed kill "
+                            f"attempt {attempt}"
+                        )
+                        return None
+                    diagnostics.append(
+                        f"attempt {attempt} verify found session live"
+                    )
+
+                if attempt < _SPAWN_ROLLBACK_ATTEMPTS:
+                    await asyncio.sleep(_SPAWN_ROLLBACK_RETRY_DELAY_SEC)
+
+            message = (
+                f"tmux[{self.agent_name}]: spawn rollback at {site} could not "
+                f"prove teardown after {_SPAWN_ROLLBACK_ATTEMPTS} attempts; "
+                f"owned session is possibly live: {'; '.join(diagnostics)}"
+            )
+            _log(f"ERROR {message}")
+            return message
+
+        async def _bounded() -> str | None:
+            try:
+                return await asyncio.wait_for(
+                    _attempts(), timeout=_SPAWN_ROLLBACK_TIMEOUT_SEC
+                )
+            except BaseException as exc:
+                message = (
+                    f"tmux[{self.agent_name}]: spawn rollback at {site} "
+                    f"could not prove teardown within "
+                    f"{_SPAWN_ROLLBACK_TIMEOUT_SEC}s; owned session is "
+                    f"possibly live ({type(exc).__name__}: {exc})"
+                )
+                _log(f"ERROR {message}")
+                return message
+
+        cleanup_task = asyncio.create_task(
+            _bounded(), name=f"tmux-spawn-rollback-{self.agent_name}"
+        )
+        while True:
+            try:
+                return await asyncio.shield(cleanup_task)
+            except asyncio.CancelledError:
+                # Preserve the exception that selected this rollback site.
+                # A second cancellation cannot strand bounded cleanup.
+                continue
+
+    @staticmethod
+    def _annotate_spawn_rollback_failure(
+        original: BaseException,
+        rollback_failure: str | None,
+    ) -> None:
+        """Surface rollback uncertainty without replacing ``original``."""
+        if rollback_failure is None:
+            return
+        original.add_note(rollback_failure)
+        # Notes render in tracebacks; keep ordinary stringification loud too.
+        if not original.args:
+            original.args = (rollback_failure,)
+        elif len(original.args) == 1 and isinstance(original.args[0], str):
+            original.args = (f"{original.args[0]}; {rollback_failure}",)
+
     async def _spawn_tmux_repl(self) -> None:
         """Spawn the tmux session and the in-pane claude REPL, then start
         the response tailer.
@@ -3075,18 +3204,17 @@ class TmuxSession(TransportReplacementMixin):
 
         try:
             await asyncio.wait_for(_spawn(), timeout=_COLD_START_TIMEOUT_SEC)
-        except asyncio.TimeoutError:
-            # Reap whatever partial state we may have left.
-            try:
-                await self._tmux.kill_session()
-            except Exception:
-                # Best-effort cleanup; ignore failure since we're already
-                # raising the cold-start timeout to the caller.
-                pass
-            raise RuntimeError(
+        except asyncio.TimeoutError as exc:
+            rollback_failure = await self._rollback_spawned_session(
+                site="cold-start timeout"
+            )
+            message = (
                 f"tmux[{self.agent_name}]: cold-start timed out after "
                 f"{_COLD_START_TIMEOUT_SEC}s"
-            ) from None
+            )
+            if rollback_failure is not None:
+                message = f"{message}; {rollback_failure}"
+            raise RuntimeError(message) from exc
 
         # ``tmux new-session -d`` only proves that tmux launched the in-pane
         # command. The command can then fail fast (bad CLI flag, auth error,
@@ -3101,16 +3229,16 @@ class TmuxSession(TransportReplacementMixin):
                     "spawn; the in-pane command exited before the REPL became "
                     "available (inspect in-pane startup and authentication errors)"
                 )
-        except BaseException:
+        except BaseException as exc:
             # ``new-session`` already succeeded, so cancellation during the
             # delay or an exception from the liveness probe can otherwise
             # leave a live tmux REPL unmanaged while the caller transitions
-            # the Python state machine to DEAD. Reap best-effort and preserve
-            # the original failure (including CancelledError).
-            try:
-                await self._tmux.kill_session()
-            except BaseException:
-                pass
+            # the Python state machine to DEAD. Strict rollback stays bounded
+            # and preserves the original failure (including CancelledError).
+            rollback_failure = await self._rollback_spawned_session(
+                site="post-spawn liveness"
+            )
+            self._annotate_spawn_rollback_failure(exc, rollback_failure)
             raise
 
         # NOTE: ``force_fresh_context_once`` consumption is deferred to
@@ -3127,7 +3255,7 @@ class TmuxSession(TransportReplacementMixin):
         # symmetric "spawn raised → caller transitions DEAD" semantics.
         try:
             await self._start_tailer()
-        except Exception:
+        except BaseException as exc:
             # Murzik's PR #496 round-3 cleanup-hole fix: if _start_tailer
             # raises AFTER constructing self._tailer but before/during
             # the await on start(), we'd otherwise transition DEAD with
@@ -3136,15 +3264,13 @@ class TmuxSession(TransportReplacementMixin):
             # clean state. Symmetric with the tmux kill below.
             try:
                 await self._stop_tailer()
-            except Exception:
+            except BaseException:
                 pass
             self._tailer = None
-            try:
-                await self._tmux.kill_session()
-            except Exception:
-                # Best-effort cleanup; ignore failure since we're already
-                # re-raising the tailer-start error to the caller.
-                pass
+            rollback_failure = await self._rollback_spawned_session(
+                site="tailer-start failure"
+            )
+            self._annotate_spawn_rollback_failure(exc, rollback_failure)
             raise
 
         # REPL + tailer are both up as a unit — NOW it's safe to

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -669,9 +669,15 @@ class _TmuxControl:
         """Kill the tmux session. Idempotent — succeeds whether or not the
         session exists (callers shouldn't pre-check)."""
         result = await self._run("kill-session", "-t", self.session_name)
-        # tmux returns 1 if the session didn't exist; treat that as ok
-        # so callers can use this idempotently.
-        if not result.ok and "can't find session" in result.stderr:
+        if result.ok:
+            return result
+        # Do not classify absence from stderr: tmux versions and platforms use
+        # different text for a missing session versus a missing server/socket.
+        # Verify the owned target's state after the failed kill instead. A
+        # session still reported alive preserves the original failure so strict
+        # replacement callers fail closed; an already-gone target makes the
+        # kill idempotently successful. Probe exceptions still propagate.
+        if not await self.has_session():
             return TmuxCommandResult(returncode=0, stdout="", stderr=result.stderr)
         return result
 
@@ -3664,8 +3670,8 @@ class TmuxSession(TransportReplacementMixin):
         # so stats/path persist; only the background task is cancelled.
         await self._stop_tailer()
 
-        # Kill tmux session. ``kill_session`` is idempotent (treats
-        # "can't find session" as ok).
+        # Kill tmux session. ``kill_session`` is idempotent after verifying
+        # that a failed kill left no owned session behind.
         try:
             await self._tmux.kill_session()
         except Exception as e:

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -642,6 +642,54 @@ class _TmuxControl:
         result = await self._run("has-session", "-t", self.session_name)
         return result.ok
 
+    def _local_socket_path(self) -> Path | None:
+        """Return the socket path used by a locally executed tmux command.
+
+        A missing socket is the one stderr-independent proof that a failed
+        command cannot have left a live server behind.  Wrapped runners may
+        execute in another filesystem namespace, so their socket cannot be
+        safely statted from the daemon process and deliberately returns
+        ``None``.
+        """
+        if not isinstance(self._runner, LocalCommandRunner):
+            return None
+        if not self.socket_name:
+            inherited = os.environ.get("TMUX", "")
+            inherited_parts = inherited.rsplit(",", 2)
+            if len(inherited_parts) == 3 and inherited_parts[0]:
+                return Path(inherited_parts[0])
+        socket_dir = Path(os.environ.get("TMUX_TMPDIR") or "/tmp")
+        return socket_dir / f"tmux-{os.getuid()}" / (self.socket_name or "default")
+
+    def _server_socket_is_missing(self) -> bool:
+        """Return True only when local socket absence is positively known."""
+        socket_path = self._local_socket_path()
+        if socket_path is None:
+            return False
+        try:
+            os.lstat(socket_path)
+        except FileNotFoundError:
+            return True
+        except OSError:
+            # Permission, transport, and other stat errors are not absence.
+            return False
+        return False
+
+    async def _session_absence_is_verified(self) -> bool:
+        """Prove the owned target absent without classifying tmux stderr."""
+        if self._server_socket_is_missing():
+            return True
+        listing = await self._run("list-sessions", "-F", "#{session_name}")
+        if not listing.ok:
+            return False
+        session_names = listing.stdout.splitlines()
+        # A live tmux server cannot successfully enumerate zero sessions.
+        # Treat empty/malformed output conservatively instead of inventing
+        # absence from an ambiguous result.
+        if not session_names or any(not name for name in session_names):
+            return False
+        return self.session_name not in session_names
+
     async def new_session(
         self,
         *,
@@ -673,11 +721,12 @@ class _TmuxControl:
             return result
         # Do not classify absence from stderr: tmux versions and platforms use
         # different text for a missing session versus a missing server/socket.
-        # Verify the owned target's state after the failed kill instead. A
-        # session still reported alive preserves the original failure so strict
-        # replacement callers fail closed; an already-gone target makes the
-        # kill idempotently successful. Probe exceptions still propagate.
-        if not await self.has_session():
+        # Positive absence is either a missing local server socket, or an rc=0
+        # session enumeration which omits the owned target. Non-ok probes,
+        # ambiguous output, stat errors, and a still-listed target all preserve
+        # the original failure so strict replacement callers fail closed.
+        # Probe exceptions still propagate.
+        if await self._session_absence_is_verified():
             return TmuxCommandResult(returncode=0, stdout="", stderr=result.stderr)
         return result
 

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -2858,6 +2858,9 @@ class TmuxSession(TransportReplacementMixin):
                 f"(reason={reason.value}) — session remains CONNECTED"
             )
 
+    def _prepare_tmux_spawn(self) -> None:
+        """Publish transport-specific state at the final spawn boundary."""
+
     async def _spawn_tmux_repl(self) -> None:
         """Spawn the tmux session and the in-pane claude REPL, then start
         the response tailer.
@@ -2944,13 +2947,27 @@ class TmuxSession(TransportReplacementMixin):
 
         # If a stale session is left over from a previous daemon run (e.g.
         # crash without graceful disconnect), reap it. We're the cold-start
-        # owner; reclaiming the name is safe.
+        # owner; reclaiming the name is safe. A non-ok result is a known failed
+        # precondition, not best-effort cleanup: abort before the transport's
+        # spawn hook can publish state for a child that will never launch.
         if await self._tmux.has_session():
             _log(
                 f"tmux[{self.agent_name}]: stale session {self._session_name} "
                 f"found, reaping before fresh spawn"
             )
-            await self._tmux.kill_session()
+            kill_result = await self._tmux.kill_session()
+            if not kill_result.ok:
+                raise RuntimeError(
+                    f"tmux[{self.agent_name}]: stale kill-session failed before "
+                    f"spawn: rc={kill_result.returncode} "
+                    f"stderr={kill_result.stderr.strip()!r}"
+                )
+
+        # Transport-specific state publication belongs after every teardown
+        # precondition and immediately before command/env construction. The
+        # default is a no-op; Codex uses this exact boundary for AGENTS.md and
+        # soul-version publication.
+        self._prepare_tmux_spawn()
 
         # Build the in-pane command. ``claude --continue`` resumes the
         # most-recent transcript for ``cwd``; falls back to fresh session

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -74,6 +74,7 @@ from pinky_daemon.command_runner import (
     CommandRunner,
     ContainerCommandRunner,
     LocalCommandRunner,
+    RunuserCommandRunner,
 )
 from pinky_daemon.effort import EFFORT_LEVELS, is_ultracode, resolve_cli_effort
 from pinky_daemon.pricing import compute_cost_from_usage
@@ -567,6 +568,7 @@ class _TmuxControl:
         *,
         tmux_binary: str = "tmux",
         socket_name: str = "",
+        socket_path: str = "",
         command_runner: CommandRunner | None = None,
     ) -> None:
         self.session_name = session_name
@@ -574,6 +576,10 @@ class _TmuxControl:
         # An explicit socket isolates Pinky's tmux sessions from the
         # operator's own. Empty = use tmux's default socket.
         self.socket_name = socket_name
+        # Cleanup-debt replay pins the exact local server path with ``-S`` so
+        # a daemon restart under a changed TMUX/TMUX_TMPDIR cannot silently
+        # target a different server. Ordinary controls leave this empty.
+        self.socket_path = socket_path
         # #149 phase-3 execution seam: who runs the tmux subprocess. Default
         # LocalCommandRunner reproduces the prior inline create_subprocess_exec
         # verbatim (daemon's own user). An isolation_mode='unix_user' tenant is
@@ -595,7 +601,9 @@ class _TmuxControl:
 
     def _base_cmd(self) -> list[str]:
         cmd = [self.tmux_binary]
-        if self.socket_name:
+        if self.socket_path:
+            cmd.extend(["-S", self.socket_path])
+        elif self.socket_name:
             cmd.extend(["-L", self.socket_name])
         return cmd
 
@@ -669,6 +677,8 @@ class _TmuxControl:
         """
         if not isinstance(self._runner, LocalCommandRunner):
             return None
+        if self.socket_path:
+            return Path(self.socket_path)
         if not self.socket_name:
             inherited = os.environ.get("TMUX", "")
             inherited_parts = inherited.rsplit(",", 2)
@@ -926,6 +936,349 @@ class _TmuxControl:
             args.append("-J")  # join wrapped lines (de-wrap long URLs)
         args.extend(["-S", str(-abs(lines))])
         return await self._run(*args)
+
+
+_TMUX_SPAWN_CLEANUP_DEBT_DIR = "tmux-spawn-cleanup-debt"
+_TMUX_SPAWN_CLEANUP_DEBT_VERSION = 1
+
+
+def _tmux_spawn_cleanup_identity_key(
+    *,
+    agent_name: str,
+    session_name: str,
+) -> str:
+    # One owned session name per agent. Keep the record location stable when
+    # daemon environment or execution mode changes; the JSON retains the full
+    # binary/socket/runner identity needed to reach the original child.
+    raw = "\0".join((agent_name, session_name))
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+@dataclass(frozen=True)
+class _TmuxSpawnCleanupDebt:
+    """Durable identity for an owned tmux child whose teardown is unresolved."""
+
+    agent_name: str
+    session_name: str
+    socket_name: str
+    socket_path: str
+    tmux_binary: str
+    runner: dict[str, object]
+    site: str
+    created_at: float
+
+    def identity_key(self) -> str:
+        return _tmux_spawn_cleanup_identity_key(
+            agent_name=self.agent_name,
+            session_name=self.session_name,
+        )
+
+    def to_json(self) -> str:
+        return json.dumps(
+            {
+                "version": _TMUX_SPAWN_CLEANUP_DEBT_VERSION,
+                "agent_name": self.agent_name,
+                "session_name": self.session_name,
+                "socket_name": self.socket_name,
+                "socket_path": self.socket_path,
+                "tmux_binary": self.tmux_binary,
+                "runner": self.runner,
+                "site": self.site,
+                "created_at": self.created_at,
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        ) + "\n"
+
+    @classmethod
+    def from_path(cls, path: Path) -> _TmuxSpawnCleanupDebt:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(raw, dict):
+            raise ValueError("record root is not an object")
+        if raw.get("version") != _TMUX_SPAWN_CLEANUP_DEBT_VERSION:
+            raise ValueError(f"unsupported record version {raw.get('version')!r}")
+        required_strings = (
+            "agent_name",
+            "session_name",
+            "socket_name",
+            "socket_path",
+            "tmux_binary",
+            "site",
+        )
+        if any(not isinstance(raw.get(key), str) for key in required_strings):
+            raise ValueError("record identity fields must be strings")
+        if not raw["agent_name"] or not raw["session_name"] or not raw["tmux_binary"]:
+            raise ValueError("record identity fields must be non-empty")
+        runner = raw.get("runner")
+        if not isinstance(runner, dict) or not isinstance(runner.get("kind"), str):
+            raise ValueError("record runner is invalid")
+        try:
+            created_at = float(raw["created_at"])
+        except (KeyError, TypeError, ValueError) as exc:
+            raise ValueError("record created_at is invalid") from exc
+        record = cls(
+            agent_name=raw["agent_name"],
+            session_name=raw["session_name"],
+            socket_name=raw["socket_name"],
+            socket_path=raw["socket_path"],
+            tmux_binary=raw["tmux_binary"],
+            runner=runner,
+            site=raw["site"],
+            created_at=created_at,
+        )
+        if path.name != f"{record.identity_key()}.json":
+            raise ValueError("record filename does not match owned identity")
+        return record
+
+
+def _tmux_cleanup_runner_spec(runner: CommandRunner) -> dict[str, object]:
+    if isinstance(runner, ContainerCommandRunner):
+        return {
+            "kind": "container",
+            "container": runner.container,
+            "user": runner.user,
+            "workdir": runner.workdir,
+            "container_binary": runner.container_binary,
+        }
+    if isinstance(runner, RunuserCommandRunner):
+        return {
+            "kind": "runuser",
+            "username": runner.username,
+            "runuser_binary": runner.runuser_binary,
+        }
+    if isinstance(runner, LocalCommandRunner):
+        return {"kind": "local"}
+    raise TypeError(
+        f"unsupported tmux cleanup runner {type(runner).__name__}; "
+        "cannot durably retain its execution identity"
+    )
+
+
+def _tmux_cleanup_runner_from_spec(spec: dict[str, object]) -> CommandRunner:
+    kind = spec.get("kind")
+    if kind == "local":
+        return LocalCommandRunner()
+    if kind == "runuser":
+        username = spec.get("username")
+        binary = spec.get("runuser_binary")
+        if not isinstance(username, str) or not username:
+            raise ValueError("runuser cleanup record has no username")
+        if not isinstance(binary, str) or not binary:
+            raise ValueError("runuser cleanup record has no binary")
+        return RunuserCommandRunner(username, runuser_binary=binary)
+    if kind == "container":
+        container = spec.get("container")
+        binary = spec.get("container_binary")
+        user = spec.get("user")
+        workdir = spec.get("workdir")
+        if not isinstance(container, str) or not container:
+            raise ValueError("container cleanup record has no container")
+        if not isinstance(binary, str) or not binary:
+            raise ValueError("container cleanup record has no binary")
+        if user is not None and not isinstance(user, str):
+            raise ValueError("container cleanup record user is invalid")
+        if workdir is not None and not isinstance(workdir, str):
+            raise ValueError("container cleanup record workdir is invalid")
+        return ContainerCommandRunner(
+            container,
+            user=user,
+            workdir=workdir,
+            container_binary=binary,
+        )
+    raise ValueError(f"unsupported cleanup runner kind {kind!r}")
+
+
+def _tmux_spawn_cleanup_debt_dir(state_dir: Path) -> Path:
+    return state_dir / _TMUX_SPAWN_CLEANUP_DEBT_DIR
+
+
+def _fsync_directory(path: Path) -> None:
+    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0)
+    fd = os.open(path, flags)
+    try:
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+
+
+def _persist_tmux_spawn_cleanup_debt(
+    state_dir: Path,
+    debt: _TmuxSpawnCleanupDebt,
+) -> Path:
+    """Atomically retain cleanup debt before bounded teardown starts."""
+    debt_dir = _tmux_spawn_cleanup_debt_dir(state_dir)
+    debt_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+    try:
+        debt_dir.chmod(0o700)
+    except OSError:
+        pass
+    path = debt_dir / f"{debt.identity_key()}.json"
+    tmp_path = debt_dir / f".{path.name}.{os.getpid()}.{time.time_ns()}.tmp"
+    fd = os.open(tmp_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    try:
+        payload = debt.to_json().encode("utf-8")
+        offset = 0
+        while offset < len(payload):
+            offset += os.write(fd, payload[offset:])
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+    try:
+        try:
+            # link() is the publish point: atomic and no-clobber, so two
+            # concurrent rollback owners cannot overwrite each other's debt.
+            os.link(tmp_path, path)
+        except FileExistsError:
+            existing = _TmuxSpawnCleanupDebt.from_path(path)
+            if existing.identity_key() != debt.identity_key():
+                raise RuntimeError("cleanup debt identity collision")
+            if (
+                existing.tmux_binary != debt.tmux_binary
+                or existing.socket_name != debt.socket_name
+                or existing.socket_path != debt.socket_path
+                or existing.runner != debt.runner
+            ):
+                raise RuntimeError(
+                    "cleanup debt already exists for this agent/session under "
+                    "a different tmux execution identity"
+                )
+        _fsync_directory(debt_dir)
+    finally:
+        try:
+            tmp_path.unlink()
+        except FileNotFoundError:
+            pass
+    return path
+
+
+def _clear_tmux_spawn_cleanup_debt(path: Path) -> None:
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        return
+    _fsync_directory(path.parent)
+
+
+async def _strict_owned_tmux_cleanup(
+    control: _TmuxControl,
+    *,
+    agent_name: str,
+    action: str,
+) -> str | None:
+    """Prove teardown under per-command limits and one hard outer deadline."""
+
+    async def _attempts() -> str | None:
+        diagnostics: list[str] = []
+        for attempt in range(1, _SPAWN_ROLLBACK_ATTEMPTS + 1):
+            try:
+                async with asyncio.timeout(_SPAWN_ROLLBACK_COMMAND_TIMEOUT_SEC):
+                    kill_result = await control.kill_session()
+            except Exception as exc:
+                diagnostics.append(
+                    f"attempt {attempt} kill raised {type(exc).__name__}: {exc}"
+                )
+            else:
+                if kill_result.ok:
+                    _log(
+                        f"tmux[{agent_name}]: {action} proved teardown on "
+                        f"kill attempt {attempt}"
+                    )
+                    return None
+                diagnostics.append(
+                    f"attempt {attempt} kill returned rc={kill_result.returncode} "
+                    f"stderr={kill_result.stderr.strip()!r}"
+                )
+
+            try:
+                async with asyncio.timeout(_SPAWN_ROLLBACK_COMMAND_TIMEOUT_SEC):
+                    live = await control.has_session()
+            except Exception as exc:
+                diagnostics.append(
+                    f"attempt {attempt} verify couldn't answer "
+                    f"({type(exc).__name__}: {exc})"
+                )
+            else:
+                if not live:
+                    _log(
+                        f"tmux[{agent_name}]: {action} verified absence after "
+                        f"failed kill attempt {attempt}"
+                    )
+                    return None
+                diagnostics.append(f"attempt {attempt} verify found session live")
+
+            if attempt < _SPAWN_ROLLBACK_ATTEMPTS:
+                await asyncio.sleep(_SPAWN_ROLLBACK_RETRY_DELAY_SEC)
+
+        message = (
+            f"tmux[{agent_name}]: {action} could not prove teardown after "
+            f"{_SPAWN_ROLLBACK_ATTEMPTS} attempts; owned session is possibly "
+            f"live: {'; '.join(diagnostics)}"
+        )
+        _log(f"ERROR {message}")
+        return message
+
+    try:
+        async with asyncio.timeout(_SPAWN_ROLLBACK_TIMEOUT_SEC):
+            return await _attempts()
+    except TimeoutError as exc:
+        message = (
+            f"tmux[{agent_name}]: {action} could not prove teardown within "
+            f"{_SPAWN_ROLLBACK_TIMEOUT_SEC}s; owned session is possibly live "
+            f"({type(exc).__name__}: {exc})"
+        )
+        _log(f"ERROR {message}")
+        return message
+
+
+async def reconcile_tmux_spawn_cleanup_debts(
+    state_dir: Path,
+    *,
+    _control_factory=None,
+) -> tuple[int, int]:
+    """Daemon-boot reaper for every durable, pre-registration tmux debt."""
+    debt_dir = _tmux_spawn_cleanup_debt_dir(Path(state_dir))
+    if not debt_dir.exists():
+        return (0, 0)
+
+    reaped = 0
+    outstanding = 0
+    for path in sorted(debt_dir.glob("*.json")):
+        try:
+            debt = _TmuxSpawnCleanupDebt.from_path(path)
+            _log(
+                f"ERROR tmux[{debt.agent_name}]: retained spawn cleanup debt "
+                f"is outstanding at daemon boot ({path})"
+            )
+            control = (
+                _control_factory(debt)
+                if _control_factory is not None
+                else _TmuxControl(
+                    debt.session_name,
+                    tmux_binary=debt.tmux_binary,
+                    socket_name=debt.socket_name,
+                    socket_path=debt.socket_path,
+                    command_runner=_tmux_cleanup_runner_from_spec(debt.runner),
+                )
+            )
+            failure = await _strict_owned_tmux_cleanup(
+                control,
+                agent_name=debt.agent_name,
+                action="daemon-boot retained spawn cleanup",
+            )
+            if failure is not None:
+                outstanding += 1
+                continue
+            _clear_tmux_spawn_cleanup_debt(path)
+            reaped += 1
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            outstanding += 1
+            _log(
+                f"ERROR tmux spawn cleanup debt reconciliation failed for "
+                f"{path}: {type(exc).__name__}: {exc}"
+            )
+    return (reaped, outstanding)
 
 
 # ──────────────────────────────────────────────────────────────────────────
@@ -2943,6 +3296,76 @@ class TmuxSession(TransportReplacementMixin):
     def _prepare_tmux_spawn(self) -> None:
         """Publish transport-specific state at the final spawn boundary."""
 
+    def _spawn_cleanup_state_dir(self) -> Path:
+        registry_path = getattr(self._registry, "_db_path", "")
+        if isinstance(registry_path, str) and registry_path:
+            return Path(registry_path).resolve().parent
+        return Path(self._config.working_dir or ".").resolve() / "data"
+
+    def _spawn_cleanup_debt(self, *, site: str) -> _TmuxSpawnCleanupDebt:
+        local_socket_path = self._tmux._local_socket_path()
+        return _TmuxSpawnCleanupDebt(
+            agent_name=self.agent_name,
+            session_name=self._tmux.session_name,
+            socket_name=self._tmux.socket_name,
+            socket_path=str(local_socket_path) if local_socket_path is not None else "",
+            tmux_binary=self._tmux.tmux_binary,
+            runner=_tmux_cleanup_runner_spec(self._tmux._runner),
+            site=site,
+            created_at=time.time(),
+        )
+
+    def _spawn_cleanup_debt_path(self) -> Path:
+        session_name = getattr(self._tmux, "session_name", self._session_name)
+        if not isinstance(session_name, str):
+            session_name = self._session_name
+        identity_key = _tmux_spawn_cleanup_identity_key(
+            agent_name=self.agent_name,
+            session_name=session_name,
+        )
+        return (
+            _tmux_spawn_cleanup_debt_dir(self._spawn_cleanup_state_dir())
+            / f"{identity_key}.json"
+        )
+
+    async def _reap_retained_spawn_cleanup_debt(self) -> None:
+        """Next-spawn preflight: resolve this agent's retained child first."""
+        path = self._spawn_cleanup_debt_path()
+        if not path.exists():
+            return
+        debt = _TmuxSpawnCleanupDebt.from_path(path)
+        _log(
+            f"ERROR tmux[{self.agent_name}]: retained spawn cleanup debt is "
+            f"outstanding at next-spawn preflight ({path})"
+        )
+        current_runner = _tmux_cleanup_runner_spec(self._tmux._runner)
+        current_socket_path = self._tmux._local_socket_path()
+        if (
+            debt.session_name == self._tmux.session_name
+            and debt.socket_name == self._tmux.socket_name
+            and debt.socket_path
+            == (str(current_socket_path) if current_socket_path is not None else "")
+            and debt.tmux_binary == self._tmux.tmux_binary
+            and debt.runner == current_runner
+        ):
+            control = self._tmux
+        else:
+            control = _TmuxControl(
+                debt.session_name,
+                tmux_binary=debt.tmux_binary,
+                socket_name=debt.socket_name,
+                socket_path=debt.socket_path,
+                command_runner=_tmux_cleanup_runner_from_spec(debt.runner),
+            )
+        failure = await _strict_owned_tmux_cleanup(
+            control,
+            agent_name=debt.agent_name,
+            action="next-spawn retained spawn cleanup",
+        )
+        if failure is not None:
+            raise RuntimeError(f"{failure}; cleanup debt retained at {path}")
+        _clear_tmux_spawn_cleanup_debt(path)
+
     async def _rollback_spawned_session(self, *, site: str) -> str | None:
         """Strictly and boundedly roll back a possibly-created tmux session.
 
@@ -2959,84 +3382,52 @@ class TmuxSession(TransportReplacementMixin):
         that the caller must attach to the original exception.
         """
 
-        async def _attempts() -> str | None:
-            diagnostics: list[str] = []
-            for attempt in range(1, _SPAWN_ROLLBACK_ATTEMPTS + 1):
-                try:
-                    kill_result = await asyncio.wait_for(
-                        self._tmux.kill_session(),
-                        timeout=_SPAWN_ROLLBACK_COMMAND_TIMEOUT_SEC,
-                    )
-                except BaseException as exc:
-                    diagnostics.append(
-                        f"attempt {attempt} kill raised "
-                        f"{type(exc).__name__}: {exc}"
-                    )
-                else:
-                    if kill_result.ok:
-                        _log(
-                            f"tmux[{self.agent_name}]: spawn rollback at "
-                            f"{site} proved teardown on kill attempt {attempt}"
-                        )
-                        return None
-                    diagnostics.append(
-                        f"attempt {attempt} kill returned "
-                        f"rc={kill_result.returncode} "
-                        f"stderr={kill_result.stderr.strip()!r}"
-                    )
-
-                # False is verified absence; True is live; a raise is
-                # couldn't-answer. Only the first state is clean.
-                try:
-                    live = await asyncio.wait_for(
-                        self._tmux.has_session(),
-                        timeout=_SPAWN_ROLLBACK_COMMAND_TIMEOUT_SEC,
-                    )
-                except BaseException as exc:
-                    diagnostics.append(
-                        f"attempt {attempt} verify couldn't answer "
-                        f"({type(exc).__name__}: {exc})"
-                    )
-                else:
-                    if not live:
-                        _log(
-                            f"tmux[{self.agent_name}]: spawn rollback at "
-                            f"{site} verified absence after failed kill "
-                            f"attempt {attempt}"
-                        )
-                        return None
-                    diagnostics.append(
-                        f"attempt {attempt} verify found session live"
-                    )
-
-                if attempt < _SPAWN_ROLLBACK_ATTEMPTS:
-                    await asyncio.sleep(_SPAWN_ROLLBACK_RETRY_DELAY_SEC)
-
-            message = (
-                f"tmux[{self.agent_name}]: spawn rollback at {site} could not "
-                f"prove teardown after {_SPAWN_ROLLBACK_ATTEMPTS} attempts; "
-                f"owned session is possibly live: {'; '.join(diagnostics)}"
+        debt_path: Path | None = None
+        debt_persist_error: Exception | None = None
+        try:
+            debt_path = _persist_tmux_spawn_cleanup_debt(
+                self._spawn_cleanup_state_dir(),
+                self._spawn_cleanup_debt(site=site),
             )
-            _log(f"ERROR {message}")
-            return message
+        except Exception as exc:
+            debt_persist_error = exc
+            _log(
+                f"ERROR tmux[{self.agent_name}]: could not persist spawn "
+                f"cleanup debt before {site} rollback: {type(exc).__name__}: {exc}"
+            )
 
-        async def _bounded() -> str | None:
-            try:
-                return await asyncio.wait_for(
-                    _attempts(), timeout=_SPAWN_ROLLBACK_TIMEOUT_SEC
+        async def _cleanup() -> str | None:
+            failure = await _strict_owned_tmux_cleanup(
+                self._tmux,
+                agent_name=self.agent_name,
+                action=f"spawn rollback at {site}",
+            )
+            if failure is None:
+                if debt_path is not None:
+                    try:
+                        _clear_tmux_spawn_cleanup_debt(debt_path)
+                    except Exception as exc:
+                        _log(
+                            f"ERROR tmux[{self.agent_name}]: teardown proved but "
+                            f"cleanup debt clear failed at {debt_path}: "
+                            f"{type(exc).__name__}: {exc}"
+                        )
+                return None
+            if debt_path is not None:
+                failure = f"{failure}; cleanup debt retained at {debt_path}"
+                _log(
+                    f"ERROR tmux[{self.agent_name}]: retained spawn cleanup "
+                    f"debt remains outstanding at {debt_path}"
                 )
-            except BaseException as exc:
-                message = (
-                    f"tmux[{self.agent_name}]: spawn rollback at {site} "
-                    f"could not prove teardown within "
-                    f"{_SPAWN_ROLLBACK_TIMEOUT_SEC}s; owned session is "
-                    f"possibly live ({type(exc).__name__}: {exc})"
+            elif debt_persist_error is not None:
+                failure = (
+                    f"{failure}; cleanup debt persistence failed "
+                    f"({type(debt_persist_error).__name__}: {debt_persist_error})"
                 )
-                _log(f"ERROR {message}")
-                return message
+            return failure
 
         cleanup_task = asyncio.create_task(
-            _bounded(), name=f"tmux-spawn-rollback-{self.agent_name}"
+            _cleanup(), name=f"tmux-spawn-rollback-{self.agent_name}"
         )
         while True:
             try:
@@ -3044,6 +3435,15 @@ class TmuxSession(TransportReplacementMixin):
             except asyncio.CancelledError:
                 # Preserve the exception that selected this rollback site.
                 # A second cancellation cannot strand bounded cleanup.
+                if cleanup_task.cancelled():
+                    message = (
+                        f"tmux[{self.agent_name}]: spawn rollback at {site} "
+                        "cleanup task was cancelled; owned session is possibly live"
+                    )
+                    if debt_path is not None:
+                        message = f"{message}; cleanup debt retained at {debt_path}"
+                    _log(f"ERROR {message}")
+                    return message
                 continue
 
     @staticmethod
@@ -3101,6 +3501,13 @@ class TmuxSession(TransportReplacementMixin):
         # umbrella below — this can include a multi-minute image pull and
         # runs under its own budget (see _ensure_container_started).
         await self._ensure_container_started(container_agent)
+
+        # A prior spawn may have exhausted bounded rollback while its owned
+        # child was still live or unobservable. That debt is durable precisely
+        # because this session was never registered with the broker/watchdog.
+        # Resolve it before the ordinary stale-session probe and before any new
+        # spawn side effects; an unresolved record fails this spawn closed.
+        await self._reap_retained_spawn_cleanup_debt()
 
         # If a stale session is left over from a previous daemon run (e.g.
         # crash without graceful disconnect), reap it. We're the cold-start
@@ -3202,8 +3609,26 @@ class TmuxSession(TransportReplacementMixin):
             # observation window.
             self._watchdog_frozen_live_status = None
 
+        current_task = asyncio.current_task()
+        cancel_requests_before_spawn = (
+            current_task.cancelling() if current_task is not None else 0
+        )
         try:
-            await asyncio.wait_for(_spawn(), timeout=_COLD_START_TIMEOUT_SEC)
+            # Python 3.11's wait_for() can consume an accepted caller
+            # cancellation when its inner task has completed but its waiter has
+            # not resumed yet (tasks.py's ``if fut.done(): return fut.result()``
+            # branch). A task-local timeout context removes that inner-task
+            # completion race. The residual cancel-count check also covers a
+            # cancellation requested synchronously at the final _spawn await,
+            # before the task has another suspension point at which to inject
+            # CancelledError.
+            async with asyncio.timeout(_COLD_START_TIMEOUT_SEC):
+                await _spawn()
+            if (
+                current_task is not None
+                and current_task.cancelling() > cancel_requests_before_spawn
+            ):
+                raise asyncio.CancelledError
         except asyncio.TimeoutError as exc:
             rollback_failure = await self._rollback_spawned_session(
                 site="cold-start timeout"
@@ -3215,6 +3640,12 @@ class TmuxSession(TransportReplacementMixin):
             if rollback_failure is not None:
                 message = f"{message}; {rollback_failure}"
             raise RuntimeError(message) from exc
+        except asyncio.CancelledError as exc:
+            rollback_failure = await self._rollback_spawned_session(
+                site="cold-start cancellation"
+            )
+            self._annotate_spawn_rollback_failure(exc, rollback_failure)
+            raise
 
         # ``tmux new-session -d`` only proves that tmux launched the in-pane
         # command. The command can then fail fast (bad CLI flag, auth error,

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -638,9 +638,25 @@ class _TmuxControl:
         )
 
     async def has_session(self) -> bool:
-        """Return True if a tmux session with our name exists."""
+        """Return presence, or False only after positively proving absence.
+
+        ``tmux has-session`` uses a non-zero status both for an absent target
+        and for transport/permission failures.  Collapsing those cases to
+        False lets spawn callers overwrite state while the owned session may
+        still be live.  Preserve that third, ambiguous state as an exception;
+        callers that merely observe liveness already treat probe exceptions as
+        diagnostic uncertainty.
+        """
         result = await self._run("has-session", "-t", self.session_name)
-        return result.ok
+        if result.ok:
+            return True
+        if await self._session_absence_is_verified():
+            return False
+        raise RuntimeError(
+            f"tmux has-session failed without verified absence: "
+            f"rc={result.returncode} stdout={result.stdout.strip()!r} "
+            f"stderr={result.stderr.strip()!r}"
+        )
 
     def _local_socket_path(self) -> Path | None:
         """Return the socket path used by a locally executed tmux command.
@@ -2957,6 +2973,25 @@ class TmuxSession(TransportReplacementMixin):
         # runs under its own budget (see _ensure_container_started).
         await self._ensure_container_started(container_agent)
 
+        # If a stale session is left over from a previous daemon run (e.g.
+        # crash without graceful disconnect), reap it. We're the cold-start
+        # owner; reclaiming the name is safe. Ambiguous ``has-session`` and
+        # non-ok kill results are failed preconditions: abort before env
+        # construction, trust seeding, or the transport's spawn hook can
+        # publish state for a child that will never launch.
+        if await self._tmux.has_session():
+            _log(
+                f"tmux[{self.agent_name}]: stale session {self._session_name} "
+                f"found, reaping before fresh spawn"
+            )
+            kill_result = await self._tmux.kill_session()
+            if not kill_result.ok:
+                raise RuntimeError(
+                    f"tmux[{self.agent_name}]: stale kill-session failed before "
+                    f"spawn: rc={kill_result.returncode} "
+                    f"stderr={kill_result.stderr.strip()!r}"
+                )
+
         # Pre-seed Claude Code's first-run trust/bypass flags (#112) so a
         # FRESH REPL doesn't wedge on the "trust this folder?" / "Bypass
         # Permissions mode" gates that --dangerously-skip-permissions does
@@ -2999,24 +3034,6 @@ class TmuxSession(TransportReplacementMixin):
         # the fresh launch carries the stashed override via --effort, and
         # typing into the new pane's splash phase would get eaten anyway.
         self._pending_live_effort = None
-
-        # If a stale session is left over from a previous daemon run (e.g.
-        # crash without graceful disconnect), reap it. We're the cold-start
-        # owner; reclaiming the name is safe. A non-ok result is a known failed
-        # precondition, not best-effort cleanup: abort before the transport's
-        # spawn hook can publish state for a child that will never launch.
-        if await self._tmux.has_session():
-            _log(
-                f"tmux[{self.agent_name}]: stale session {self._session_name} "
-                f"found, reaping before fresh spawn"
-            )
-            kill_result = await self._tmux.kill_session()
-            if not kill_result.ok:
-                raise RuntimeError(
-                    f"tmux[{self.agent_name}]: stale kill-session failed before "
-                    f"spawn: rc={kill_result.returncode} "
-                    f"stderr={kill_result.stderr.strip()!r}"
-                )
 
         # Transport-specific state publication belongs after every teardown
         # precondition and immediately before command/env construction. The

--- a/tests/test_codex_home.py
+++ b/tests/test_codex_home.py
@@ -170,9 +170,119 @@ def test_prepare_replaces_linked_soul_without_writing_its_shared_target(
     assert agents_md.read_text(encoding="utf-8") == "compiled soul"
     assert shared_soul.read_text(encoding="utf-8") == "shared operator soul"
     assert soul_store.calls == [
-        ("test-agent", "shared operator soul", "agent"),
         ("test-agent", "compiled soul", "spawn"),
     ]
+
+
+def test_prepare_replaces_dangling_soul_symlink_without_creating_target(
+    tmp_path,
+    monkeypatch,
+):
+    shared_home = tmp_path / "shared"
+    working_dir = tmp_path / "agent"
+    agent_home = working_dir / ".codex"
+    working_dir.mkdir()
+    agent_home.mkdir()
+    _auth(shared_home)
+    missing_target = shared_home / "missing-operator-soul.md"
+    agents_md = agent_home / "AGENTS.md"
+    agents_md.symlink_to(missing_target)
+    monkeypatch.setenv("CODEX_HOME", str(shared_home))
+    monkeypatch.setenv(PER_AGENT_CODEX_HOME_ENV, "1")
+    soul_store = _SoulStore()
+
+    prepare_agent_codex_home(
+        _scope(working_dir, system_prompt="compiled soul"),
+        log=lambda _message: None,
+        soul_version_store=soul_store,
+    )
+
+    assert not agents_md.is_symlink()
+    assert agents_md.read_text(encoding="utf-8") == "compiled soul"
+    assert not missing_target.exists()
+    assert soul_store.calls == [("test-agent", "compiled soul", "spawn")]
+
+
+def test_prepare_publishes_soul_mode_0600_under_restrictive_umask(
+    tmp_path,
+    monkeypatch,
+):
+    shared_home = tmp_path / "shared"
+    working_dir = tmp_path / "agent"
+    working_dir.mkdir()
+    _auth(shared_home)
+    monkeypatch.setenv("CODEX_HOME", str(shared_home))
+    monkeypatch.setenv(PER_AGENT_CODEX_HOME_ENV, "1")
+
+    previous_umask = os.umask(0o777)
+    try:
+        prepare_agent_codex_home(
+            _scope(working_dir, system_prompt="compiled soul"),
+            log=lambda _message: None,
+            soul_version_store=_SoulStore(),
+        )
+    finally:
+        os.umask(previous_umask)
+
+    agents_md = working_dir / ".codex" / "AGENTS.md"
+    assert stat.S_IMODE(agents_md.stat().st_mode) == 0o600
+    assert agents_md.read_text(encoding="utf-8") == "compiled soul"
+
+
+def test_shared_home_equality_refuses_before_every_writer_and_preserves_bytes(
+    tmp_path,
+    monkeypatch,
+):
+    shared_home = tmp_path / "shared"
+    working_dir = tmp_path / "agent"
+    working_dir.mkdir()
+    _auth(shared_home)
+    (shared_home / "AGENTS.md").write_text("shared operator soul", encoding="utf-8")
+    (shared_home / "config.toml").write_text("shared operator config", encoding="utf-8")
+    before = {
+        path.name: path.read_bytes()
+        for path in shared_home.iterdir()
+        if path.is_file()
+    }
+    monkeypatch.setenv("CODEX_HOME", str(shared_home))
+    monkeypatch.setenv(PER_AGENT_CODEX_HOME_ENV, "1")
+    writer_calls: list[str] = []
+
+    def _writer_spy(name):
+        def _record(*_args, **_kwargs):
+            writer_calls.append(name)
+
+        return _record
+
+    monkeypatch.setattr(codex_home_mod, "_write_managed_config", _writer_spy("config"))
+    monkeypatch.setattr(codex_home_mod, "_ensure_auth_link", _writer_spy("auth"))
+    monkeypatch.setattr(codex_home_mod, "_write_agent_soul", _writer_spy("soul"))
+    monkeypatch.setattr(
+        codex_home_mod,
+        "_run_initial_rollout_migration",
+        _writer_spy("migration"),
+    )
+    soul_store = _SoulStore()
+
+    with pytest.raises(RuntimeError, match="resolves to the shared home"):
+        prepare_agent_codex_home(
+            _scope(
+                working_dir,
+                codex_home=str(shared_home),
+                system_prompt="compiled soul",
+            ),
+            log=lambda _message: None,
+            soul_version_store=soul_store,
+        )
+
+    after = {
+        path.name: path.read_bytes()
+        for path in shared_home.iterdir()
+        if path.is_file()
+    }
+    assert writer_calls == []
+    assert soul_store.calls == []
+    assert after == before
 
 
 def test_subprocess_transport_flag_off_has_zero_env_delta_and_zero_soul_writes(
@@ -2027,6 +2137,45 @@ def test_tmux_transport_preflight_writes_soul_only_to_agent_home(
     assert not (shared_home / "AGENTS.md").exists()
 
 
+@pytest.mark.asyncio
+async def test_tmux_replacement_publishes_and_snapshots_soul_once(
+    tmp_path,
+    monkeypatch,
+):
+    shared_home = tmp_path / "shared"
+    working_dir = tmp_path / "agent"
+    working_dir.mkdir()
+    _auth(shared_home)
+    monkeypatch.setenv("CODEX_HOME", str(shared_home))
+    monkeypatch.setenv(PER_AGENT_CODEX_HOME_ENV, "1")
+    config = StreamingSessionConfig(
+        agent_name="test-agent",
+        working_dir=str(working_dir),
+        provider_url="codex_cli",
+        system_prompt="compiled tmux soul",
+    )
+    soul_store = _SoulStore()
+    session = CodexTmuxSession(config, registry=soul_store)
+
+    async def _noop():
+        return None
+
+    async def _base_spawn(_session):
+        return None
+
+    monkeypatch.setattr(session, "disconnect", _noop)
+    monkeypatch.setattr(session, "_seed_codex_trust", lambda _cwd: None)
+    monkeypatch.setattr(session, "_codex_dismiss_nux_and_ready", _noop)
+    monkeypatch.setattr(
+        "pinky_daemon.codex_tmux_session.TmuxSession._spawn_tmux_repl",
+        _base_spawn,
+    )
+
+    await session.restart_transport(bring_up=session._spawn_tmux_repl)
+
+    assert soul_store.calls == [("test-agent", "compiled tmux soul", "spawn")]
+
+
 def test_tmux_app_server_boundary_uses_the_shared_soul_writer(
     tmp_path,
     monkeypatch,
@@ -2061,6 +2210,83 @@ def test_tmux_app_server_boundary_uses_the_shared_soul_writer(
         ("test-agent", "compiled app-server soul", "spawn")
     ]
     assert not (shared_home / "AGENTS.md").exists()
+
+
+@pytest.mark.asyncio
+async def test_tmux_app_server_replacement_publishes_and_snapshots_soul_once(
+    tmp_path,
+    monkeypatch,
+):
+    shared_home = tmp_path / "shared"
+    working_dir = tmp_path / "agent"
+    working_dir.mkdir()
+    _auth(shared_home)
+    monkeypatch.setenv("CODEX_HOME", str(shared_home))
+    monkeypatch.setenv(PER_AGENT_CODEX_HOME_ENV, "1")
+    monkeypatch.setenv("PINKY_CODEX_APP_SERVER", "1")
+    monkeypatch.setenv("PINKY_CODEX_TMUX_APP_SERVER", "1")
+    config = StreamingSessionConfig(
+        agent_name="test-agent",
+        working_dir=str(working_dir),
+        provider_url="codex_cli",
+        system_prompt="compiled app-server soul",
+    )
+    soul_store = _SoulStore()
+    session = CodexSession(config, registry=soul_store)
+    assert session._app_supervisor is not None
+    supervisor = session._app_supervisor
+
+    class _Client:
+        def __init__(self) -> None:
+            self.is_closed = False
+            self.initialized = False
+
+        async def close(self) -> None:
+            self.is_closed = True
+
+        def set_transport_closed_handler(self, _handler) -> None:
+            return None
+
+        async def initialize(self, *, name: str, version: str) -> None:
+            assert (name, version) == ("pinkybot", "1")
+            self.initialized = True
+
+    class _Proc:
+        def __init__(self, returncode) -> None:
+            self.pid = 4321
+            self.returncode = returncode
+
+        def kill(self) -> None:
+            self.returncode = -9
+
+        async def wait(self) -> int:
+            return self.returncode
+
+    stale_client = _Client()
+    session._app_client = stale_client
+    session._app_proc = _Proc(1)
+
+    async def _noop_teardown() -> None:
+        return None
+
+    async def _start(**kwargs):
+        prepared_home = kwargs.get("prepared_codex_home")
+        if prepared_home is None:
+            env = supervisor._build_env()
+        else:
+            env = supervisor._build_env(prepared_codex_home=prepared_home)
+        assert env["CODEX_HOME"] == str(working_dir / ".codex")
+        return _Client(), _Proc(None)
+
+    monkeypatch.setattr(supervisor, "teardown", _noop_teardown)
+    monkeypatch.setattr(supervisor, "start", _start)
+
+    assert await session._ensure_app_server() is True
+
+    assert stale_client.is_closed is True
+    assert soul_store.calls == [
+        ("test-agent", "compiled app-server soul", "spawn")
+    ]
 
 
 def test_reverse_migration_moves_only_matching_rollouts(tmp_path):

--- a/tests/test_codex_home.py
+++ b/tests/test_codex_home.py
@@ -17,7 +17,10 @@ from types import SimpleNamespace
 import pytest
 
 from pinky_daemon import codex_home as codex_home_mod
-from pinky_daemon.codex_app_server_tmux import CodexAppServerSupervisor
+from pinky_daemon.codex_app_server_tmux import (
+    CodexAppServerSupervisor,
+    _TmuxAppServerProc,
+)
 from pinky_daemon.codex_home import (
     MANAGED_CONFIG_SENTINEL,
     PER_AGENT_CODEX_HOME_ENV,
@@ -31,6 +34,7 @@ from pinky_daemon.codex_session import CodexSession
 from pinky_daemon.codex_tmux_session import CodexTmuxSession
 from pinky_daemon.codex_tmux_transcript import _discover_codex_rollout
 from pinky_daemon.streaming_session import StreamingSessionConfig
+from pinky_daemon.tmux_session import TmuxCommandResult
 
 
 def _scope(
@@ -2160,7 +2164,7 @@ async def test_tmux_replacement_publishes_and_snapshots_soul_once(
         return None
 
     async def _base_spawn(_session):
-        return None
+        _session._prepare_tmux_spawn()
 
     monkeypatch.setattr(session, "disconnect", _noop)
     monkeypatch.setattr(session, "_seed_codex_trust", lambda _cwd: None)
@@ -2206,7 +2210,7 @@ async def test_tmux_child_spawn_inside_replacement_resnapshots_self_edit(
         return None
 
     async def _base_spawn(_session):
-        return None
+        _session._prepare_tmux_spawn()
 
     async def _spawn_child_after_preflight():
         agents_md.write_text("self edit after preflight", encoding="utf-8")
@@ -2265,7 +2269,7 @@ async def test_tmux_refused_replacement_does_not_stale_next_spawn_soul(
         return None
 
     async def _base_spawn(_session):
-        return None
+        _session._prepare_tmux_spawn()
 
     monkeypatch.setattr(session, "_seed_codex_trust", lambda _cwd: None)
     monkeypatch.setattr(session, "_codex_dismiss_nux_and_ready", _noop)
@@ -2379,7 +2383,7 @@ async def test_tmux_app_server_replacement_publishes_and_snapshots_soul_once(
     session._app_client = stale_client
     session._app_proc = _Proc(1)
 
-    async def _noop_teardown() -> None:
+    async def _noop_teardown(*, strict: bool = False) -> None:
         return None
 
     async def _start(**_kwargs):
@@ -2398,6 +2402,265 @@ async def test_tmux_app_server_replacement_publishes_and_snapshots_soul_once(
     assert soul_store.calls == [
         ("test-agent", "compiled app-server soul", "spawn")
     ]
+
+
+@pytest.mark.asyncio
+async def test_tmux_app_server_stale_kill_failure_refuses_before_publication(
+    tmp_path,
+    monkeypatch,
+):
+    """R5: a known-live stale tmux session is a strict spawn precondition."""
+    shared_home = tmp_path / "shared"
+    working_dir = tmp_path / "agent"
+    working_dir.mkdir()
+    _auth(shared_home)
+    monkeypatch.setenv("CODEX_HOME", str(shared_home))
+    monkeypatch.setenv(PER_AGENT_CODEX_HOME_ENV, "1")
+    config = StreamingSessionConfig(
+        agent_name="test-agent",
+        working_dir=str(working_dir),
+        provider_url="codex_cli",
+        system_prompt="compiled app-server soul",
+    )
+    soul_store = _SoulStore()
+    prepare_agent_codex_home(
+        config,
+        log=lambda _message: None,
+        soul_version_store=soul_store,
+    )
+    soul_store.calls.clear()
+    agents_md = working_dir / ".codex" / "AGENTS.md"
+    agents_md.write_text("self edit before replacement", encoding="utf-8")
+    supervisor = CodexAppServerSupervisor(
+        "test-agent",
+        working_dir=str(working_dir),
+        agent_config=config,
+        soul_version_store=soul_store,
+    )
+    build_env_calls = 0
+    real_build_env = supervisor._build_env
+
+    async def _failed_kill():
+        return TmuxCommandResult(
+            returncode=1,
+            stdout="",
+            stderr="stale session still alive",
+        )
+
+    async def _unexpected_new_session(**_kwargs):
+        raise AssertionError("new_session reached after failed stale kill")
+
+    def _tracked_build_env():
+        nonlocal build_env_calls
+        build_env_calls += 1
+        return real_build_env()
+
+    monkeypatch.setattr(supervisor._tmux, "kill_session", _failed_kill)
+    monkeypatch.setattr(supervisor._tmux, "new_session", _unexpected_new_session)
+    monkeypatch.setattr(supervisor, "_build_env", _tracked_build_env)
+
+    with pytest.raises(RuntimeError, match="kill-session failed"):
+        await supervisor.start()
+
+    assert build_env_calls == 0
+    assert agents_md.read_text(encoding="utf-8") == "self edit before replacement"
+    assert soul_store.calls == []
+
+
+@pytest.mark.asyncio
+async def test_tmux_app_server_cached_kill_failure_blocks_replacement_publication(
+    tmp_path,
+    monkeypatch,
+):
+    """R5: the cached proc kill/wait seam must propagate strict cleanup failure."""
+    shared_home = tmp_path / "shared"
+    working_dir = tmp_path / "agent"
+    working_dir.mkdir()
+    _auth(shared_home)
+    monkeypatch.setenv("CODEX_HOME", str(shared_home))
+    monkeypatch.setenv(PER_AGENT_CODEX_HOME_ENV, "1")
+    monkeypatch.setenv("PINKY_CODEX_APP_SERVER", "1")
+    monkeypatch.setenv("PINKY_CODEX_TMUX_APP_SERVER", "1")
+    config = StreamingSessionConfig(
+        agent_name="test-agent",
+        working_dir=str(working_dir),
+        provider_url="codex_cli",
+        system_prompt="compiled app-server soul",
+    )
+    soul_store = _SoulStore()
+    prepare_agent_codex_home(
+        config,
+        log=lambda _message: None,
+        soul_version_store=soul_store,
+    )
+    soul_store.calls.clear()
+    agents_md = working_dir / ".codex" / "AGENTS.md"
+    agents_md.write_text("self edit before replacement", encoding="utf-8")
+    session = CodexSession(config, registry=soul_store)
+    assert session._app_supervisor is not None
+    supervisor = session._app_supervisor
+
+    class _Client:
+        is_closed = True
+
+        async def close(self) -> None:
+            return None
+
+    async def _failed_kill():
+        return TmuxCommandResult(
+            returncode=1,
+            stdout="",
+            stderr="stale session still alive",
+        )
+
+    async def _unexpected_start(**_kwargs):
+        raise AssertionError("replacement start reached after failed cached kill")
+
+    monkeypatch.setattr(supervisor._tmux, "kill_session", _failed_kill)
+    monkeypatch.setattr(supervisor, "start", _unexpected_start)
+    stale_proc = _TmuxAppServerProc(supervisor, pid=4321)
+    session._app_client = _Client()
+    session._app_proc = stale_proc
+
+    with pytest.raises(RuntimeError, match="kill-session failed"):
+        await session._ensure_app_server()
+
+    assert session._app_proc is stale_proc
+    assert agents_md.read_text(encoding="utf-8") == "self edit before replacement"
+    assert soul_store.calls == []
+
+
+@pytest.mark.asyncio
+async def test_direct_app_server_failed_shutdown_handle_blocks_replacement_publication(
+    tmp_path,
+    monkeypatch,
+):
+    """R5 sibling: best-effort shutdown retains proof of a failed direct kill."""
+    shared_home = tmp_path / "shared"
+    working_dir = tmp_path / "agent"
+    working_dir.mkdir()
+    _auth(shared_home)
+    monkeypatch.setenv("CODEX_HOME", str(shared_home))
+    monkeypatch.setenv(PER_AGENT_CODEX_HOME_ENV, "1")
+    monkeypatch.setenv("PINKY_CODEX_APP_SERVER", "1")
+    monkeypatch.delenv("PINKY_CODEX_TMUX_APP_SERVER", raising=False)
+    config = StreamingSessionConfig(
+        agent_name="test-agent",
+        working_dir=str(working_dir),
+        provider_url="codex_cli",
+        system_prompt="compiled app-server soul",
+    )
+    soul_store = _SoulStore()
+    prepare_agent_codex_home(
+        config,
+        log=lambda _message: None,
+        soul_version_store=soul_store,
+    )
+    soul_store.calls.clear()
+    agents_md = working_dir / ".codex" / "AGENTS.md"
+    agents_md.write_text("self edit before replacement", encoding="utf-8")
+    session = CodexSession(config, registry=soul_store)
+
+    class _Client:
+        is_closed = False
+
+        async def close(self) -> None:
+            self.is_closed = True
+
+    class _Proc:
+        returncode = None
+        pid = 4321
+
+        def kill(self) -> None:
+            raise RuntimeError("direct kill failed")
+
+        async def wait(self) -> int:
+            raise AssertionError("wait reached after failed direct kill")
+
+    async def _unexpected_spawn(**_kwargs):
+        raise AssertionError("replacement spawn reached after failed direct kill")
+
+    stale_proc = _Proc()
+    session._app_client = _Client()
+    session._app_proc = stale_proc
+    monkeypatch.setattr(
+        "pinky_daemon.codex_session.spawn_app_server",
+        _unexpected_spawn,
+    )
+
+    with pytest.raises(RuntimeError, match="direct kill failed"):
+        await session.restart_transport()
+
+    assert session._app_proc is stale_proc
+    assert agents_md.read_text(encoding="utf-8") == "self edit before replacement"
+    assert soul_store.calls == []
+
+
+@pytest.mark.asyncio
+async def test_tmux_repl_stale_kill_failure_refuses_before_publication(
+    tmp_path,
+    monkeypatch,
+):
+    """R5 sibling: inherited tmux REPL cleanup gates Codex publication too."""
+    shared_home = tmp_path / "shared"
+    working_dir = tmp_path / "agent"
+    working_dir.mkdir()
+    _auth(shared_home)
+    monkeypatch.setenv("CODEX_HOME", str(shared_home))
+    monkeypatch.setenv(PER_AGENT_CODEX_HOME_ENV, "1")
+    config = StreamingSessionConfig(
+        agent_name="test-agent",
+        working_dir=str(working_dir),
+        provider_url="codex_cli",
+        system_prompt="compiled tmux soul",
+    )
+    soul_store = _SoulStore()
+    prepare_agent_codex_home(
+        config,
+        log=lambda _message: None,
+        soul_version_store=soul_store,
+    )
+    soul_store.calls.clear()
+    agents_md = working_dir / ".codex" / "AGENTS.md"
+    agents_md.write_text("self edit before replacement", encoding="utf-8")
+    session = CodexTmuxSession(config, registry=soul_store)
+
+    async def _noop(*_args, **_kwargs):
+        return None
+
+    async def _has_stale_session():
+        return True
+
+    async def _failed_kill():
+        return TmuxCommandResult(
+            returncode=1,
+            stdout="",
+            stderr="stale session still alive",
+        )
+
+    async def _unexpected_new_session(**_kwargs):
+        raise AssertionError("new_session reached after failed stale kill")
+
+    monkeypatch.setattr(session, "_container_agent", lambda *, strict: None)
+    monkeypatch.setattr(
+        session,
+        "_select_command_runner",
+        lambda _container_agent: session._tmux._runner,
+    )
+    monkeypatch.setattr(session, "_ensure_container_started", _noop)
+    monkeypatch.setattr(
+        "pinky_daemon.tmux_session._seed_claude_trust_file",
+        lambda _path, _cwd: False,
+    )
+    monkeypatch.setattr(session._tmux, "has_session", _has_stale_session)
+    monkeypatch.setattr(session._tmux, "kill_session", _failed_kill)
+    monkeypatch.setattr(session._tmux, "new_session", _unexpected_new_session)
+
+    with pytest.raises(RuntimeError, match="kill-session failed"):
+        await session._spawn_tmux_repl()
+
+    assert agents_md.read_text(encoding="utf-8") == "self edit before replacement"
+    assert soul_store.calls == []
 
 
 def test_reverse_migration_moves_only_matching_rollouts(tmp_path):

--- a/tests/test_codex_home.py
+++ b/tests/test_codex_home.py
@@ -89,6 +89,17 @@ def _rollout(home: Path, name: str, cwd: Path) -> Path:
     return path
 
 
+def _mark_tmux_server_socket(tmp_path: Path, monkeypatch) -> Path:
+    """Make the verifier take its server-alive session-listing leg."""
+    tmux_tmpdir = tmp_path / "tmux-tmp"
+    socket_path = tmux_tmpdir / f"tmux-{os.getuid()}" / "default"
+    socket_path.parent.mkdir(parents=True)
+    socket_path.touch()
+    monkeypatch.delenv("TMUX", raising=False)
+    monkeypatch.setenv("TMUX_TMPDIR", str(tmux_tmpdir))
+    return socket_path
+
+
 def test_flag_off_preserves_shared_path_and_performs_no_bootstrap(tmp_path, monkeypatch):
     shared_home = tmp_path / "shared"
     working_dir = tmp_path / "agent"
@@ -2416,6 +2427,8 @@ async def test_tmux_app_server_first_start_with_absent_server_proceeds(
     _auth(shared_home)
     monkeypatch.setenv("CODEX_HOME", str(shared_home))
     monkeypatch.setenv(PER_AGENT_CODEX_HOME_ENV, "1")
+    monkeypatch.delenv("TMUX", raising=False)
+    monkeypatch.setenv("TMUX_TMPDIR", str(tmp_path / "absent-tmux"))
     config = StreamingSessionConfig(
         agent_name="test-agent",
         working_dir=str(working_dir),
@@ -2450,7 +2463,7 @@ async def test_tmux_app_server_first_start_with_absent_server_proceeds(
 
     async def _tmux_run(*args, timeout=5.0, stdin_data=None):
         tmux_calls.append(args)
-        if args[0] in {"kill-session", "has-session"}:
+        if args[0] == "kill-session":
             return absent_server
         raise AssertionError(f"unexpected direct tmux call: {args}")
 
@@ -2488,7 +2501,7 @@ async def test_tmux_app_server_first_start_with_absent_server_proceeds(
 
     assert isinstance(client, _Client)
     assert isinstance(proc, _TmuxAppServerProc)
-    assert [call[0] for call in tmux_calls] == ["kill-session", "has-session"]
+    assert [call[0] for call in tmux_calls] == ["kill-session"]
     assert build_env_calls == 1
     assert new_session_calls == 1
     assert client_start_calls == 1
@@ -2511,26 +2524,26 @@ async def test_tmux_repl_stale_kill_already_gone_race_proceeds(
     )
     tmux = _TmuxControl("pinky-test-agent")
     session = TmuxSession(config, tmux_control=tmux)
+    _mark_tmux_server_socket(tmp_path, monkeypatch)
     tmux_calls: list[tuple[str, ...]] = []
-    has_session_calls = 0
-    absent_server = TmuxCommandResult(
+    failed_kill = TmuxCommandResult(
         returncode=1,
         stdout="",
-        stderr=("error connecting to /private/tmp/tmux-501/pinky-test (No such file or directory)"),
+        stderr="target disappeared during kill",
     )
 
     async def _tmux_run(*args, timeout=5.0, stdin_data=None):
-        nonlocal has_session_calls
         tmux_calls.append(args)
         if args[0] == "has-session":
-            has_session_calls += 1
-            if has_session_calls == 1:
-                return TmuxCommandResult(returncode=0, stdout="", stderr="")
-            if has_session_calls == 2:
-                return absent_server
             return TmuxCommandResult(returncode=0, stdout="", stderr="")
         if args[0] == "kill-session":
-            return absent_server
+            return failed_kill
+        if args[0] == "list-sessions":
+            return TmuxCommandResult(
+                returncode=0,
+                stdout="pinky-some-other-session\n",
+                stderr="",
+            )
         if args[0] == "new-session":
             return TmuxCommandResult(returncode=0, stdout="", stderr="")
         raise AssertionError(f"unexpected tmux call: {args}")
@@ -2568,7 +2581,7 @@ async def test_tmux_repl_stale_kill_already_gone_race_proceeds(
     assert [call[0] for call in tmux_calls] == [
         "has-session",
         "kill-session",
-        "has-session",
+        "list-sessions",
         "new-session",
         "has-session",
     ]
@@ -2607,6 +2620,7 @@ async def test_tmux_app_server_stale_kill_failure_refuses_before_publication(
         agent_config=config,
         soul_version_store=soul_store,
     )
+    _mark_tmux_server_socket(tmp_path, monkeypatch)
     build_env_calls = 0
     tmux_calls: list[tuple[str, ...]] = []
     real_build_env = supervisor._build_env
@@ -2619,8 +2633,12 @@ async def test_tmux_app_server_stale_kill_failure_refuses_before_publication(
                 stdout="",
                 stderr="stale session still alive",
             )
-        if args[0] == "has-session":
-            return TmuxCommandResult(returncode=0, stdout="", stderr="")
+        if args[0] == "list-sessions":
+            return TmuxCommandResult(
+                returncode=0,
+                stdout=f"{supervisor.session_name}\n",
+                stderr="",
+            )
         raise AssertionError(f"unexpected direct tmux call: {args}")
 
     async def _unexpected_new_session(**_kwargs):
@@ -2639,9 +2657,106 @@ async def test_tmux_app_server_stale_kill_failure_refuses_before_publication(
         await supervisor.start()
 
     assert build_env_calls == 0
-    assert [call[0] for call in tmux_calls] == ["kill-session", "has-session"]
+    assert [call[0] for call in tmux_calls] == ["kill-session", "list-sessions"]
     assert agents_md.read_text(encoding="utf-8") == "self edit before replacement"
     assert soul_store.calls == []
+
+
+@pytest.mark.asyncio
+async def test_tmux_app_server_permission_probe_refuses_before_publication(
+    tmp_path,
+    monkeypatch,
+):
+    """R7: a returned verifier error is not proof that the target is absent."""
+    shared_home = tmp_path / "shared"
+    working_dir = tmp_path / "agent"
+    working_dir.mkdir()
+    _auth(shared_home)
+    monkeypatch.setenv("CODEX_HOME", str(shared_home))
+    monkeypatch.setenv(PER_AGENT_CODEX_HOME_ENV, "1")
+    config = StreamingSessionConfig(
+        agent_name="test-agent",
+        working_dir=str(working_dir),
+        provider_url="codex_cli",
+        system_prompt="compiled app-server soul",
+    )
+    soul_store = _SoulStore()
+    prepare_agent_codex_home(
+        config,
+        log=lambda _message: None,
+        soul_version_store=soul_store,
+    )
+    soul_store.calls.clear()
+    agents_md = working_dir / ".codex" / "AGENTS.md"
+    agents_md.write_text("self edit before replacement", encoding="utf-8")
+    supervisor = CodexAppServerSupervisor(
+        "test-agent",
+        working_dir=str(working_dir),
+        agent_config=config,
+        soul_version_store=soul_store,
+    )
+    _mark_tmux_server_socket(tmp_path, monkeypatch)
+    tmux_calls: list[tuple[str, ...]] = []
+    build_env_calls = 0
+    permission_error = TmuxCommandResult(
+        returncode=1,
+        stdout="",
+        stderr="couldn't create directory /blocked/tmux-501 (Permission denied)",
+    )
+    real_build_env = supervisor._build_env
+
+    async def _tmux_run(*args, timeout=5.0, stdin_data=None):
+        tmux_calls.append(args)
+        if args[0] in {"kill-session", "list-sessions"}:
+            return permission_error
+        raise AssertionError(f"unexpected direct tmux call: {args}")
+
+    async def _unexpected_new_session(**_kwargs):
+        raise AssertionError("new_session reached after verifier error")
+
+    def _tracked_build_env():
+        nonlocal build_env_calls
+        build_env_calls += 1
+        return real_build_env()
+
+    monkeypatch.setattr(supervisor._tmux, "_run", _tmux_run)
+    monkeypatch.setattr(supervisor._tmux, "new_session", _unexpected_new_session)
+    monkeypatch.setattr(supervisor, "_build_env", _tracked_build_env)
+
+    with pytest.raises(RuntimeError, match="kill-session failed"):
+        await supervisor.start()
+
+    assert [call[0] for call in tmux_calls] == ["kill-session", "list-sessions"]
+    assert build_env_calls == 0
+    assert agents_md.read_text(encoding="utf-8") == "self edit before replacement"
+    assert soul_store.calls == []
+
+
+@pytest.mark.asyncio
+async def test_tmux_kill_session_listing_timeout_propagates(tmp_path, monkeypatch):
+    """R7: exceptions from the positive-absence verifier remain terminal."""
+    control = _TmuxControl("pinky-test-agent")
+    _mark_tmux_server_socket(tmp_path, monkeypatch)
+    tmux_calls: list[tuple[str, ...]] = []
+
+    async def _tmux_run(*args, timeout=5.0, stdin_data=None):
+        tmux_calls.append(args)
+        if args[0] == "kill-session":
+            return TmuxCommandResult(
+                returncode=1,
+                stdout="",
+                stderr="kill transport failed",
+            )
+        if args[0] == "list-sessions":
+            raise asyncio.TimeoutError("tmux verifier timed out")
+        raise AssertionError(f"unexpected direct tmux call: {args}")
+
+    monkeypatch.setattr(control, "_run", _tmux_run)
+
+    with pytest.raises(asyncio.TimeoutError, match="tmux verifier timed out"):
+        await control.kill_session()
+
+    assert [call[0] for call in tmux_calls] == ["kill-session", "list-sessions"]
 
 
 @pytest.mark.asyncio
@@ -2801,6 +2916,7 @@ async def test_tmux_repl_stale_kill_failure_refuses_before_publication(
     agents_md = working_dir / ".codex" / "AGENTS.md"
     agents_md.write_text("self edit before replacement", encoding="utf-8")
     session = CodexTmuxSession(config, registry=soul_store)
+    _mark_tmux_server_socket(tmp_path, monkeypatch)
     tmux_calls: list[tuple[str, ...]] = []
 
     async def _noop(*_args, **_kwargs):
@@ -2815,6 +2931,12 @@ async def test_tmux_repl_stale_kill_failure_refuses_before_publication(
                 returncode=1,
                 stdout="",
                 stderr="stale session still alive",
+            )
+        if args[0] == "list-sessions":
+            return TmuxCommandResult(
+                returncode=0,
+                stdout=f"{session._session_name}\n",
+                stderr="",
             )
         raise AssertionError(f"unexpected direct tmux call: {args}")
 
@@ -2845,7 +2967,87 @@ async def test_tmux_repl_stale_kill_failure_refuses_before_publication(
     assert [call[0] for call in tmux_calls] == [
         "has-session",
         "kill-session",
+        "list-sessions",
+    ]
+    assert agents_md.read_text(encoding="utf-8") == "self edit before replacement"
+    assert soul_store.calls == []
+
+
+@pytest.mark.asyncio
+async def test_tmux_repl_permission_probe_refuses_before_publication(
+    tmp_path,
+    monkeypatch,
+):
+    """R7 sibling: returned verifier errors gate shared REPL publication."""
+    shared_home = tmp_path / "shared"
+    working_dir = tmp_path / "agent"
+    working_dir.mkdir()
+    _auth(shared_home)
+    monkeypatch.setenv("CODEX_HOME", str(shared_home))
+    monkeypatch.setenv(PER_AGENT_CODEX_HOME_ENV, "1")
+    config = StreamingSessionConfig(
+        agent_name="test-agent",
+        working_dir=str(working_dir),
+        provider_url="codex_cli",
+        system_prompt="compiled tmux soul",
+    )
+    soul_store = _SoulStore()
+    prepare_agent_codex_home(
+        config,
+        log=lambda _message: None,
+        soul_version_store=soul_store,
+    )
+    soul_store.calls.clear()
+    agents_md = working_dir / ".codex" / "AGENTS.md"
+    agents_md.write_text("self edit before replacement", encoding="utf-8")
+    session = CodexTmuxSession(config, registry=soul_store)
+    _mark_tmux_server_socket(tmp_path, monkeypatch)
+    tmux_calls: list[tuple[str, ...]] = []
+    permission_error = TmuxCommandResult(
+        returncode=1,
+        stdout="",
+        stderr="couldn't create directory /blocked/tmux-501 (Permission denied)",
+    )
+
+    async def _noop(*_args, **_kwargs):
+        return None
+
+    async def _tmux_run(*args, timeout=5.0, stdin_data=None):
+        tmux_calls.append(args)
+        if args[0] == "has-session":
+            return TmuxCommandResult(returncode=0, stdout="", stderr="")
+        if args[0] in {"kill-session", "list-sessions"}:
+            return permission_error
+        raise AssertionError(f"unexpected direct tmux call: {args}")
+
+    async def _unexpected_new_session(**_kwargs):
+        raise AssertionError("new_session reached after verifier error")
+
+    monkeypatch.setattr(
+        session,
+        "_container_agent",
+        lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(
+        session,
+        "_select_command_runner",
+        lambda _container_agent: session._tmux._runner,
+    )
+    monkeypatch.setattr(session, "_ensure_container_started", _noop)
+    monkeypatch.setattr(
+        "pinky_daemon.tmux_session._seed_claude_trust_file",
+        lambda _path, _cwd: False,
+    )
+    monkeypatch.setattr(session._tmux, "_run", _tmux_run)
+    monkeypatch.setattr(session._tmux, "new_session", _unexpected_new_session)
+
+    with pytest.raises(RuntimeError, match="kill-session failed"):
+        await session._spawn_tmux_repl()
+
+    assert [call[0] for call in tmux_calls] == [
         "has-session",
+        "kill-session",
+        "list-sessions",
     ]
     assert agents_md.read_text(encoding="utf-8") == "self edit before replacement"
     assert soul_store.calls == []

--- a/tests/test_codex_home.py
+++ b/tests/test_codex_home.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import fcntl
 import json
 import os
@@ -2109,7 +2110,7 @@ def test_subprocess_transport_overlays_prepared_home(tmp_path, monkeypatch):
     assert not (shared_home / "AGENTS.md").exists()
 
 
-def test_tmux_transport_preflight_writes_soul_only_to_agent_home(
+def test_tmux_transport_preflight_validates_without_publishing_soul(
     tmp_path,
     monkeypatch,
 ):
@@ -2130,10 +2131,8 @@ def test_tmux_transport_preflight_writes_soul_only_to_agent_home(
 
     session._preflight_transport_replacement()
 
-    assert (working_dir / ".codex" / "AGENTS.md").read_text(
-        encoding="utf-8"
-    ) == "compiled tmux soul"
-    assert soul_store.calls == [("test-agent", "compiled tmux soul", "spawn")]
+    assert not (working_dir / ".codex").exists()
+    assert soul_store.calls == []
     assert not (shared_home / "AGENTS.md").exists()
 
 
@@ -2177,6 +2176,63 @@ async def test_tmux_replacement_publishes_and_snapshots_soul_once(
 
 
 @pytest.mark.asyncio
+async def test_tmux_child_spawn_inside_replacement_resnapshots_self_edit(
+    tmp_path,
+    monkeypatch,
+):
+    shared_home = tmp_path / "shared"
+    working_dir = tmp_path / "agent"
+    working_dir.mkdir()
+    _auth(shared_home)
+    monkeypatch.setenv("CODEX_HOME", str(shared_home))
+    monkeypatch.setenv(PER_AGENT_CODEX_HOME_ENV, "1")
+    config = StreamingSessionConfig(
+        agent_name="test-agent",
+        working_dir=str(working_dir),
+        provider_url="codex_cli",
+        system_prompt="compiled tmux soul",
+    )
+    soul_store = _SoulStore()
+    session = CodexTmuxSession(config, registry=soul_store)
+    prepare_agent_codex_home(
+        config,
+        log=lambda _message: None,
+        soul_version_store=soul_store,
+    )
+    soul_store.calls.clear()
+    agents_md = working_dir / ".codex" / "AGENTS.md"
+
+    async def _noop():
+        return None
+
+    async def _base_spawn(_session):
+        return None
+
+    async def _spawn_child_after_preflight():
+        agents_md.write_text("self edit after preflight", encoding="utf-8")
+        await asyncio.create_task(session._spawn_tmux_repl())
+
+    monkeypatch.setattr(session, "disconnect", _noop)
+    monkeypatch.setattr(session, "_seed_codex_trust", lambda _cwd: None)
+    monkeypatch.setattr(session, "_codex_dismiss_nux_and_ready", _noop)
+    monkeypatch.setattr(
+        "pinky_daemon.codex_tmux_session.TmuxSession._spawn_tmux_repl",
+        _base_spawn,
+    )
+
+    await session.restart_transport(
+        configure=_spawn_child_after_preflight,
+        bring_up=_noop,
+    )
+
+    assert agents_md.read_text(encoding="utf-8") == "compiled tmux soul"
+    assert soul_store.calls == [
+        ("test-agent", "self edit after preflight", "agent"),
+        ("test-agent", "compiled tmux soul", "spawn"),
+    ]
+
+
+@pytest.mark.asyncio
 async def test_tmux_refused_replacement_does_not_stale_next_spawn_soul(
     tmp_path,
     monkeypatch,
@@ -2197,6 +2253,13 @@ async def test_tmux_refused_replacement_does_not_stale_next_spawn_soul(
     soul_store = _SoulStore()
     session = CodexTmuxSession(config, registry=soul_store)
     session._has_completed_turn = True
+    prepare_agent_codex_home(
+        config,
+        log=lambda _message: None,
+        soul_version_store=soul_store,
+    )
+    soul_store.calls.clear()
+    agents_md = working_dir / ".codex" / "AGENTS.md"
 
     async def _noop():
         return None
@@ -2212,19 +2275,15 @@ async def test_tmux_refused_replacement_does_not_stale_next_spawn_soul(
     )
 
     assert await session.force_restart() is False
-    assert soul_store.calls == [
-        ("test-agent", "compiled tmux soul", "spawn"),
-    ]
-    assert session._preflighted_codex_homes == {}
+    assert soul_store.calls == []
+    assert agents_md.read_text(encoding="utf-8") == "compiled tmux soul"
 
-    agents_md = working_dir / ".codex" / "AGENTS.md"
     agents_md.write_text("self edit after refused restart", encoding="utf-8")
 
     await session._spawn_tmux_repl()
 
     assert agents_md.read_text(encoding="utf-8") == "compiled tmux soul"
     assert soul_store.calls == [
-        ("test-agent", "compiled tmux soul", "spawn"),
         ("test-agent", "self edit after refused restart", "agent"),
         ("test-agent", "compiled tmux soul", "spawn"),
     ]
@@ -2323,12 +2382,10 @@ async def test_tmux_app_server_replacement_publishes_and_snapshots_soul_once(
     async def _noop_teardown() -> None:
         return None
 
-    async def _start(**kwargs):
-        prepared_home = kwargs.get("prepared_codex_home")
-        if prepared_home is None:
-            env = supervisor._build_env()
-        else:
-            env = supervisor._build_env(prepared_codex_home=prepared_home)
+    async def _start(**_kwargs):
+        assert stale_client.is_closed is True
+        assert soul_store.calls == []
+        env = supervisor._build_env()
         assert env["CODEX_HOME"] == str(working_dir / ".codex")
         return _Client(), _Proc(None)
 

--- a/tests/test_codex_home.py
+++ b/tests/test_codex_home.py
@@ -100,6 +100,117 @@ def _mark_tmux_server_socket(tmp_path: Path, monkeypatch) -> Path:
     return socket_path
 
 
+class _SpawnRollbackTmuxTrace:
+    """Stateful raw-tmux seam for spawn rollback/no-leak regressions."""
+
+    def __init__(
+        self,
+        *,
+        first_kill: str,
+        post_probe_error: bool = True,
+        ambiguous_verify: bool = False,
+        new_session_hangs: bool = False,
+    ) -> None:
+        self.first_kill = first_kill
+        self.post_probe_error = post_probe_error
+        self.ambiguous_verify = ambiguous_verify
+        self.new_session_hangs = new_session_hangs
+        self.live = False
+        self.kill_calls = 0
+        self.post_probe_seen = False
+        self.pending_list_reason = ""
+        self.calls: list[tuple[str, ...]] = []
+        self.spawned = asyncio.Event()
+        self.permission_error = TmuxCommandResult(
+            returncode=1,
+            stdout="",
+            stderr="couldn't access tmux socket (Permission denied)",
+        )
+
+    async def run(self, *args, timeout=5.0, stdin_data=None):
+        del timeout, stdin_data
+        self.calls.append(args)
+        operation = args[0]
+        if operation == "has-session":
+            if not self.live:
+                self.pending_list_reason = "absence"
+                return TmuxCommandResult(
+                    returncode=1, stdout="", stderr="can't find session"
+                )
+            if self.post_probe_error and not self.post_probe_seen:
+                self.post_probe_seen = True
+                self.pending_list_reason = "ambiguous"
+                return self.permission_error
+            self.post_probe_seen = True
+            if self.ambiguous_verify:
+                self.pending_list_reason = "ambiguous"
+                return self.permission_error
+            return TmuxCommandResult(returncode=0, stdout="", stderr="")
+        if operation == "list-sessions":
+            reason = self.pending_list_reason
+            self.pending_list_reason = ""
+            if reason == "ambiguous":
+                return self.permission_error
+            sessions = "pinky-test-agent\n" if self.live else "operator\n"
+            return TmuxCommandResult(returncode=0, stdout=sessions, stderr="")
+        if operation == "new-session":
+            self.live = True
+            self.spawned.set()
+            if self.new_session_hangs:
+                await asyncio.Event().wait()
+            return TmuxCommandResult(returncode=0, stdout="", stderr="")
+        if operation == "kill-session":
+            self.kill_calls += 1
+            if self.first_kill == "raise_then_ok" and self.kill_calls == 1:
+                raise RuntimeError("rollback kill transport error")
+            if self.first_kill == "always_non_ok" or self.kill_calls == 1:
+                self.pending_list_reason = "kill"
+                return TmuxCommandResult(
+                    returncode=1, stdout="", stderr="rollback kill denied"
+                )
+            self.live = False
+            return TmuxCommandResult(returncode=0, stdout="", stderr="")
+        raise AssertionError(f"unexpected tmux call: {args}")
+
+
+def _spawn_rollback_session(
+    tmp_path: Path,
+    monkeypatch,
+    trace: _SpawnRollbackTmuxTrace,
+) -> tuple[TmuxSession, _TmuxControl]:
+    """Build a real ``_TmuxControl`` around the stateful raw-command seam."""
+    _mark_tmux_server_socket(tmp_path, monkeypatch)
+    config = StreamingSessionConfig(
+        agent_name="test-agent",
+        working_dir=str(tmp_path / "agent"),
+    )
+    tmux = _TmuxControl("pinky-test-agent")
+    session = TmuxSession(config, tmux_control=tmux)
+
+    async def _noop(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr(tmux, "_run", trace.run)
+    monkeypatch.setattr(
+        session, "_container_agent", lambda *args, **kwargs: None
+    )
+    monkeypatch.setattr(
+        session,
+        "_select_command_runner",
+        lambda _container_agent: tmux._runner,
+    )
+    monkeypatch.setattr(session, "_ensure_container_started", _noop)
+    monkeypatch.setattr(session, "_seed_container_trust", _noop)
+    monkeypatch.setattr(session, "_seed_container_home_creds", _noop)
+    monkeypatch.setattr(session, "_start_tailer", _noop)
+    monkeypatch.setattr(session, "_build_claude_cmd", lambda: "claude")
+    monkeypatch.setattr(
+        "pinky_daemon.tmux_session._seed_claude_trust_file",
+        lambda _path, _cwd: False,
+    )
+    return session, tmux
+
+
 def test_flag_off_preserves_shared_path_and_performs_no_bootstrap(tmp_path, monkeypatch):
     shared_home = tmp_path / "shared"
     working_dir = tmp_path / "agent"
@@ -3227,6 +3338,159 @@ async def test_tmux_repl_returned_has_session_error_refuses_before_spawn_side_ef
     assert new_session_count == 0
     assert agents_md.read_text(encoding="utf-8") == "self edit before replacement"
     assert soul_store.calls == []
+
+
+@pytest.mark.asyncio
+async def test_post_spawn_rollback_retries_returned_non_ok_and_leaves_no_session(
+    tmp_path,
+    monkeypatch,
+):
+    """R9: returned kill failure is a signal, then retry proves no leak."""
+    trace = _SpawnRollbackTmuxTrace(first_kill="non_ok_then_ok")
+    session, tmux = _spawn_rollback_session(tmp_path, monkeypatch, trace)
+    monkeypatch.setattr(
+        "pinky_daemon.tmux_session._POST_SPAWN_LIVENESS_DELAY_SEC", 0
+    )
+
+    with pytest.raises(RuntimeError, match="has-session failed"):
+        await session._spawn_tmux_repl()
+
+    assert trace.kill_calls == 2
+    assert trace.live is False
+    assert await tmux.has_session() is False
+    assert [call[0] for call in trace.calls] == [
+        "has-session", "list-sessions", "new-session",
+        "has-session", "list-sessions",
+        "kill-session", "list-sessions", "has-session",
+        "kill-session", "has-session", "list-sessions",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_post_spawn_rollback_retries_kill_exception_and_leaves_no_session(
+    tmp_path,
+    monkeypatch,
+):
+    """R9: a raised kill follows the same verify/retry/no-leak path."""
+    trace = _SpawnRollbackTmuxTrace(first_kill="raise_then_ok")
+    session, tmux = _spawn_rollback_session(tmp_path, monkeypatch, trace)
+    monkeypatch.setattr(
+        "pinky_daemon.tmux_session._POST_SPAWN_LIVENESS_DELAY_SEC", 0
+    )
+
+    with pytest.raises(RuntimeError, match="has-session failed"):
+        await session._spawn_tmux_repl()
+
+    assert trace.kill_calls == 2
+    assert trace.live is False
+    assert await tmux.has_session() is False
+
+
+@pytest.mark.asyncio
+async def test_post_spawn_rollback_ambiguous_verify_surfaces_possibly_live(
+    tmp_path,
+    monkeypatch,
+    capsys,
+):
+    """R9: couldn't-answer after both kills remains loudly conservative."""
+    trace = _SpawnRollbackTmuxTrace(
+        first_kill="always_non_ok", ambiguous_verify=True
+    )
+    session, _tmux = _spawn_rollback_session(tmp_path, monkeypatch, trace)
+    monkeypatch.setattr(
+        "pinky_daemon.tmux_session._POST_SPAWN_LIVENESS_DELAY_SEC", 0
+    )
+
+    with pytest.raises(RuntimeError) as caught:
+        await session._spawn_tmux_repl()
+
+    raised_text = str(caught.value)
+    assert "has-session failed" in raised_text
+    assert "owned session is possibly live" in raised_text
+    assert "verify couldn't answer" in raised_text
+    assert trace.kill_calls == 2
+    assert trace.live is True
+    assert [call[0] for call in trace.calls] == [
+        "has-session", "list-sessions", "new-session",
+        "has-session", "list-sessions",
+        "kill-session", "list-sessions", "has-session", "list-sessions",
+        "kill-session", "list-sessions", "has-session", "list-sessions",
+    ]
+    assert "ERROR tmux[test-agent]: spawn rollback" in capsys.readouterr().err
+
+
+@pytest.mark.asyncio
+async def test_post_spawn_cancellation_waits_for_strict_rollback_and_no_leak(
+    tmp_path,
+    monkeypatch,
+):
+    """R9: original CancelledError propagates only after bounded rollback."""
+    trace = _SpawnRollbackTmuxTrace(first_kill="non_ok_then_ok")
+    session, tmux = _spawn_rollback_session(tmp_path, monkeypatch, trace)
+    monkeypatch.setattr(
+        "pinky_daemon.tmux_session._POST_SPAWN_LIVENESS_DELAY_SEC", 60
+    )
+
+    spawn_task = asyncio.create_task(session._spawn_tmux_repl())
+    await trace.spawned.wait()
+    await asyncio.sleep(0)
+    spawn_task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await spawn_task
+
+    assert trace.kill_calls == 2
+    assert trace.live is False
+    assert await tmux.has_session() is False
+
+
+@pytest.mark.asyncio
+async def test_cold_start_timeout_uses_strict_rollback_and_leaves_no_session(
+    tmp_path,
+    monkeypatch,
+):
+    """R9 Site A: a partial timed-out spawn uses the central rollback."""
+    trace = _SpawnRollbackTmuxTrace(
+        first_kill="non_ok_then_ok", new_session_hangs=True
+    )
+    session, tmux = _spawn_rollback_session(tmp_path, monkeypatch, trace)
+    monkeypatch.setattr(
+        "pinky_daemon.tmux_session._COLD_START_TIMEOUT_SEC", 0.01
+    )
+
+    with pytest.raises(RuntimeError, match="cold-start timed out"):
+        await session._spawn_tmux_repl()
+
+    assert trace.kill_calls == 2
+    assert trace.live is False
+    assert await tmux.has_session() is False
+
+
+@pytest.mark.asyncio
+async def test_tailer_start_failure_uses_strict_rollback_and_leaves_no_session(
+    tmp_path,
+    monkeypatch,
+):
+    """R9 Site C: tailer failure uses the same strict rollback helper."""
+    trace = _SpawnRollbackTmuxTrace(
+        first_kill="non_ok_then_ok", post_probe_error=False
+    )
+    session, tmux = _spawn_rollback_session(tmp_path, monkeypatch, trace)
+    monkeypatch.setattr(
+        "pinky_daemon.tmux_session._POST_SPAWN_LIVENESS_DELAY_SEC", 0
+    )
+
+    async def _tailer_failure():
+        raise RuntimeError("synthetic tailer-start failure")
+
+    monkeypatch.setattr(session, "_start_tailer", _tailer_failure)
+
+    with pytest.raises(RuntimeError, match="synthetic tailer-start failure"):
+        await session._spawn_tmux_repl()
+
+    assert trace.kill_calls == 2
+    assert trace.live is False
+    assert await tmux.has_session() is False
 
 
 def test_reverse_migration_moves_only_matching_rollouts(tmp_path):

--- a/tests/test_codex_home.py
+++ b/tests/test_codex_home.py
@@ -34,7 +34,7 @@ from pinky_daemon.codex_session import CodexSession
 from pinky_daemon.codex_tmux_session import CodexTmuxSession
 from pinky_daemon.codex_tmux_transcript import _discover_codex_rollout
 from pinky_daemon.streaming_session import StreamingSessionConfig
-from pinky_daemon.tmux_session import TmuxCommandResult
+from pinky_daemon.tmux_session import TmuxCommandResult, TmuxSession, _TmuxControl
 
 
 def _scope(
@@ -2405,6 +2405,176 @@ async def test_tmux_app_server_replacement_publishes_and_snapshots_soul_once(
 
 
 @pytest.mark.asyncio
+async def test_tmux_app_server_first_start_with_absent_server_proceeds(
+    tmp_path,
+    monkeypatch,
+):
+    """R6: a missing tmux server is an idempotent pre-start cleanup result."""
+    shared_home = tmp_path / "shared"
+    working_dir = tmp_path / "agent"
+    working_dir.mkdir()
+    _auth(shared_home)
+    monkeypatch.setenv("CODEX_HOME", str(shared_home))
+    monkeypatch.setenv(PER_AGENT_CODEX_HOME_ENV, "1")
+    config = StreamingSessionConfig(
+        agent_name="test-agent",
+        working_dir=str(working_dir),
+        provider_url="codex_cli",
+        system_prompt="compiled app-server soul",
+    )
+    soul_store = _SoulStore()
+    prepare_agent_codex_home(
+        config,
+        log=lambda _message: None,
+        soul_version_store=soul_store,
+    )
+    soul_store.calls.clear()
+    agents_md = working_dir / ".codex" / "AGENTS.md"
+    agents_md.write_text("self edit before first start", encoding="utf-8")
+    supervisor = CodexAppServerSupervisor(
+        "test-agent",
+        working_dir=str(working_dir),
+        agent_config=config,
+        soul_version_store=soul_store,
+    )
+    tmux_calls: list[tuple[str, ...]] = []
+    build_env_calls = 0
+    new_session_calls = 0
+    client_start_calls = 0
+    absent_server = TmuxCommandResult(
+        returncode=1,
+        stdout="",
+        stderr=("error connecting to /private/tmp/tmux-501/pinky-test (No such file or directory)"),
+    )
+    real_build_env = supervisor._build_env
+
+    async def _tmux_run(*args, timeout=5.0, stdin_data=None):
+        tmux_calls.append(args)
+        if args[0] in {"kill-session", "has-session"}:
+            return absent_server
+        raise AssertionError(f"unexpected direct tmux call: {args}")
+
+    async def _new_session(**_kwargs):
+        nonlocal new_session_calls
+        new_session_calls += 1
+        return TmuxCommandResult(returncode=0, stdout="", stderr="")
+
+    async def _await_accept():
+        return object(), object()
+
+    def _tracked_build_env():
+        nonlocal build_env_calls
+        build_env_calls += 1
+        return real_build_env()
+
+    class _Client:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        def start(self):
+            nonlocal client_start_calls
+            client_start_calls += 1
+
+    monkeypatch.setattr(supervisor._tmux, "_run", _tmux_run)
+    monkeypatch.setattr(supervisor._tmux, "new_session", _new_session)
+    monkeypatch.setattr(supervisor, "_await_accept", _await_accept)
+    monkeypatch.setattr(supervisor, "_build_env", _tracked_build_env)
+    monkeypatch.setattr(
+        "pinky_daemon.codex_app_server_tmux.CodexAppServerClient",
+        _Client,
+    )
+
+    client, proc = await supervisor.start()
+
+    assert isinstance(client, _Client)
+    assert isinstance(proc, _TmuxAppServerProc)
+    assert [call[0] for call in tmux_calls] == ["kill-session", "has-session"]
+    assert build_env_calls == 1
+    assert new_session_calls == 1
+    assert client_start_calls == 1
+    assert agents_md.read_text(encoding="utf-8") == "compiled app-server soul"
+    assert soul_store.calls == [
+        ("test-agent", "self edit before first start", "agent"),
+        ("test-agent", "compiled app-server soul", "spawn"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_tmux_repl_stale_kill_already_gone_race_proceeds(
+    tmp_path,
+    monkeypatch,
+):
+    """R6 sibling: a stale session that exits during kill may be respawned."""
+    config = StreamingSessionConfig(
+        agent_name="test-agent",
+        working_dir=str(tmp_path / "agent"),
+    )
+    tmux = _TmuxControl("pinky-test-agent")
+    session = TmuxSession(config, tmux_control=tmux)
+    tmux_calls: list[tuple[str, ...]] = []
+    has_session_calls = 0
+    absent_server = TmuxCommandResult(
+        returncode=1,
+        stdout="",
+        stderr=("error connecting to /private/tmp/tmux-501/pinky-test (No such file or directory)"),
+    )
+
+    async def _tmux_run(*args, timeout=5.0, stdin_data=None):
+        nonlocal has_session_calls
+        tmux_calls.append(args)
+        if args[0] == "has-session":
+            has_session_calls += 1
+            if has_session_calls == 1:
+                return TmuxCommandResult(returncode=0, stdout="", stderr="")
+            if has_session_calls == 2:
+                return absent_server
+            return TmuxCommandResult(returncode=0, stdout="", stderr="")
+        if args[0] == "kill-session":
+            return absent_server
+        if args[0] == "new-session":
+            return TmuxCommandResult(returncode=0, stdout="", stderr="")
+        raise AssertionError(f"unexpected tmux call: {args}")
+
+    async def _noop(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr(tmux, "_run", _tmux_run)
+    monkeypatch.setattr(
+        session,
+        "_container_agent",
+        lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(
+        session,
+        "_select_command_runner",
+        lambda _container_agent: tmux._runner,
+    )
+    monkeypatch.setattr(session, "_ensure_container_started", _noop)
+    monkeypatch.setattr(session, "_seed_container_trust", _noop)
+    monkeypatch.setattr(session, "_seed_container_home_creds", _noop)
+    monkeypatch.setattr(session, "_start_tailer", _noop)
+    monkeypatch.setattr(session, "_build_claude_cmd", lambda: "claude")
+    monkeypatch.setattr(
+        "pinky_daemon.tmux_session._seed_claude_trust_file",
+        lambda _path, _cwd: False,
+    )
+    monkeypatch.setattr(
+        "pinky_daemon.tmux_session._POST_SPAWN_LIVENESS_DELAY_SEC",
+        0,
+    )
+
+    await session._spawn_tmux_repl()
+
+    assert [call[0] for call in tmux_calls] == [
+        "has-session",
+        "kill-session",
+        "has-session",
+        "new-session",
+        "has-session",
+    ]
+
+
+@pytest.mark.asyncio
 async def test_tmux_app_server_stale_kill_failure_refuses_before_publication(
     tmp_path,
     monkeypatch,
@@ -2438,14 +2608,20 @@ async def test_tmux_app_server_stale_kill_failure_refuses_before_publication(
         soul_version_store=soul_store,
     )
     build_env_calls = 0
+    tmux_calls: list[tuple[str, ...]] = []
     real_build_env = supervisor._build_env
 
-    async def _failed_kill():
-        return TmuxCommandResult(
-            returncode=1,
-            stdout="",
-            stderr="stale session still alive",
-        )
+    async def _tmux_run(*args, timeout=5.0, stdin_data=None):
+        tmux_calls.append(args)
+        if args[0] == "kill-session":
+            return TmuxCommandResult(
+                returncode=1,
+                stdout="",
+                stderr="stale session still alive",
+            )
+        if args[0] == "has-session":
+            return TmuxCommandResult(returncode=0, stdout="", stderr="")
+        raise AssertionError(f"unexpected direct tmux call: {args}")
 
     async def _unexpected_new_session(**_kwargs):
         raise AssertionError("new_session reached after failed stale kill")
@@ -2455,7 +2631,7 @@ async def test_tmux_app_server_stale_kill_failure_refuses_before_publication(
         build_env_calls += 1
         return real_build_env()
 
-    monkeypatch.setattr(supervisor._tmux, "kill_session", _failed_kill)
+    monkeypatch.setattr(supervisor._tmux, "_run", _tmux_run)
     monkeypatch.setattr(supervisor._tmux, "new_session", _unexpected_new_session)
     monkeypatch.setattr(supervisor, "_build_env", _tracked_build_env)
 
@@ -2463,6 +2639,7 @@ async def test_tmux_app_server_stale_kill_failure_refuses_before_publication(
         await supervisor.start()
 
     assert build_env_calls == 0
+    assert [call[0] for call in tmux_calls] == ["kill-session", "has-session"]
     assert agents_md.read_text(encoding="utf-8") == "self edit before replacement"
     assert soul_store.calls == []
 
@@ -2624,24 +2801,31 @@ async def test_tmux_repl_stale_kill_failure_refuses_before_publication(
     agents_md = working_dir / ".codex" / "AGENTS.md"
     agents_md.write_text("self edit before replacement", encoding="utf-8")
     session = CodexTmuxSession(config, registry=soul_store)
+    tmux_calls: list[tuple[str, ...]] = []
 
     async def _noop(*_args, **_kwargs):
         return None
 
-    async def _has_stale_session():
-        return True
-
-    async def _failed_kill():
-        return TmuxCommandResult(
-            returncode=1,
-            stdout="",
-            stderr="stale session still alive",
-        )
+    async def _tmux_run(*args, timeout=5.0, stdin_data=None):
+        tmux_calls.append(args)
+        if args[0] == "has-session":
+            return TmuxCommandResult(returncode=0, stdout="", stderr="")
+        if args[0] == "kill-session":
+            return TmuxCommandResult(
+                returncode=1,
+                stdout="",
+                stderr="stale session still alive",
+            )
+        raise AssertionError(f"unexpected direct tmux call: {args}")
 
     async def _unexpected_new_session(**_kwargs):
         raise AssertionError("new_session reached after failed stale kill")
 
-    monkeypatch.setattr(session, "_container_agent", lambda *, strict: None)
+    monkeypatch.setattr(
+        session,
+        "_container_agent",
+        lambda *args, **kwargs: None,
+    )
     monkeypatch.setattr(
         session,
         "_select_command_runner",
@@ -2652,13 +2836,17 @@ async def test_tmux_repl_stale_kill_failure_refuses_before_publication(
         "pinky_daemon.tmux_session._seed_claude_trust_file",
         lambda _path, _cwd: False,
     )
-    monkeypatch.setattr(session._tmux, "has_session", _has_stale_session)
-    monkeypatch.setattr(session._tmux, "kill_session", _failed_kill)
+    monkeypatch.setattr(session._tmux, "_run", _tmux_run)
     monkeypatch.setattr(session._tmux, "new_session", _unexpected_new_session)
 
     with pytest.raises(RuntimeError, match="kill-session failed"):
         await session._spawn_tmux_repl()
 
+    assert [call[0] for call in tmux_calls] == [
+        "has-session",
+        "kill-session",
+        "has-session",
+    ]
     assert agents_md.read_text(encoding="utf-8") == "self edit before replacement"
     assert soul_store.calls == []
 

--- a/tests/test_codex_home.py
+++ b/tests/test_codex_home.py
@@ -34,7 +34,12 @@ from pinky_daemon.codex_session import CodexSession
 from pinky_daemon.codex_tmux_session import CodexTmuxSession
 from pinky_daemon.codex_tmux_transcript import _discover_codex_rollout
 from pinky_daemon.streaming_session import StreamingSessionConfig
-from pinky_daemon.tmux_session import TmuxCommandResult, TmuxSession, _TmuxControl
+from pinky_daemon.tmux_session import (
+    TmuxCommandResult,
+    TmuxSession,
+    _TmuxControl,
+    reconcile_tmux_spawn_cleanup_debts,
+)
 
 
 def _scope(
@@ -121,6 +126,7 @@ class _SpawnRollbackTmuxTrace:
         self.pending_list_reason = ""
         self.calls: list[tuple[str, ...]] = []
         self.spawned = asyncio.Event()
+        self.cancel_spawn_task = None
         self.permission_error = TmuxCommandResult(
             returncode=1,
             stdout="",
@@ -156,6 +162,8 @@ class _SpawnRollbackTmuxTrace:
         if operation == "new-session":
             self.live = True
             self.spawned.set()
+            if self.cancel_spawn_task is not None:
+                self.cancel_spawn_task()
             if self.new_session_hangs:
                 await asyncio.Event().wait()
             return TmuxCommandResult(returncode=0, stdout="", stderr="")
@@ -3445,6 +3453,36 @@ async def test_post_spawn_cancellation_waits_for_strict_rollback_and_no_leak(
 
 
 @pytest.mark.asyncio
+async def test_repeated_cancellation_cannot_strand_strict_spawn_rollback(
+    tmp_path,
+    monkeypatch,
+):
+    """R10: repeated caller cancels stay outside the shielded cleanup task."""
+    trace = _SpawnRollbackTmuxTrace(first_kill="non_ok_then_ok")
+    session, _tmux = _spawn_rollback_session(tmp_path, monkeypatch, trace)
+    monkeypatch.setattr(
+        "pinky_daemon.tmux_session._POST_SPAWN_LIVENESS_DELAY_SEC", 60
+    )
+
+    spawn_task = asyncio.create_task(session._spawn_tmux_repl())
+    await trace.spawned.wait()
+    assert spawn_task.cancel() is True
+    while trace.kill_calls == 0:
+        await asyncio.sleep(0)
+    for _ in range(18):
+        assert spawn_task.cancel() is True
+        await asyncio.sleep(0)
+
+    with pytest.raises(asyncio.CancelledError):
+        await spawn_task
+
+    assert spawn_task.cancelling() == 19
+    assert trace.kill_calls == 2
+    assert trace.live is False
+    assert not session._spawn_cleanup_debt_path().exists()
+
+
+@pytest.mark.asyncio
 async def test_cold_start_timeout_uses_strict_rollback_and_leaves_no_session(
     tmp_path,
     monkeypatch,
@@ -3491,6 +3529,183 @@ async def test_tailer_start_failure_uses_strict_rollback_and_leaves_no_session(
     assert trace.kill_calls == 2
     assert trace.live is False
     assert await tmux.has_session() is False
+
+
+@pytest.mark.parametrize(
+    ("failure_site", "record_site"),
+    [
+        ("post_liveness", "post-spawn liveness"),
+        ("cold_timeout", "cold-start timeout"),
+        ("tailer_failure", "tailer-start failure"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_persistent_spawn_ambiguity_retains_and_reaps_cleanup_debt_per_site(
+    tmp_path,
+    monkeypatch,
+    failure_site,
+    record_site,
+):
+    """R10: every give-up site leaves durable debt that the next spawn reaps."""
+    trace = _SpawnRollbackTmuxTrace(
+        first_kill="always_non_ok",
+        ambiguous_verify=True,
+        new_session_hangs=failure_site == "cold_timeout",
+        post_probe_error=failure_site == "post_liveness",
+    )
+    session, _tmux = _spawn_rollback_session(tmp_path, monkeypatch, trace)
+    monkeypatch.setattr(
+        "pinky_daemon.tmux_session._POST_SPAWN_LIVENESS_DELAY_SEC", 0
+    )
+
+    if failure_site == "cold_timeout":
+        monkeypatch.setattr(
+            "pinky_daemon.tmux_session._COLD_START_TIMEOUT_SEC", 0.01
+        )
+    elif failure_site == "tailer_failure":
+        trace.ambiguous_verify = False
+
+        async def _tailer_failure():
+            trace.ambiguous_verify = True
+            raise RuntimeError("synthetic tailer-start failure")
+
+        monkeypatch.setattr(session, "_start_tailer", _tailer_failure)
+
+    if failure_site == "cold_timeout":
+        with pytest.raises(RuntimeError, match="cold-start timed out"):
+            await session._spawn_tmux_repl()
+    elif failure_site == "tailer_failure":
+        with pytest.raises(RuntimeError, match="synthetic tailer-start failure"):
+            await session._spawn_tmux_repl()
+    else:
+        with pytest.raises(RuntimeError, match="has-session failed"):
+            await session._spawn_tmux_repl()
+
+    debt_path = session._spawn_cleanup_debt_path()
+    assert debt_path.is_file()
+    debt = json.loads(debt_path.read_text(encoding="utf-8"))
+    assert debt["agent_name"] == "test-agent"
+    assert debt["session_name"] == "pinky-test-agent"
+    assert debt["socket_name"] == ""
+    assert debt["socket_path"].endswith(f"tmux-{os.getuid()}/default")
+    assert debt["tmux_binary"] == "tmux"
+    assert debt["runner"] == {"kind": "local"}
+    assert debt["site"] == record_site
+    assert stat.S_IMODE(debt_path.stat().st_mode) == 0o600
+    assert trace.live is True
+
+    # Permission/transport ambiguity clears before the next spawn. The exact
+    # preflight method used by _spawn_tmux_repl must kill the retained child
+    # under its recorded execution identity, then durably clear the record.
+    trace.first_kill = "non_ok_then_ok"
+    trace.ambiguous_verify = False
+    trace.post_probe_error = False
+    await session._reap_retained_spawn_cleanup_debt()
+
+    assert trace.live is False
+    assert not debt_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_daemon_boot_reconciler_reaps_retained_spawn_cleanup_debt(
+    tmp_path,
+    monkeypatch,
+):
+    """R10: daemon boot scans debt even when no session gets registered."""
+    trace = _SpawnRollbackTmuxTrace(
+        first_kill="always_non_ok", ambiguous_verify=True
+    )
+    session, tmux = _spawn_rollback_session(tmp_path, monkeypatch, trace)
+    trace.live = True
+
+    failure = await session._rollback_spawned_session(site="boot fixture")
+    debt_path = session._spawn_cleanup_debt_path()
+    assert failure is not None
+    assert debt_path.exists()
+    assert trace.live is True
+
+    trace.first_kill = "non_ok_then_ok"
+    trace.ambiguous_verify = False
+    reaped, outstanding = await reconcile_tmux_spawn_cleanup_debts(
+        session._spawn_cleanup_state_dir(),
+        _control_factory=lambda _debt: tmux,
+    )
+
+    assert (reaped, outstanding) == (1, 0)
+    assert trace.live is False
+    assert not debt_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_spawn_rollback_outer_deadline_is_hard(
+    tmp_path,
+    monkeypatch,
+):
+    """R10: the outer timeout escapes attempt handlers instead of being eaten."""
+    trace = _SpawnRollbackTmuxTrace(first_kill="always_non_ok")
+    session, tmux = _spawn_rollback_session(tmp_path, monkeypatch, trace)
+    operations = []
+    never = asyncio.Event()
+
+    async def _hung_run(*args, timeout=5.0, stdin_data=None):
+        del timeout, stdin_data
+        operations.append(args[0])
+        await never.wait()
+        raise AssertionError("unreachable")
+
+    monkeypatch.setattr(tmux, "_run", _hung_run)
+    monkeypatch.setattr(
+        "pinky_daemon.tmux_session._SPAWN_ROLLBACK_COMMAND_TIMEOUT_SEC", 0.02
+    )
+    monkeypatch.setattr(
+        "pinky_daemon.tmux_session._SPAWN_ROLLBACK_RETRY_DELAY_SEC", 0.01
+    )
+    monkeypatch.setattr(
+        "pinky_daemon.tmux_session._SPAWN_ROLLBACK_TIMEOUT_SEC", 0.07
+    )
+
+    started = asyncio.get_running_loop().time()
+    failure = await session._rollback_spawned_session(site="scaled deadline")
+    elapsed = asyncio.get_running_loop().time() - started
+
+    assert failure is not None
+    assert "within 0.07s" in failure
+    assert elapsed < 0.085
+    assert operations == ["kill-session", "has-session", "kill-session"]
+    assert session._spawn_cleanup_debt_path().exists()
+
+
+@pytest.mark.asyncio
+async def test_cold_start_completion_boundary_honors_cancellation_on_python_311(
+    tmp_path,
+    monkeypatch,
+):
+    """R10: cancellation at _spawn completion cannot be consumed by wait_for."""
+    trace = _SpawnRollbackTmuxTrace(first_kill="non_ok_then_ok")
+    session, _tmux = _spawn_rollback_session(tmp_path, monkeypatch, trace)
+    monkeypatch.setattr(
+        "pinky_daemon.tmux_session._POST_SPAWN_LIVENESS_DELAY_SEC", 0
+    )
+    spawn_task = None
+
+    def _cancel_outer_spawn():
+        assert spawn_task is not None
+        assert spawn_task.cancel() is True
+
+    trace.cancel_spawn_task = _cancel_outer_spawn
+    spawn_task = asyncio.create_task(session._spawn_tmux_repl())
+
+    with pytest.raises(asyncio.CancelledError):
+        await spawn_task
+
+    operations = [call[0] for call in trace.calls]
+    new_session_index = operations.index("new-session")
+    assert operations[new_session_index + 1] == "kill-session"
+    assert trace.kill_calls == 2
+    assert trace.live is False
+    assert spawn_task.cancelled() is True
+    assert spawn_task.cancelling() == 1
+    assert not session._spawn_cleanup_debt_path().exists()
 
 
 def test_reverse_migration_moves_only_matching_rollouts(tmp_path):

--- a/tests/test_codex_home.py
+++ b/tests/test_codex_home.py
@@ -2513,6 +2513,77 @@ async def test_tmux_app_server_first_start_with_absent_server_proceeds(
 
 
 @pytest.mark.asyncio
+async def test_tmux_repl_absent_server_cold_start_proceeds(
+    tmp_path,
+    monkeypatch,
+):
+    """R8: a missing local socket remains positive cold-start absence."""
+    config = StreamingSessionConfig(
+        agent_name="test-agent",
+        working_dir=str(tmp_path / "agent"),
+    )
+    tmux = _TmuxControl("pinky-test-agent")
+    session = TmuxSession(config, tmux_control=tmux)
+    socket_dir = tmp_path / "tmux-empty"
+    monkeypatch.setenv("TMUX_TMPDIR", str(socket_dir))
+    monkeypatch.delenv("TMUX", raising=False)
+    tmux_calls: list[tuple[str, ...]] = []
+    has_session_calls = 0
+
+    async def _tmux_run(*args, timeout=5.0, stdin_data=None):
+        nonlocal has_session_calls
+        tmux_calls.append(args)
+        if args[0] == "has-session":
+            has_session_calls += 1
+            if has_session_calls == 1:
+                return TmuxCommandResult(
+                    returncode=1,
+                    stdout="",
+                    stderr="no server running",
+                )
+            return TmuxCommandResult(returncode=0, stdout="", stderr="")
+        if args[0] == "new-session":
+            return TmuxCommandResult(returncode=0, stdout="", stderr="")
+        raise AssertionError(f"unexpected tmux call: {args}")
+
+    async def _noop(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr(tmux, "_run", _tmux_run)
+    monkeypatch.setattr(
+        session,
+        "_container_agent",
+        lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(
+        session,
+        "_select_command_runner",
+        lambda _container_agent: tmux._runner,
+    )
+    monkeypatch.setattr(session, "_ensure_container_started", _noop)
+    monkeypatch.setattr(session, "_seed_container_trust", _noop)
+    monkeypatch.setattr(session, "_seed_container_home_creds", _noop)
+    monkeypatch.setattr(session, "_start_tailer", _noop)
+    monkeypatch.setattr(session, "_build_claude_cmd", lambda: "claude")
+    monkeypatch.setattr(
+        "pinky_daemon.tmux_session._seed_claude_trust_file",
+        lambda _path, _cwd: False,
+    )
+    monkeypatch.setattr(
+        "pinky_daemon.tmux_session._POST_SPAWN_LIVENESS_DELAY_SEC",
+        0,
+    )
+
+    await session._spawn_tmux_repl()
+
+    assert [call[0] for call in tmux_calls] == [
+        "has-session",
+        "new-session",
+        "has-session",
+    ]
+
+
+@pytest.mark.asyncio
 async def test_tmux_repl_stale_kill_already_gone_race_proceeds(
     tmp_path,
     monkeypatch,
@@ -3049,6 +3120,111 @@ async def test_tmux_repl_permission_probe_refuses_before_publication(
         "kill-session",
         "list-sessions",
     ]
+    assert agents_md.read_text(encoding="utf-8") == "self edit before replacement"
+    assert soul_store.calls == []
+
+
+@pytest.mark.asyncio
+async def test_tmux_repl_returned_has_session_error_refuses_before_spawn_side_effects(
+    tmp_path,
+    monkeypatch,
+):
+    """R8: an ambiguous stale-session probe must fail before spawn effects."""
+    shared_home = tmp_path / "shared"
+    working_dir = tmp_path / "agent"
+    working_dir.mkdir()
+    _auth(shared_home)
+    monkeypatch.setenv("CODEX_HOME", str(shared_home))
+    monkeypatch.setenv(PER_AGENT_CODEX_HOME_ENV, "1")
+    config = StreamingSessionConfig(
+        agent_name="test-agent",
+        working_dir=str(working_dir),
+        provider_url="codex_cli",
+        system_prompt="compiled tmux soul",
+    )
+    soul_store = _SoulStore()
+    prepare_agent_codex_home(
+        config,
+        log=lambda _message: None,
+        soul_version_store=soul_store,
+    )
+    soul_store.calls.clear()
+    agents_md = working_dir / ".codex" / "AGENTS.md"
+    agents_md.write_text("self edit before replacement", encoding="utf-8")
+    session = CodexTmuxSession(config, registry=soul_store)
+    _mark_tmux_server_socket(tmp_path, monkeypatch)
+    tmux_calls: list[tuple[str, ...]] = []
+    env_build_count = 0
+    publication_count = 0
+    new_session_count = 0
+    permission_error = TmuxCommandResult(
+        returncode=1,
+        stdout="",
+        stderr="couldn't create directory /blocked/tmux-501 (Permission denied)",
+    )
+    real_build_env = session._build_repl_env
+    real_prepare_spawn = session._prepare_tmux_spawn
+
+    async def _noop(*_args, **_kwargs):
+        return None
+
+    async def _tmux_run(*args, timeout=5.0, stdin_data=None):
+        tmux_calls.append(args)
+        if args[0] in {"has-session", "list-sessions"}:
+            return permission_error
+        raise AssertionError(f"unexpected direct tmux call: {args}")
+
+    async def _tracked_new_session(**_kwargs):
+        nonlocal new_session_count
+        new_session_count += 1
+        return TmuxCommandResult(
+            returncode=1,
+            stdout="",
+            stderr="new-session reached after ambiguous has-session probe",
+        )
+
+    def _tracked_build_env():
+        nonlocal env_build_count
+        env_build_count += 1
+        return real_build_env()
+
+    def _tracked_prepare_spawn():
+        nonlocal publication_count
+        publication_count += 1
+        return real_prepare_spawn()
+
+    monkeypatch.setattr(
+        session,
+        "_container_agent",
+        lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(
+        session,
+        "_select_command_runner",
+        lambda _container_agent: session._tmux._runner,
+    )
+    monkeypatch.setattr(session, "_ensure_container_started", _noop)
+    monkeypatch.setattr(session, "_seed_container_trust", _noop)
+    monkeypatch.setattr(session, "_seed_container_home_creds", _noop)
+    monkeypatch.setattr(
+        "pinky_daemon.tmux_session._seed_claude_trust_file",
+        lambda _path, _cwd: False,
+    )
+    monkeypatch.setattr(session._tmux, "_run", _tmux_run)
+    monkeypatch.setattr(session._tmux, "new_session", _tracked_new_session)
+    monkeypatch.setattr(session, "_build_repl_env", _tracked_build_env)
+    monkeypatch.setattr(session, "_prepare_tmux_spawn", _tracked_prepare_spawn)
+
+    with pytest.raises(RuntimeError, match="has-session failed"):
+        await session._spawn_tmux_repl()
+
+    assert [call[0] for call in tmux_calls] == [
+        "has-session",
+        "list-sessions",
+    ]
+    assert env_build_count == 0
+    assert publication_count == 0
+    assert new_session_count == 0
     assert agents_md.read_text(encoding="utf-8") == "self edit before replacement"
     assert soul_store.calls == []
 

--- a/tests/test_codex_home.py
+++ b/tests/test_codex_home.py
@@ -2176,6 +2176,60 @@ async def test_tmux_replacement_publishes_and_snapshots_soul_once(
     assert soul_store.calls == [("test-agent", "compiled tmux soul", "spawn")]
 
 
+@pytest.mark.asyncio
+async def test_tmux_refused_replacement_does_not_stale_next_spawn_soul(
+    tmp_path,
+    monkeypatch,
+):
+    shared_home = tmp_path / "shared"
+    working_dir = tmp_path / "agent"
+    working_dir.mkdir()
+    _auth(shared_home)
+    monkeypatch.setenv("CODEX_HOME", str(shared_home))
+    monkeypatch.setenv(PER_AGENT_CODEX_HOME_ENV, "1")
+    config = StreamingSessionConfig(
+        agent_name="test-agent",
+        working_dir=str(working_dir),
+        provider_url="codex_cli",
+        system_prompt="compiled tmux soul",
+        restart_guard=lambda _session: {"restart_safe": False},
+    )
+    soul_store = _SoulStore()
+    session = CodexTmuxSession(config, registry=soul_store)
+    session._has_completed_turn = True
+
+    async def _noop():
+        return None
+
+    async def _base_spawn(_session):
+        return None
+
+    monkeypatch.setattr(session, "_seed_codex_trust", lambda _cwd: None)
+    monkeypatch.setattr(session, "_codex_dismiss_nux_and_ready", _noop)
+    monkeypatch.setattr(
+        "pinky_daemon.codex_tmux_session.TmuxSession._spawn_tmux_repl",
+        _base_spawn,
+    )
+
+    assert await session.force_restart() is False
+    assert soul_store.calls == [
+        ("test-agent", "compiled tmux soul", "spawn"),
+    ]
+    assert session._preflighted_codex_homes == {}
+
+    agents_md = working_dir / ".codex" / "AGENTS.md"
+    agents_md.write_text("self edit after refused restart", encoding="utf-8")
+
+    await session._spawn_tmux_repl()
+
+    assert agents_md.read_text(encoding="utf-8") == "compiled tmux soul"
+    assert soul_store.calls == [
+        ("test-agent", "compiled tmux soul", "spawn"),
+        ("test-agent", "self edit after refused restart", "agent"),
+        ("test-agent", "compiled tmux soul", "spawn"),
+    ]
+
+
 def test_tmux_app_server_boundary_uses_the_shared_soul_writer(
     tmp_path,
     monkeypatch,

--- a/tests/test_codex_home.py
+++ b/tests/test_codex_home.py
@@ -16,6 +16,7 @@ from types import SimpleNamespace
 import pytest
 
 from pinky_daemon import codex_home as codex_home_mod
+from pinky_daemon.codex_app_server_tmux import CodexAppServerSupervisor
 from pinky_daemon.codex_home import (
     MANAGED_CONFIG_SENTINEL,
     PER_AGENT_CODEX_HOME_ENV,
@@ -31,12 +32,32 @@ from pinky_daemon.codex_tmux_transcript import _discover_codex_rollout
 from pinky_daemon.streaming_session import StreamingSessionConfig
 
 
-def _scope(working_dir: Path, *, codex_home: str = "") -> SimpleNamespace:
+def _scope(
+    working_dir: Path,
+    *,
+    codex_home: str = "",
+    system_prompt: str = "",
+) -> SimpleNamespace:
     return SimpleNamespace(
         agent_name="test-agent",
         working_dir=str(working_dir),
         codex_home=codex_home,
+        system_prompt=system_prompt,
     )
+
+
+class _SoulStore:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str, str]] = []
+
+    def save_soul_version(
+        self,
+        agent_name: str,
+        content: str,
+        source: str = "unknown",
+    ) -> int:
+        self.calls.append((agent_name, content, source))
+        return len(self.calls)
 
 
 def _auth(shared_home: Path) -> Path:
@@ -70,13 +91,113 @@ def test_flag_off_preserves_shared_path_and_performs_no_bootstrap(tmp_path, monk
     monkeypatch.setenv("CODEX_HOME", str(shared_home))
     monkeypatch.delenv(PER_AGENT_CODEX_HOME_ENV, raising=False)
     monkeypatch.setenv(codex_home_mod.MIGRATION_LOCK_TIMEOUT_ENV, "invalid")
-    scope = _scope(working_dir, codex_home=str(override))
+    scope = _scope(
+        working_dir,
+        codex_home=str(override),
+        system_prompt="compiled soul",
+    )
+    soul_store = _SoulStore()
 
     assert codex_home_for(scope) == shared_home
-    assert prepare_agent_codex_home(scope, log=lambda _message: None) == shared_home
+    assert prepare_agent_codex_home(
+        scope,
+        log=lambda _message: None,
+        soul_version_store=soul_store,
+    ) == shared_home
     assert not working_dir.exists()
     assert not override.exists()
     assert not shared_home.exists()
+    assert soul_store.calls == []
+
+
+def test_prepare_writes_agent_soul_and_snapshots_self_edit_before_overwrite(
+    tmp_path,
+    monkeypatch,
+):
+    shared_home = tmp_path / "shared"
+    working_dir = tmp_path / "agent"
+    agent_home = working_dir / ".codex"
+    working_dir.mkdir()
+    agent_home.mkdir()
+    _auth(shared_home)
+    agents_md = agent_home / "AGENTS.md"
+    agents_md.write_text("agent-authored edit", encoding="utf-8")
+    monkeypatch.setenv("CODEX_HOME", str(shared_home))
+    monkeypatch.setenv(PER_AGENT_CODEX_HOME_ENV, "1")
+    soul_store = _SoulStore()
+
+    prepared = prepare_agent_codex_home(
+        _scope(working_dir, system_prompt="compiled soul"),
+        log=lambda _message: None,
+        soul_version_store=soul_store,
+    )
+
+    assert prepared == agent_home
+    assert agents_md.read_text(encoding="utf-8") == "compiled soul"
+    assert stat.S_IMODE(agents_md.stat().st_mode) == 0o600
+    assert soul_store.calls == [
+        ("test-agent", "agent-authored edit", "agent"),
+        ("test-agent", "compiled soul", "spawn"),
+    ]
+    assert not (shared_home / "AGENTS.md").exists()
+
+
+def test_prepare_replaces_linked_soul_without_writing_its_shared_target(
+    tmp_path,
+    monkeypatch,
+):
+    shared_home = tmp_path / "shared"
+    working_dir = tmp_path / "agent"
+    agent_home = working_dir / ".codex"
+    working_dir.mkdir()
+    agent_home.mkdir()
+    _auth(shared_home)
+    shared_soul = shared_home / "AGENTS.md"
+    shared_soul.write_text("shared operator soul", encoding="utf-8")
+    agents_md = agent_home / "AGENTS.md"
+    agents_md.symlink_to(shared_soul)
+    monkeypatch.setenv("CODEX_HOME", str(shared_home))
+    monkeypatch.setenv(PER_AGENT_CODEX_HOME_ENV, "1")
+    soul_store = _SoulStore()
+
+    prepare_agent_codex_home(
+        _scope(working_dir, system_prompt="compiled soul"),
+        log=lambda _message: None,
+        soul_version_store=soul_store,
+    )
+
+    assert not agents_md.is_symlink()
+    assert agents_md.read_text(encoding="utf-8") == "compiled soul"
+    assert shared_soul.read_text(encoding="utf-8") == "shared operator soul"
+    assert soul_store.calls == [
+        ("test-agent", "shared operator soul", "agent"),
+        ("test-agent", "compiled soul", "spawn"),
+    ]
+
+
+def test_subprocess_transport_flag_off_has_zero_env_delta_and_zero_soul_writes(
+    tmp_path,
+    monkeypatch,
+):
+    shared_home = tmp_path / "shared"
+    working_dir = tmp_path / "agent"
+    monkeypatch.setenv("CODEX_HOME", str(shared_home))
+    monkeypatch.delenv(PER_AGENT_CODEX_HOME_ENV, raising=False)
+    config = StreamingSessionConfig(
+        agent_name="test-agent",
+        working_dir=str(working_dir),
+        provider_url="codex_cli",
+        system_prompt="compiled soul",
+    )
+    soul_store = _SoulStore()
+    before = dict(os.environ)
+
+    env = CodexSession(config, registry=soul_store)._build_codex_env()
+
+    assert env == before
+    assert soul_store.calls == []
+    assert not (shared_home / "AGENTS.md").exists()
+    assert not (working_dir / ".codex" / "AGENTS.md").exists()
 
 
 def test_flag_off_home_fallback_is_test_controlled(tmp_path, monkeypatch):
@@ -1861,12 +1982,85 @@ def test_subprocess_transport_overlays_prepared_home(tmp_path, monkeypatch):
         agent_name="test-agent",
         working_dir=str(working_dir),
         provider_url="codex_cli",
+        system_prompt="compiled subprocess soul",
     )
+    soul_store = _SoulStore()
 
-    env = CodexSession(config)._build_codex_env()
+    env = CodexSession(config, registry=soul_store)._build_codex_env()
 
     assert env["CODEX_HOME"] == str(working_dir / ".codex")
     assert (working_dir / ".codex" / "auth.json").is_symlink()
+    assert (working_dir / ".codex" / "AGENTS.md").read_text(
+        encoding="utf-8"
+    ) == "compiled subprocess soul"
+    assert soul_store.calls == [
+        ("test-agent", "compiled subprocess soul", "spawn")
+    ]
+    assert not (shared_home / "AGENTS.md").exists()
+
+
+def test_tmux_transport_preflight_writes_soul_only_to_agent_home(
+    tmp_path,
+    monkeypatch,
+):
+    shared_home = tmp_path / "shared"
+    working_dir = tmp_path / "agent"
+    working_dir.mkdir()
+    _auth(shared_home)
+    monkeypatch.setenv("CODEX_HOME", str(shared_home))
+    monkeypatch.setenv(PER_AGENT_CODEX_HOME_ENV, "1")
+    config = StreamingSessionConfig(
+        agent_name="test-agent",
+        working_dir=str(working_dir),
+        provider_url="codex_cli",
+        system_prompt="compiled tmux soul",
+    )
+    soul_store = _SoulStore()
+    session = CodexTmuxSession(config, registry=soul_store)
+
+    session._preflight_transport_replacement()
+
+    assert (working_dir / ".codex" / "AGENTS.md").read_text(
+        encoding="utf-8"
+    ) == "compiled tmux soul"
+    assert soul_store.calls == [("test-agent", "compiled tmux soul", "spawn")]
+    assert not (shared_home / "AGENTS.md").exists()
+
+
+def test_tmux_app_server_boundary_uses_the_shared_soul_writer(
+    tmp_path,
+    monkeypatch,
+):
+    shared_home = tmp_path / "shared"
+    working_dir = tmp_path / "agent"
+    working_dir.mkdir()
+    _auth(shared_home)
+    monkeypatch.setenv("CODEX_HOME", str(shared_home))
+    monkeypatch.setenv(PER_AGENT_CODEX_HOME_ENV, "1")
+    config = StreamingSessionConfig(
+        agent_name="test-agent",
+        working_dir=str(working_dir),
+        provider_url="codex_cli",
+        system_prompt="compiled app-server soul",
+    )
+    soul_store = _SoulStore()
+    supervisor = CodexAppServerSupervisor(
+        "test-agent",
+        working_dir=str(working_dir),
+        agent_config=config,
+        soul_version_store=soul_store,
+    )
+
+    env = supervisor._build_env()
+
+    assert env["CODEX_HOME"] == str(working_dir / ".codex")
+    assert (working_dir / ".codex" / "AGENTS.md").read_text(
+        encoding="utf-8"
+    ) == "compiled app-server soul"
+    assert soul_store.calls == [
+        ("test-agent", "compiled app-server soul", "spawn")
+    ]
+    assert not (shared_home / "AGENTS.md").exists()
 
 
 def test_reverse_migration_moves_only_matching_rollouts(tmp_path):


### PR DESCRIPTION
## Contract

This change completes the AGENTS.md amendment to per-agent Codex-home isolation.

- Keep `PINKY_CODEX_PER_AGENT_HOME` default-off. When disabled, Codex keeps the existing shared-home behavior and the daemon performs no isolated-home or AGENTS.md writes.
- When enabled, publish the session's compiled `system_prompt` as `<agent CODEX_HOME>/AGENTS.md` through the shared Codex-home writer used by every Codex transport.
- Snapshot existing AGENTS.md content with `source="agent"` before replacement, then snapshot the installed compiled soul with `source="spawn"` after publication.
- Publish with an adjacent temporary file, mode `0600`, atomic replacement, and directory sync. Linked AGENTS.md entries are replaced rather than followed.
- Refuse flagged spawns when the shared home is selected, shared auth is unavailable, managed auth state is invalid, an existing soul cannot be read, compiled soul versions cannot be recorded, or replacement cleanup cannot positively establish that the owned child is gone.

## Spawn-boundary design

Retained transports use distinct validation, cleanup, and publication seams:

1. `validate_agent_codex_home` performs non-mutating validation before any live transport is torn down.
2. The shared REPL stale-session gate preserves three outcomes. `has-session` rc=0 means present. A nonzero result means absent only after the shared positive-absence verifier proves a missing local socket or obtains a successful, nonempty, well-formed session enumeration omitting the exact target. Permission, transport, stat, malformed-output, and other ambiguous results raise before trust seeding, environment construction, soul publication, or `new-session`.
3. Replacement cleanup is strict. After a non-ok tmux `kill-session`, the same positive-absence verifier may synthesize idempotent success; otherwise the original failure is preserved and probe exceptions propagate.
4. Direct-process kill/wait failure or cached app-server cleanup failure likewise aborts before environment construction, soul publication, or replacement spawn.
5. `prepare_agent_codex_home` snapshots and publishes the current soul at each actual process-spawn boundary, after successful cleanup.

Ordinary terminal shutdown remains best-effort. Failed direct-process shutdown retains its cached process handle, so a later replacement must retry strict cleanup rather than losing the failure and spawning over a stale child.

No prepared-home publication state is handed between replacement operations or async tasks. Direct subprocess, direct app-server, tmux REPL, and tmux-hosted app-server paths all use the same validation and publication helpers.

The existing auth decision is unchanged: per-agent homes retain the reviewed symlink to shared `auth.json`. Working-directory AGENTS.md precedence is also unchanged.

## r8 shared entry-gate proof

Frozen head: `9befe7917a6e296312e5eaf28f5b1ce1cfc9c06b`  
Tree: `af74f0b5bb225ef86782f22ad78c758585907112`  
Parent/r7: `f25d92a9b4255e89ef10c1ae724c7edbf4c45010`

Root cause: `_TmuxControl.has_session()` reduced every returned nonzero result to `False`. The inherited `TmuxSession._spawn_tmux_repl()` stale-session gate therefore treated a returned permission/transport error as positive absence, skipped `kill_session()` and its r7 verifier, then constructed the environment, published spawn state, and attempted `new-session`.

The real-host tmux 3.6a chmod-000 `TMUX_TMPDIR` repro now fails closed through the shared `CodexTmuxSession -> TmuxSession._spawn_tmux_repl` path:

```text
r7 pre-fix:
calls=[('has-session', 1)]
env_build_count=2 publication_count=1 new_session_count=1
error=RuntimeError: tmux new-session failed ...

r8 post-fix:
calls=[('has-session', 1), ('list-sessions', 1)]
env_build_count=0 publication_count=0 new_session_count=0
error=RuntimeError: tmux has-session failed without verified absence ... Permission denied
```

The r8 regression injects the returned `has-session` permission/transport shape into the real shared spawn method and pins refusal before environment construction, transport publication, AGENTS.md replacement, soul-store writes, and `new-session`. The missing-local-socket cold-start path still spawns, and the successful-enumeration stale-kill race still respawns. All r1-r7 cleanup, publication-order, retry, auth, linked-entry, mode, and flag-off regressions remain green.

## Boolean tmux-probe consumer audit

Every boolean-reduced tmux probe helper in the cumulative six-file scope and every source call site was enumerated:

| Helper / source consumer | Classification | r8 disposition |
| --- | --- | --- |
| `_TmuxControl.has_session()` -> `TmuxSession._spawn_tmux_repl` pre-spawn stale gate | Publication-gating | Fixed centrally: nonzero is never absence without positive verification; ambiguity raises before env/publication/spawn. |
| `_TmuxControl.has_session()` -> `TmuxSession._spawn_tmux_repl` post-spawn liveness gate | Publication-gating | Fixed centrally: verified absence reports the existing died-immediately error; ambiguity raises, and the strict spawn rollback (below) reaps the child or retains durable cleanup debt. |
| `_TmuxControl.has_session()` -> `api._watchdog_tmux_liveness` | Publication-gating (owner-alert publication) | Fixed centrally: ambiguity raises; the watchdog's existing diagnostic-exception path does not page or restart a potentially healthy agent. |
| `_server_socket_is_missing()` -> `_session_absence_is_verified()` | Benign positive-evidence primitive | Unchanged and conservative: only `FileNotFoundError` proves absence; stat/permission errors return no proof. |
| `_session_absence_is_verified()` -> `has_session()` and `kill_session()` | Publication-gating verifier | Safe by construction: only positive absence returns true; false makes `has_session()` raise or preserves the original failed kill. |
| `_codex_capture_explicit_idle()` -> Codex scheduler double-idle checks | Benign scheduling evidence | Unchanged: capture error/non-ok means not proven idle, so metadata is not retired and no scheduler paste is authorized. |
| `_timed_out_turn_landed()` -> worker delivery-timeout and paste-timeout retry sites | Benign delivery-recovery evidence | Unchanged: it does not authorize transport publication or replacement. |
| `_pane_is_animating()` -> inflight watchdog liveness carve-out | Benign liveness evidence | Unchanged: it only supplies positive evidence against an already-derived wedge verdict and never authorizes spawn/publication. |

Boolean action reducers such as strict app-server kill, pane resize, pane input, and REPL command delivery were also inspected and excluded from the probe set: they report command outcomes, not resource-existence evidence. The strict app-server kill path already preserves/raises cleanup errors before replacement publication.

## Strict spawn rollback, durable cleanup debt, hard bounds, 3.11 boundary

Later review rounds hardened the spawn failure paths themselves:

- **Strict central rollback.** All three spawn rollback sites (cold-start timeout, post-spawn liveness, tailer-start failure) share one bounded helper: two kill attempts, each failure followed by the three-valued liveness verifier. A returned non-ok kill is treated exactly like a raised one. No best-effort `except: pass` kill shape remains at any spawn rollback site.
- **Durable cleanup debt.** Before cleanup attempts, the helper persists a crash-safe (fsynced `O_EXCL` temp, atomic hard-link publish, directory fsync) mode-`0600` JSON debt record with the exact session, socket path, and runner identity. Proved teardown clears it; persistent ambiguity keeps it, annotates the original exception, and logs ERROR. The next spawn for the same agent reaps recorded debt before any new-session effects and fails closed if teardown remains unproved; daemon startup reconciles all debt records — including for disabled or unregistered agents — before pollers and session startup. A corrupt or unreapable record blocks only that spawn, boundedly and loudly.
- **Hard bounds.** Command and outer rollback bounds use task-local `asyncio.timeout()`; attempt-level handlers catch `Exception`, never `BaseException`, so the outer bound's cancellation cannot be consumed by the cleanup it limits.
- **CPython 3.11 completion-boundary cancellation.** Pre-3.12 `asyncio.wait_for` can consume a caller's accepted cancellation when the inner future is already complete (CPython 3.11 `tasks.py` returns `fut.result()` after catching `CancelledError`), leaving the spawn running while the caller believes it cancelled. The cold spawn now uses task-local `asyncio.timeout` plus a `current_task().cancelling()` baseline check at the completion boundary; a consumed cancel triggers strict rollback and propagates `CancelledError`. A deterministic regression cancels from the new-session completion seam and fails on the unfixed code under real 3.11.
- Regressions cover per-site debt retention and reap, returned-non-ok and raised kills, ambiguous verification, scaled hard-ceiling timing, repeated cancellation, and the 3.11 boundary — run on real CPython 3.11 and 3.13.

## Verification (final head)

- Codex-home isolation module, full round matrix: `87 passed` (real 3.11.15 and 3.13.14)
- Focused blocker/positive set: `13 passed` on both interpreters
- Broad Codex modules: `359 passed, 1 skipped` on both interpreters
- Shared tmux, Codex tmux, command-runner: `470 passed, 1 skipped` on both interpreters
- Session watchdog: `78 passed`; container isolation: `77 passed`
- Locked non-API repository coverage: `4694 passed, 4 skipped, 1 deselected`
- Approved deselection: `tests/test_sweep_api_fixes.py::TestCodexSharedMcpBearer::test_codex_mcp_headers_include_derived_bearer`
- Real-host artifacts: tmux `3.6a` chmod-000 socket-directory repros at all three rollback sites (durable debt retained, reaped by next-spawn preflight and by daemon-boot reconciliation, including with `TMUX`/`TMUX_TMPDIR` changed between spawn and boot); scaled ceiling probe; production-shape 3.11 completion-boundary cancel
- Independent reviewer verification and CI (3.11/3.12/3.13) green at the final head
- Ruff, compileall (3.11 and 3.13), `git diff --check`: clean

## Scope and rollout

The cumulative PR changes exactly seven tracked files. The original five-file isolation scope remains intact; `src/pinky_daemon/tmux_session.py` is the justified sixth file because the shared stale-session reap and spawn rollback are the sibling cleanup barrier between Codex validation and publication, and `src/pinky_daemon/api.py` is the justified seventh: daemon-boot debt reconciliation must run before pollers and session startup because pre-registration debts are, by design, absent from the broker and watchdog registries.

No host flag is flipped by this PR. Per-host enablement remains an operations step at an idle lane seam with a witnessed per-agent restart, resume check, MCP check, and live turn.

🤖 Opened by Kuzya

