### PR TITLE
Guard agent registration and soul mutations

### DIFF
--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -23,11 +23,13 @@ Hierarchy:
 from __future__ import annotations
 
 import json
+import os
 import re
 import secrets
 import shlex
 import sqlite3
 import sys
+import tempfile
 import threading
 import time
 from dataclasses import dataclass, field
@@ -97,6 +99,60 @@ def _validate_agent_name(name: str) -> str:
             f"starts with letter or digit; up to 63 chars)"
         )
     return name
+
+
+class AgentPathContainmentError(ValueError):
+    """A requested agent path resolved outside its owning workspace."""
+
+
+def resolve_agent_path(
+    agent_name: str,
+    agent_dir: str | Path,
+    *parts: str | Path,
+) -> Path:
+    """Resolve an agent-owned path and refuse aliases outside its workspace.
+
+    ``agent_dir`` is the persisted owning workspace.  Resolution happens
+    before any caller reads or writes the result, so ``..`` components,
+    absolute children, symlinks, and case-normalized aliases cannot escape
+    the workspace.  The agent name is validated here as well so every path
+    boundary shares the registry's existing strict allowlist.
+    """
+    _validate_agent_name(agent_name)
+    if not agent_dir:
+        raise AgentPathContainmentError("agent workspace is not configured")
+    workspace_path = Path(agent_dir)
+    if not workspace_path.is_absolute():
+        raise AgentPathContainmentError("agent workspace is not an absolute path")
+    workspace = workspace_path.resolve()
+    candidate = workspace.joinpath(*parts) if parts else workspace
+    resolved = candidate.resolve()
+    if resolved != workspace and not resolved.is_relative_to(workspace):
+        raise AgentPathContainmentError("agent path is outside its workspace")
+    return resolved
+
+
+def replace_agent_text(
+    agent_name: str,
+    agent_dir: str | Path,
+    path: str | Path,
+    content: str,
+) -> Path:
+    """Atomically replace one contained agent file without following links."""
+    target = resolve_agent_path(agent_name, agent_dir, path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    fd, temp_name = tempfile.mkstemp(prefix=f".{target.name}.", dir=target.parent)
+    temp_path = Path(temp_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as stream:
+            stream.write(content)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temp_path, target)
+    except Exception:
+        temp_path.unlink(missing_ok=True)
+        raise
+    return target
 
 
 def _log(msg: str) -> None:
@@ -772,6 +828,22 @@ class ScheduleNameConflictError(ValueError):
 
 class AgentAlreadyExistsError(ValueError):
     """A create-only registration collided with an existing agent name."""
+
+
+class AgentRegistrationIncompleteError(RuntimeError):
+    """A create-only registration won its DB name but failed before completion."""
+
+    def __init__(self, name: str, *, row_committed: bool):
+        super().__init__(f"registration incomplete for {name}")
+        self.row_committed = row_committed
+
+
+class AgentWorkspacePathError(ValueError):
+    """An agent workspace could not be resolved to a usable absolute path."""
+
+
+class AgentWorkspaceOverlapError(ValueError):
+    """An agent workspace overlaps another registered agent's owner root."""
 
 
 @dataclass(frozen=True)
@@ -2173,10 +2245,11 @@ class AgentRegistry:
         from #429) on agents whose workspace pre-dates them, without nuking
         any user customizations to existing scripts.
         """
+        agent_name = _validate_agent_name(agent_name)
         agent = self.get(agent_name)
         if not agent or not agent.working_dir:
             return
-        work_dir = Path(agent.working_dir)
+        work_dir = resolve_agent_path(agent_name, agent.working_dir)
         if not work_dir.exists():
             return
         try:
@@ -2195,11 +2268,21 @@ class AgentRegistry:
             ├── .claude/        # Claude Code hooks + settings
             └── CLAUDE.md       # Written by spawn, not here
         """
+        if agent_name:
+            work_dir = resolve_agent_path(agent_name, work_dir)
+            data_dir = resolve_agent_path(agent_name, work_dir, "data")
+            output_dir = resolve_agent_path(agent_name, work_dir, "output")
+            workspace_dir = resolve_agent_path(agent_name, work_dir, "workspace")
+        else:
+            work_dir = Path(work_dir).resolve()
+            data_dir = work_dir / "data"
+            output_dir = work_dir / "output"
+            workspace_dir = work_dir / "workspace"
         try:
             work_dir.mkdir(parents=True, exist_ok=True)
-            (work_dir / "data").mkdir(exist_ok=True)
-            (work_dir / "output").mkdir(exist_ok=True)
-            (work_dir / "workspace").mkdir(exist_ok=True)
+            data_dir.mkdir(exist_ok=True)
+            output_dir.mkdir(exist_ok=True)
+            workspace_dir.mkdir(exist_ok=True)
         except PermissionError:
             _log(f"agent_registry: workspace init skipped for {work_dir} (permission denied)")
             return
@@ -2211,6 +2294,7 @@ class AgentRegistry:
     @staticmethod
     def _write_hook_if_changed(
         *,
+        agent_dir: Path,
         hook_path: Path,
         new_source: str,
         hook_filename: str,
@@ -2230,11 +2314,11 @@ class AgentRegistry:
         ``_validate_agent_name``). The validation is cheap and raises
         ``ValueError`` on bad input rather than corrupting disk layout.
         """
-        _validate_agent_name(agent_name)
+        hook_path = resolve_agent_path(agent_name, agent_dir, hook_path)
         existing = hook_path.read_text() if hook_path.exists() else ""
         if existing == new_source:
             return
-        hook_path.write_text(new_source)
+        replace_agent_text(agent_name, agent_dir, hook_path, new_source)
         verb = "updated" if existing else "created"
         _log(f"agent_registry: {verb} {hook_filename} for {agent_name}")
 
@@ -2255,8 +2339,8 @@ class AgentRegistry:
         # the public entry point. Cheap re-check; raises ``ValueError`` on
         # bad input so the daemon crashes loudly rather than corrupting
         # filesystem layout.
-        _validate_agent_name(agent_name)
-        claude_dir = work_dir / ".claude"
+        work_dir = resolve_agent_path(agent_name, work_dir)
+        claude_dir = resolve_agent_path(agent_name, work_dir, ".claude")
         claude_dir.mkdir(exist_ok=True)
 
         hook_template = '''\
@@ -2324,14 +2408,26 @@ except Exception as exc:
         "%s: %s" % (type(exc).__name__, exc),
     )
 '''
-        working_path = claude_dir / "hook_working.py"
-        idle_path = claude_dir / "hook_idle.py"
-        verify_effort_path = claude_dir / "hook_verify_effort.py"
-        tmux_wake_path = claude_dir / "hook_tmux_wake.py"
-        tmux_session_start_path = claude_dir / "hook_tmux_session_start.py"
-        tmux_pre_tool_path = claude_dir / "hook_tmux_pre_tool.py"
-        tmux_post_tool_path = claude_dir / "hook_tmux_post_tool.py"
-        tmux_stop_failure_path = claude_dir / "hook_tmux_stop_failure.py"
+        working_path = resolve_agent_path(agent_name, work_dir, ".claude", "hook_working.py")
+        idle_path = resolve_agent_path(agent_name, work_dir, ".claude", "hook_idle.py")
+        verify_effort_path = resolve_agent_path(
+            agent_name, work_dir, ".claude", "hook_verify_effort.py"
+        )
+        tmux_wake_path = resolve_agent_path(
+            agent_name, work_dir, ".claude", "hook_tmux_wake.py"
+        )
+        tmux_session_start_path = resolve_agent_path(
+            agent_name, work_dir, ".claude", "hook_tmux_session_start.py"
+        )
+        tmux_pre_tool_path = resolve_agent_path(
+            agent_name, work_dir, ".claude", "hook_tmux_pre_tool.py"
+        )
+        tmux_post_tool_path = resolve_agent_path(
+            agent_name, work_dir, ".claude", "hook_tmux_post_tool.py"
+        )
+        tmux_stop_failure_path = resolve_agent_path(
+            agent_name, work_dir, ".claude", "hook_tmux_stop_failure.py"
+        )
 
         # #638: these two were historically written once and left alone, which
         # stranded fleet agents on stale sources (e.g. the hardcoded
@@ -2339,12 +2435,14 @@ except Exception as exc:
         # are fully PinkyBot-managed, so keep them current like the five
         # always-rewritten hooks below.
         AgentRegistry._write_hook_if_changed(
+            agent_dir=work_dir,
             hook_path=working_path,
             new_source=hook_template.format(agent_name=agent_name, status="working"),
             hook_filename="hook_working.py",
             agent_name=agent_name,
         )
         AgentRegistry._write_hook_if_changed(
+            agent_dir=work_dir,
             hook_path=idle_path,
             new_source=hook_template.format(agent_name=agent_name, status="idle"),
             hook_filename="hook_idle.py",
@@ -2369,36 +2467,42 @@ except Exception as exc:
         # returns ``ok: True, session: None`` for non-tmux runtimes, so each
         # is a cheap no-op for SDK / codex agents (one extra POST per turn).
         AgentRegistry._write_hook_if_changed(
+            agent_dir=work_dir,
             hook_path=verify_effort_path,
             new_source=_verify_effort_hook_source(),
             hook_filename="hook_verify_effort.py",
             agent_name=agent_name,
         )
         AgentRegistry._write_hook_if_changed(
+            agent_dir=work_dir,
             hook_path=tmux_wake_path,
             new_source=_tmux_wake_hook_source(agent_name),
             hook_filename="hook_tmux_wake.py",
             agent_name=agent_name,
         )
         AgentRegistry._write_hook_if_changed(
+            agent_dir=work_dir,
             hook_path=tmux_session_start_path,
             new_source=_tmux_session_start_hook_source(agent_name),
             hook_filename="hook_tmux_session_start.py",
             agent_name=agent_name,
         )
         AgentRegistry._write_hook_if_changed(
+            agent_dir=work_dir,
             hook_path=tmux_pre_tool_path,
             new_source=_tmux_pre_tool_hook_source(agent_name),
             hook_filename="hook_tmux_pre_tool.py",
             agent_name=agent_name,
         )
         AgentRegistry._write_hook_if_changed(
+            agent_dir=work_dir,
             hook_path=tmux_post_tool_path,
             new_source=_tmux_post_tool_hook_source(agent_name),
             hook_filename="hook_tmux_post_tool.py",
             agent_name=agent_name,
         )
         AgentRegistry._write_hook_if_changed(
+            agent_dir=work_dir,
             hook_path=tmux_stop_failure_path,
             new_source=_tmux_stop_failure_hook_source(agent_name),
             hook_filename="hook_tmux_stop_failure.py",
@@ -2406,7 +2510,8 @@ except Exception as exc:
         )
 
         AgentRegistry._sync_hooks_settings(
-            claude_dir / "settings.json",
+            resolve_agent_path(agent_name, work_dir, ".claude", "settings.json"),
+            agent_dir=work_dir,
             working_path=working_path.resolve(),
             idle_path=idle_path.resolve(),
             verify_effort_path=verify_effort_path.resolve(),
@@ -2422,6 +2527,7 @@ except Exception as exc:
     def _sync_hooks_settings(
         settings_path: Path,
         *,
+        agent_dir: Path,
         working_path: Path,
         idle_path: Path,
         verify_effort_path: Path,
@@ -2442,6 +2548,36 @@ except Exception as exc:
           appearing in the command string.
         """
         import json as _json
+
+        settings_path = resolve_agent_path(agent_name, agent_dir, settings_path)
+        working_path = resolve_agent_path(agent_name, agent_dir, working_path)
+        idle_path = resolve_agent_path(agent_name, agent_dir, idle_path)
+        verify_effort_path = resolve_agent_path(
+            agent_name,
+            agent_dir,
+            verify_effort_path,
+        )
+        tmux_wake_path = resolve_agent_path(agent_name, agent_dir, tmux_wake_path)
+        tmux_session_start_path = resolve_agent_path(
+            agent_name,
+            agent_dir,
+            tmux_session_start_path,
+        )
+        tmux_pre_tool_path = resolve_agent_path(
+            agent_name,
+            agent_dir,
+            tmux_pre_tool_path,
+        )
+        tmux_post_tool_path = resolve_agent_path(
+            agent_name,
+            agent_dir,
+            tmux_post_tool_path,
+        )
+        tmux_stop_failure_path = resolve_agent_path(
+            agent_name,
+            agent_dir,
+            tmux_stop_failure_path,
+        )
 
         # Quote script paths: a working_dir containing spaces would otherwise
         # make python3 open a nonexistent file, and the trailing
@@ -2531,7 +2667,12 @@ except Exception as exc:
                     ],
                 }
             }
-            settings_path.write_text(_json.dumps(settings, indent=2) + "\n")
+            replace_agent_text(
+                agent_name,
+                agent_dir,
+                settings_path,
+                _json.dumps(settings, indent=2) + "\n",
+            )
             _log(f"agent_registry: created settings.json for {agent_name}")
             return
 
@@ -2609,7 +2750,12 @@ except Exception as exc:
         )
 
         if changed:
-            settings_path.write_text(_json.dumps(data, indent=2) + "\n")
+            replace_agent_text(
+                agent_name,
+                agent_dir,
+                settings_path,
+                _json.dumps(data, indent=2) + "\n",
+            )
             _log(
                 f"agent_registry: merged PinkyBot hooks into settings.json "
                 f"for {agent_name}"
@@ -2656,6 +2802,47 @@ except Exception as exc:
     # ── Agent CRUD ──────────────────────────────────────────
 
     @staticmethod
+    def _markdown_heading_text(line: str, level: int) -> str | None:
+        """Parse one ATX heading in linear time, without regex backtracking."""
+        prefix = "#" * level
+        if not line.startswith(prefix):
+            return None
+        if len(line) == level or not line[level].isspace():
+            return None
+        body = line[level:].lstrip()
+        if not body:
+            return None
+        closing_start = len(body)
+        while closing_start and body[closing_start - 1] == "#":
+            closing_start -= 1
+        if closing_start < len(body) and body[closing_start - 1].isspace():
+            body = body[:closing_start].rstrip()
+        return body or None
+
+    @staticmethod
+    def _has_identity_label(line: str, label: str) -> bool:
+        """Recognize the legacy name/role label prefix in linear time."""
+        starts = [0]
+        if line[:1] in {"-", "*"}:
+            after_bullet = 1
+            while after_bullet < len(line) and line[after_bullet].isspace():
+                after_bullet += 1
+            starts.append(after_bullet)
+        for start in starts:
+            cursor = start
+            if line[cursor : cursor + 2] == "**":
+                cursor += 2
+            end = cursor + len(label)
+            if line[cursor:end].casefold() != label:
+                continue
+            cursor = end
+            while cursor < len(line) and line[cursor].isspace():
+                cursor += 1
+            if cursor < len(line) and line[cursor] == ":":
+                return True
+        return False
+
+    @staticmethod
     def _soul_identity_anchors(
         content: str,
         *,
@@ -2671,22 +2858,15 @@ except Exception as exc:
         }
         for raw_line in content.splitlines():
             line = raw_line.strip()
-            heading = re.fullmatch(r"#\s+(.+?)(?:\s+#+)?", line)
-            if heading and heading.group(1).strip().casefold() in identities:
+            heading = AgentRegistry._markdown_heading_text(line, 1)
+            if heading and heading.casefold() in identities:
                 anchors.add("agent_heading")
-            if re.fullmatch(r"##\s+identity(?:\s+#+)?", line, re.IGNORECASE):
+            identity_heading = AgentRegistry._markdown_heading_text(line, 2)
+            if identity_heading and identity_heading.casefold() == "identity":
                 anchors.add("identity_heading")
-            if re.match(
-                r"^(?:[-*]\s*)?(?:\*\*)?name\s*:(?:\s*\*\*)?",
-                line,
-                re.IGNORECASE,
-            ):
+            if AgentRegistry._has_identity_label(line, "name"):
                 anchors.add("name_label")
-            if re.match(
-                r"^(?:[-*]\s*)?(?:\*\*)?role\s*:(?:\s*\*\*)?",
-                line,
-                re.IGNORECASE,
-            ):
+            if AgentRegistry._has_identity_label(line, "role"):
                 anchors.add("role_label")
         return anchors
 
@@ -2853,8 +3033,10 @@ except Exception as exc:
     ) -> None:
         """Insert first, then initialize only the DB-winning workspace."""
         with self._rmw_lock:
+            insert_won = False
             try:
                 self._db.execute(sql, params)
+                insert_won = True
                 # A losing create-only request must not reinitialize files in
                 # either the winner's workspace or an attacker-chosen path.
                 # Keep the insert transaction open so only the PRIMARY KEY
@@ -2871,10 +3053,77 @@ except Exception as exc:
                 raise
             except Exception:
                 self._db.rollback()
+                if create_only and insert_won:
+                    raise AgentRegistrationIncompleteError(
+                        name,
+                        row_committed=False,
+                    )
                 raise
 
+    @staticmethod
+    def _resolve_workspace_root(name: str, working_dir: str | Path) -> Path:
+        """Return a stable absolute owner root suitable for persistence."""
+        _validate_agent_name(name)
+        try:
+            root = Path(working_dir).resolve()
+        except (OSError, RuntimeError, TypeError, ValueError) as exc:
+            raise AgentWorkspacePathError("agent workspace path is invalid") from exc
+        if not root.is_absolute() or (root.exists() and not root.is_dir()):
+            raise AgentWorkspacePathError("agent workspace path is invalid")
+        return root
+
+    def _refuse_workspace_overlap(self, name: str, root: Path) -> None:
+        """Fail closed when ``root`` intersects another agent's owner root."""
+        _validate_agent_name(name)
+        rows = self._db.execute(
+            "SELECT name, working_dir FROM agents WHERE name<>?",
+            (name,),
+        ).fetchall()
+        for other_name, other_working_dir in rows:
+            try:
+                other_root = self._resolve_workspace_root(
+                    other_name,
+                    other_working_dir,
+                )
+            except (AgentWorkspacePathError, ValueError) as exc:
+                raise AgentWorkspacePathError(
+                    "registered agent workspace path is invalid"
+                ) from exc
+            if (
+                root == other_root
+                or root.is_relative_to(other_root)
+                or other_root.is_relative_to(root)
+            ):
+                raise AgentWorkspaceOverlapError(
+                    "agent workspace overlaps another registered agent"
+                )
+
+    def resolve_registration_workspace(
+        self,
+        name: str,
+        working_dir: str | Path,
+    ) -> Path:
+        """Resolve and preflight a proposed owner root without mutating state."""
+        name = _validate_agent_name(name)
+        with self._rmw_lock:
+            root = self._resolve_workspace_root(name, working_dir)
+            self._refuse_workspace_overlap(name, root)
+            return root
+
     def register(self, name: str, *, create_only: bool = False, **kwargs) -> Agent:
-        """Register an agent, optionally refusing DB-level name collisions."""
+        """Register atomically, including cross-agent workspace ownership."""
+        name = _validate_agent_name(name)
+        with self._rmw_lock:
+            return self._register_locked(name, create_only=create_only, **kwargs)
+
+    def _register_locked(
+        self,
+        name: str,
+        *,
+        create_only: bool = False,
+        **kwargs,
+    ) -> Agent:
+        """Register while ``_rmw_lock`` protects root checks and mutation."""
         # Sanitize before any path is constructed downstream. Same regex as
         # the API model — duplicated here so in-process callers (tests,
         # scripts, future routes) can't bypass it. ``_validate_agent_name``
@@ -2893,8 +3142,8 @@ except Exception as exc:
             # API. AgentRegistry.update() is intentionally path-free.
             updated_working_dir = ""
             if kwargs.get("working_dir"):
-                upd_dir = Path(kwargs["working_dir"])
-                upd_dir_abs = upd_dir if upd_dir.is_absolute() else upd_dir.resolve()
+                upd_dir_abs = self._resolve_workspace_root(name, kwargs["working_dir"])
+                self._refuse_workspace_overlap(name, upd_dir_abs)
                 if str(upd_dir_abs) != existing.working_dir:
                     self._init_workspace(upd_dir_abs, agent_name=name)
                 updated_working_dir = str(upd_dir_abs)
@@ -2921,8 +3170,8 @@ except Exception as exc:
             # Set up workspace — always store absolute path for portability.
             # Relative paths break when daemon CWD differs from install dir.
             raw_dir = kwargs.get("working_dir", "") or f"data/agents/{name}"
-            work_dir = Path(raw_dir)
-            work_dir_abs = work_dir if work_dir.is_absolute() else work_dir.resolve()
+            work_dir_abs = self._resolve_workspace_root(name, raw_dir)
+            self._refuse_workspace_overlap(name, work_dir_abs)
             agent = Agent(
                 name=name,
                 display_name=kwargs.get("display_name", ""),
@@ -2976,8 +3225,10 @@ except Exception as exc:
                 created_at=now,
                 updated_at=now,
             )
-            self._insert_agent_row(
-                """INSERT OR ABORT INTO agents
+            insert_complete = False
+            try:
+                self._insert_agent_row(
+                    """INSERT OR ABORT INTO agents
                    (name, display_name, model, soul, users, boundaries,
                     system_prompt, working_dir,
                     permission_mode, allowed_tools, disallowed_tools, max_turns, timeout,
@@ -2993,7 +3244,7 @@ except Exception as exc:
                     watchdog_config,
                     created_at, updated_at)
                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
-                (agent.name, agent.display_name, agent.model, agent.soul,
+                    (agent.name, agent.display_name, agent.model, agent.soul,
                  agent.users, agent.boundaries,
                  agent.system_prompt, agent.working_dir, agent.permission_mode,
                  json.dumps(agent.allowed_tools), json.dumps(agent.disallowed_tools),
@@ -3013,31 +3264,41 @@ except Exception as exc:
                  agent.thinking_effort, int(agent.strict_effort_enforcement),
                  int(agent.dedicated_config_dir),
                  json.dumps(agent.watchdog_config),
-                 agent.created_at, agent.updated_at),
-                name=name,
-                create_only=create_only,
-                work_dir=work_dir_abs,
-            )
-            _log(f"agents: registered {name}")
+                     agent.created_at, agent.updated_at),
+                    name=name,
+                    create_only=create_only,
+                    work_dir=work_dir_abs,
+                )
+                insert_complete = True
+                _log(f"agents: registered {name}")
 
-            # First-run convenience: if no main agent is designated yet, adopt
-            # this newly created agent. Without a main agent the daemon starts
-            # no autonomy loop and the agent never auto-wakes — a silent
-            # dead-end for fresh installs. Only fires on creation of an enabled
-            # agent when main is unset, so it never overrides an existing choice.
-            if agent.enabled and not self.get_setting("main_agent"):
-                self.set_setting("main_agent", name)
-                _log(f"agents: auto-assigned main_agent={name} (first agent)")
+                # First-run convenience: if no main agent is designated yet, adopt
+                # this newly created agent. Without a main agent the daemon starts
+                # no autonomy loop and the agent never auto-wakes — a silent
+                # dead-end for fresh installs. Only fires on creation of an enabled
+                # agent when main is unset, so it never overrides an existing choice.
+                if agent.enabled and not self.get_setting("main_agent"):
+                    self.set_setting("main_agent", name)
+                    _log(f"agents: auto-assigned main_agent={name} (first agent)")
 
-        # Ensure the agent has a per-agent signing key (#623). Idempotent —
-        # returns the existing key on re-registration / update.
-        self.get_or_create_signing_key(name)
-        # Fresh databases initialize before any agents exist. Retry the
-        # caller-specified bootstrap after registration so the seed ships for
-        # both upgrades and new installs without weakening the unique key.
-        self._seed_verified_contacts()
+                # Ensure the agent has a per-agent signing key (#623). Idempotent —
+                # returns the existing key on re-registration / update.
+                self.get_or_create_signing_key(name)
+                # Fresh databases initialize before any agents exist. Retry the
+                # caller-specified bootstrap after registration so the seed ships for
+                # both upgrades and new installs without weakening the unique key.
+                self._seed_verified_contacts()
+            except (AgentAlreadyExistsError, AgentRegistrationIncompleteError):
+                raise
+            except Exception as exc:
+                if create_only and insert_complete:
+                    raise AgentRegistrationIncompleteError(
+                        name,
+                        row_committed=True,
+                    ) from exc
+                raise
 
-        return self.get(name)  # type: ignore
+            return self.get(name)  # type: ignore
 
     _AGENT_COLUMNS = (
         "name, display_name, model, soul, system_prompt, working_dir, "
@@ -4324,6 +4585,7 @@ except Exception as exc:
         source: str,
     ) -> int:
         """Insert one version row; the caller owns commit/rollback."""
+        agent_name = _validate_agent_name(agent_name)
         cursor = self._db.execute(
             "INSERT INTO soul_versions (agent_name, content, source, created_at) "
             "VALUES (?, ?, ?, ?)",
@@ -4339,6 +4601,7 @@ except Exception as exc:
         source: str,
     ) -> int:
         """Durably snapshot replaced content before a non-DB mutation."""
+        agent_name = _validate_agent_name(agent_name)
         with self._rmw_lock:
             try:
                 version_id = self._insert_soul_version_uncommitted(
@@ -4357,6 +4620,7 @@ except Exception as exc:
 
         Sources: 'ui', 'agent', 'spawn', 'refresh', 'api'
         """
+        agent_name = _validate_agent_name(agent_name)
         with self._rmw_lock:
             try:
                 # Spawn publication records the installed content after writing.
@@ -4382,6 +4646,7 @@ except Exception as exc:
 
     def get_soul_versions(self, agent_name: str, limit: int = 20) -> list[dict]:
         """List soul versions for an agent, newest first."""
+        agent_name = _validate_agent_name(agent_name)
         rows = self._db.execute(
             "SELECT id, agent_name, source, created_at, LENGTH(content) as size FROM soul_versions WHERE agent_name=? ORDER BY created_at DESC LIMIT ?",
             (agent_name, limit),
@@ -4393,6 +4658,7 @@ except Exception as exc:
 
     def get_soul_version(self, agent_name: str, version_id: int) -> dict | None:
         """Get a specific soul version by ID."""
+        agent_name = _validate_agent_name(agent_name)
         row = self._db.execute(
             "SELECT id, agent_name, content, source, created_at FROM soul_versions WHERE agent_name=? AND id=?",
             (agent_name, version_id),

--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -1430,6 +1430,7 @@ class AgentRegistry:
                 groups TEXT NOT NULL DEFAULT '[]',
                 max_sessions INTEGER NOT NULL DEFAULT 5,
                 enabled INTEGER NOT NULL DEFAULT 1,
+                registration_finalized INTEGER NOT NULL DEFAULT 1,
                 auto_start INTEGER NOT NULL DEFAULT 0,
                 heartbeat_interval INTEGER NOT NULL DEFAULT 0,
                 plain_text_fallback INTEGER NOT NULL DEFAULT 0,
@@ -1866,6 +1867,11 @@ class AgentRegistry:
         }
         migrations = [
             ("auto_start", "INTEGER NOT NULL DEFAULT 0"),
+            # HTTP create-only registration commits its ownership claim before
+            # fallible provisioning/MCP publication. Pre-upgrade rows are all
+            # completed registrations; new claim rows override this default to
+            # 0 until finalize_registration() publishes bootstrap state.
+            ("registration_finalized", "INTEGER NOT NULL DEFAULT 1"),
             ("heartbeat_interval", "INTEGER NOT NULL DEFAULT 0"),
             # Off by default — must match the dataclass + CREATE TABLE default (0).
             # A DEFAULT 1 here silently backfilled every pre-existing agent with
@@ -2172,12 +2178,15 @@ class AgentRegistry:
         # Seed default models
         self._seed_models()
 
-    def _seed_verified_contacts(self) -> None:
-        """Install caller-specified verified contacts when their agent exists."""
+    def _seed_verified_contacts(self, *, _commit: bool = True) -> None:
+        """Install caller-specified contacts for a finalized registration."""
         marker = "migration:verified_contacts_brad_owner_seed_v1"
         if self.get_setting(marker) == "1":
             return
-        if self._db.execute("SELECT 1 FROM agents WHERE name='barsik'").fetchone() is None:
+        if self._db.execute(
+            "SELECT 1 FROM agents "
+            "WHERE name='barsik' AND registration_finalized=1"
+        ).fetchone() is None:
             return
         try:
             cursor = self._db.execute(
@@ -2197,20 +2206,32 @@ class AgentRegistry:
                    ON CONFLICT(key) DO UPDATE SET value='1'""",
                 (marker,),
             )
-            self._db.commit()
+            if _commit:
+                self._db.commit()
         except Exception:
-            self._db.rollback()
+            if _commit:
+                self._db.rollback()
             raise
         if cursor.rowcount:
             _log("agent_registry: seeded barsik Buzz owner verified contact")
 
     def finalize_registration(self, name: str) -> None:
-        """Publish bootstrap state only after every external registration stage."""
+        """Atomically finalize registration and publish its bootstrap state."""
         name = _validate_agent_name(name)
         with self._rmw_lock:
-            if not self.get(name):
-                raise KeyError(f"Agent '{name}' not found")
-            self._seed_verified_contacts()
+            try:
+                self._db.execute("BEGIN IMMEDIATE")
+                cursor = self._db.execute(
+                    "UPDATE agents SET registration_finalized=1 WHERE name=?",
+                    (name,),
+                )
+                if cursor.rowcount == 0:
+                    raise KeyError(f"Agent '{name}' not found")
+                self._seed_verified_contacts(_commit=False)
+                self._db.commit()
+            except Exception:
+                self._db.rollback()
+                raise
 
     def _backfill_runtime_from_provider_url(self) -> None:
         """One-shot migration from legacy provider_url runtime selection."""
@@ -3302,7 +3323,8 @@ except Exception as exc:
                     system_prompt, working_dir,
                     permission_mode, allowed_tools, disallowed_tools, max_turns, timeout,
                     restart_threshold_pct, context_nudge_threshold_pct, auto_restart, parent, groups,
-                    max_sessions, enabled, auto_start, heartbeat_interval, plain_text_fallback,
+                    max_sessions, enabled, registration_finalized, auto_start,
+                    heartbeat_interval, plain_text_fallback,
                     wake_interval, clock_aligned, auto_sleep_hours, voice_config, role, isolated,
                     isolation_mode, container_image,
                     dream_enabled, dream_schedule, dream_timezone, dream_model, dream_notify,
@@ -3312,7 +3334,7 @@ except Exception as exc:
                     thinking_effort, strict_effort_enforcement, dedicated_config_dir,
                     watchdog_config,
                     created_at, updated_at)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                     (agent.name, agent.display_name, agent.model, agent.soul,
                  agent.users, agent.boundaries,
                  agent.system_prompt, agent.working_dir, agent.permission_mode,
@@ -3321,7 +3343,8 @@ except Exception as exc:
                  agent.restart_threshold_pct, agent.context_nudge_threshold_pct,
                  int(agent.auto_restart),
                  agent.parent, json.dumps(agent.groups), agent.max_sessions,
-                 int(agent.enabled), int(agent.auto_start), agent.heartbeat_interval, int(agent.plain_text_fallback),
+                 int(agent.enabled), int(not create_only), int(agent.auto_start),
+                 agent.heartbeat_interval, int(agent.plain_text_fallback),
                  agent.wake_interval, int(agent.clock_aligned), agent.auto_sleep_hours,
                  json.dumps(agent.voice_config), agent.role, int(agent.isolated),
                  agent.isolation_mode, agent.container_image,

--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -770,6 +770,36 @@ class ScheduleNameConflictError(ValueError):
     """An enabled schedule already uses the requested agent/name pair."""
 
 
+class AgentAlreadyExistsError(ValueError):
+    """A create-only registration collided with an existing agent name."""
+
+
+@dataclass(frozen=True)
+class SoulMutationSummary:
+    """Content-free evidence explaining why a soul replacement is risky."""
+
+    old_length: int
+    new_length: int
+    shrink_percent: float
+    missing_anchors: tuple[str, ...]
+
+    def to_dict(self) -> dict:
+        return {
+            "old_length": self.old_length,
+            "new_length": self.new_length,
+            "shrink_percent": self.shrink_percent,
+            "missing_anchors": list(self.missing_anchors),
+        }
+
+
+class SoulMutationRejectedError(ValueError):
+    """A soul replacement needs an explicit force flag before it may run."""
+
+    def __init__(self, summary: SoulMutationSummary) -> None:
+        super().__init__("soul mutation rejected by shrink/identity guard")
+        self.summary = summary
+
+
 @dataclass
 class AgentHeartbeat:
     """A heartbeat record for an agent."""
@@ -2625,6 +2655,98 @@ except Exception as exc:
 
     # ── Agent CRUD ──────────────────────────────────────────
 
+    @staticmethod
+    def _soul_identity_anchors(
+        content: str,
+        *,
+        agent_name: str,
+        display_name: str = "",
+    ) -> set[str]:
+        """Return recognized identity structure without retaining its text."""
+        anchors: set[str] = set()
+        identities = {
+            value.strip().casefold()
+            for value in (agent_name, display_name)
+            if value and value.strip()
+        }
+        for raw_line in content.splitlines():
+            line = raw_line.strip()
+            heading = re.fullmatch(r"#\s+(.+?)(?:\s+#+)?", line)
+            if heading and heading.group(1).strip().casefold() in identities:
+                anchors.add("agent_heading")
+            if re.fullmatch(r"##\s+identity(?:\s+#+)?", line, re.IGNORECASE):
+                anchors.add("identity_heading")
+            if re.match(
+                r"^(?:[-*]\s*)?(?:\*\*)?name\s*:(?:\s*\*\*)?",
+                line,
+                re.IGNORECASE,
+            ):
+                anchors.add("name_label")
+            if re.match(
+                r"^(?:[-*]\s*)?(?:\*\*)?role\s*:(?:\s*\*\*)?",
+                line,
+                re.IGNORECASE,
+            ):
+                anchors.add("role_label")
+        return anchors
+
+    def assess_soul_mutation(
+        self,
+        name: str,
+        old_content: str,
+        new_content: str,
+        *,
+        display_name: str = "",
+    ) -> SoulMutationSummary:
+        """Describe a proposed soul replacement without exposing soul text."""
+        name = _validate_agent_name(name)
+        if not isinstance(old_content, str) or not isinstance(new_content, str):
+            raise TypeError("soul content must be text")
+        old_length = len(old_content)
+        new_length = len(new_content)
+        shrink_percent = (
+            round(max(0.0, (old_length - new_length) * 100.0 / old_length), 2)
+            if old_length
+            else 0.0
+        )
+        old_anchors = self._soul_identity_anchors(
+            old_content,
+            agent_name=name,
+            display_name=display_name,
+        )
+        new_anchors = self._soul_identity_anchors(
+            new_content,
+            agent_name=name,
+            display_name=display_name,
+        )
+        return SoulMutationSummary(
+            old_length=old_length,
+            new_length=new_length,
+            shrink_percent=shrink_percent,
+            missing_anchors=tuple(sorted(old_anchors - new_anchors)),
+        )
+
+    def guard_soul_mutation(
+        self,
+        name: str,
+        old_content: str,
+        new_content: str,
+        *,
+        display_name: str = "",
+        force_soul: bool = False,
+    ) -> SoulMutationSummary:
+        """Reject destructive soul replacement unless explicitly forced."""
+        summary = self.assess_soul_mutation(
+            name,
+            old_content,
+            new_content,
+            display_name=display_name,
+        )
+        shrinks_more_than_half = summary.new_length * 2 < summary.old_length
+        if not force_soul and (shrinks_more_than_half or summary.missing_anchors):
+            raise SoulMutationRejectedError(summary)
+        return summary
+
     def update(self, name: str, **kwargs) -> Agent:
         """Partially update an existing agent without creating one.
 
@@ -2634,69 +2756,125 @@ except Exception as exc:
         agent or reset fields omitted from a PATCH-like request.
         """
         name = _validate_agent_name(name)
-        existing = self.get(name)
-        if not existing:
-            raise KeyError(f"Agent '{name}' not found")
-        if "working_dir" in kwargs:
-            raise ValueError(
-                "working_dir is not supported by partial update; use register()"
-            )
+        force_soul = bool(kwargs.pop("force_soul", False))
+        soul_source = str(kwargs.pop("soul_source", "registry-update") or "registry-update")
+        with self._rmw_lock:
+            existing = self.get(name)
+            if not existing:
+                raise KeyError(f"Agent '{name}' not found")
+            if "working_dir" in kwargs:
+                raise ValueError(
+                    "working_dir is not supported by partial update; use register()"
+                )
 
-        updates = {}
-        for key in ("display_name", "model", "soul", "users", "boundaries",
-                    "system_prompt",
-                    "permission_mode", "max_turns", "timeout", "restart_threshold_pct",
-                    "context_nudge_threshold_pct",
-                    "auto_restart", "parent", "max_sessions", "enabled",
-                    "auto_start", "heartbeat_interval", "wake_interval",
-                    "clock_aligned", "auto_sleep_hours", "plain_text_fallback", "voice_config", "role",
-                    "dream_enabled", "dream_schedule", "dream_timezone", "dream_model", "dream_notify",
-                    "librarian_enabled", "librarian_schedule",
-                    "runtime", "transport", "provider_url", "provider_model", "provider_ref",
-                    "codex_home",
-                    "thinking_effort", "strict_effort_enforcement",
-                    "dedicated_config_dir", "isolated",
-                    "isolation_mode", "container_image"):
-            if key in kwargs:
-                updates[key] = kwargs[key]
+            updates = {}
+            for key in ("display_name", "model", "soul", "users", "boundaries",
+                        "system_prompt",
+                        "permission_mode", "max_turns", "timeout", "restart_threshold_pct",
+                        "context_nudge_threshold_pct",
+                        "auto_restart", "parent", "max_sessions", "enabled",
+                        "auto_start", "heartbeat_interval", "wake_interval",
+                        "clock_aligned", "auto_sleep_hours", "plain_text_fallback", "voice_config", "role",
+                        "dream_enabled", "dream_schedule", "dream_timezone", "dream_model", "dream_notify",
+                        "librarian_enabled", "librarian_schedule",
+                        "runtime", "transport", "provider_url", "provider_model", "provider_ref",
+                        "codex_home",
+                        "thinking_effort", "strict_effort_enforcement",
+                        "dedicated_config_dir", "isolated",
+                        "isolation_mode", "container_image"):
+                if key in kwargs:
+                    updates[key] = kwargs[key]
 
-        # Secret: empty/absent means "unchanged" so callers round-tripping
-        # the redacted to_dict() (provider_key_set) can't wipe the key.
-        # Wiping requires the explicit clear_provider_key flag.
-        if kwargs.get("provider_key"):
-            updates["provider_key"] = kwargs["provider_key"]
-        elif kwargs.get("clear_provider_key"):
-            updates["provider_key"] = ""
+            # Secret: empty/absent means "unchanged" so callers round-tripping
+            # the redacted to_dict() (provider_key_set) can't wipe the key.
+            # Wiping requires the explicit clear_provider_key flag.
+            if kwargs.get("provider_key"):
+                updates["provider_key"] = kwargs["provider_key"]
+            elif kwargs.get("clear_provider_key"):
+                updates["provider_key"] = ""
 
-        for key in ("watchdog_config", "allowed_tools", "disallowed_tools", "groups"):
-            if key in kwargs:
-                updates[key] = json.dumps(kwargs[key])
+            for key in ("watchdog_config", "allowed_tools", "disallowed_tools", "groups"):
+                if key in kwargs:
+                    updates[key] = json.dumps(kwargs[key])
 
-        for key in ("auto_restart", "enabled", "auto_start", "clock_aligned",
-                    "plain_text_fallback", "dream_enabled", "dream_notify",
-                    "librarian_enabled", "strict_effort_enforcement",
-                    "dedicated_config_dir", "isolated"):
-            if key in updates:
-                updates[key] = int(updates[key])
-        if "voice_config" in updates and isinstance(updates["voice_config"], dict):
-            updates["voice_config"] = json.dumps(updates["voice_config"])
+            for key in ("auto_restart", "enabled", "auto_start", "clock_aligned",
+                        "plain_text_fallback", "dream_enabled", "dream_notify",
+                        "librarian_enabled", "strict_effort_enforcement",
+                        "dedicated_config_dir", "isolated"):
+                if key in updates:
+                    updates[key] = int(updates[key])
+            if "voice_config" in updates and isinstance(updates["voice_config"], dict):
+                updates["voice_config"] = json.dumps(updates["voice_config"])
 
-        if updates:
-            updates["updated_at"] = time.time()
-            set_clause = ", ".join(f"{key}=?" for key in updates)
-            self._db.execute(
-                f"UPDATE agents SET {set_clause} WHERE name=?",
-                list(updates.values()) + [name],
-            )
-            self._db.commit()
+            soul_changed = "soul" in updates and updates["soul"] != existing.soul
+            if "soul" in updates and not soul_changed:
+                updates.pop("soul")
+            if soul_changed:
+                self.guard_soul_mutation(
+                    name,
+                    existing.soul,
+                    updates["soul"],
+                    display_name=existing.display_name,
+                    force_soul=force_soul,
+                )
+
+            if updates:
+                updates["updated_at"] = time.time()
+                set_clause = ", ".join(f"{key}=?" for key in updates)
+                try:
+                    if soul_changed:
+                        self._insert_soul_version_uncommitted(
+                            name,
+                            existing.soul,
+                            source=f"{soul_source}:before",
+                        )
+                    self._db.execute(
+                        f"UPDATE agents SET {set_clause} WHERE name=?",
+                        list(updates.values()) + [name],
+                    )
+                    self._db.commit()
+                except Exception:
+                    self._db.rollback()
+                    raise
 
         updated = self.get(name)
         if not updated:  # Defensive against a concurrent delete.
             raise KeyError(f"Agent '{name}' not found")
         return updated
 
-    def register(self, name: str, **kwargs) -> Agent:
-        """Register a new agent or update an existing one."""
+    def _insert_agent_row(
+        self,
+        sql: str,
+        params: tuple,
+        *,
+        name: str,
+        create_only: bool,
+        work_dir: Path,
+    ) -> None:
+        """Insert first, then initialize only the DB-winning workspace."""
+        with self._rmw_lock:
+            try:
+                self._db.execute(sql, params)
+                # A losing create-only request must not reinitialize files in
+                # either the winner's workspace or an attacker-chosen path.
+                # Keep the insert transaction open so only the PRIMARY KEY
+                # winner reaches filesystem setup; rollback the row if setup
+                # itself fails.
+                self._init_workspace(work_dir, agent_name=name)
+                self._db.commit()
+            except sqlite3.IntegrityError as exc:
+                self._db.rollback()
+                if create_only and "agents.name" in str(exc):
+                    raise AgentAlreadyExistsError(
+                        f"Agent '{name}' already exists"
+                    ) from exc
+                raise
+            except Exception:
+                self._db.rollback()
+                raise
+
+    def register(self, name: str, *, create_only: bool = False, **kwargs) -> Agent:
+        """Register an agent, optionally refusing DB-level name collisions."""
         # Sanitize before any path is constructed downstream. Same regex as
         # the API model — duplicated here so in-process callers (tests,
         # scripts, future routes) can't bypass it. ``_validate_agent_name``
@@ -2704,7 +2882,10 @@ except Exception as exc:
         # source-of-path-construction.
         name = _validate_agent_name(name)
         now = time.time()
-        existing = self.get(name)
+        # A create-only caller must reach INSERT OR ABORT without a read-side
+        # availability decision. The agents.name PRIMARY KEY is authoritative,
+        # including when multiple daemon processes race on the same DB.
+        existing = None if create_only else self.get(name)
 
         if existing:
             # Keep the legacy workspace mutation on register(), whose admin
@@ -2742,7 +2923,6 @@ except Exception as exc:
             raw_dir = kwargs.get("working_dir", "") or f"data/agents/{name}"
             work_dir = Path(raw_dir)
             work_dir_abs = work_dir if work_dir.is_absolute() else work_dir.resolve()
-            self._init_workspace(work_dir_abs, agent_name=name)
             agent = Agent(
                 name=name,
                 display_name=kwargs.get("display_name", ""),
@@ -2796,8 +2976,8 @@ except Exception as exc:
                 created_at=now,
                 updated_at=now,
             )
-            self._db.execute(
-                """INSERT INTO agents
+            self._insert_agent_row(
+                """INSERT OR ABORT INTO agents
                    (name, display_name, model, soul, users, boundaries,
                     system_prompt, working_dir,
                     permission_mode, allowed_tools, disallowed_tools, max_turns, timeout,
@@ -2834,8 +3014,10 @@ except Exception as exc:
                  int(agent.dedicated_config_dir),
                  json.dumps(agent.watchdog_config),
                  agent.created_at, agent.updated_at),
+                name=name,
+                create_only=create_only,
+                work_dir=work_dir_abs,
             )
-            self._db.commit()
             _log(f"agents: registered {name}")
 
             # First-run convenience: if no main agent is designated yet, adopt
@@ -4134,25 +4316,69 @@ except Exception as exc:
 
     # ── Soul Versioning ─────────────────────────────────────
 
+    def _insert_soul_version_uncommitted(
+        self,
+        agent_name: str,
+        content: str,
+        *,
+        source: str,
+    ) -> int:
+        """Insert one version row; the caller owns commit/rollback."""
+        cursor = self._db.execute(
+            "INSERT INTO soul_versions (agent_name, content, source, created_at) "
+            "VALUES (?, ?, ?, ?)",
+            (agent_name, content, source, time.time()),
+        )
+        return int(cursor.lastrowid)
+
+    def snapshot_soul_before_mutation(
+        self,
+        agent_name: str,
+        content: str,
+        *,
+        source: str,
+    ) -> int:
+        """Durably snapshot replaced content before a non-DB mutation."""
+        with self._rmw_lock:
+            try:
+                version_id = self._insert_soul_version_uncommitted(
+                    agent_name,
+                    content,
+                    source=source,
+                )
+                self._db.commit()
+            except Exception:
+                self._db.rollback()
+                raise
+        return version_id
+
     def save_soul_version(self, agent_name: str, content: str, source: str = "unknown") -> int:
         """Archive a soul version. Returns the version ID.
 
         Sources: 'ui', 'agent', 'spawn', 'refresh', 'api'
         """
-        # Skip if content matches the latest version
-        latest = self.get_soul_versions(agent_name, limit=1)
-        if latest:
-            full = self.get_soul_version(agent_name, latest[0]["id"])
-            if full and full["content"] == content:
-                return latest[0]["id"]
+        with self._rmw_lock:
+            try:
+                # Spawn publication records the installed content after writing.
+                # Keep that historical deduplication contract; mutation snapshots
+                # use _insert_soul_version_uncommitted so every actual replacement
+                # gets an audit row even when the same content appeared previously.
+                latest = self.get_soul_versions(agent_name, limit=1)
+                if latest:
+                    full = self.get_soul_version(agent_name, latest[0]["id"])
+                    if full and full["content"] == content:
+                        return latest[0]["id"]
 
-        now = time.time()
-        cursor = self._db.execute(
-            "INSERT INTO soul_versions (agent_name, content, source, created_at) VALUES (?, ?, ?, ?)",
-            (agent_name, content, source, now),
-        )
-        self._db.commit()
-        return cursor.lastrowid
+                version_id = self._insert_soul_version_uncommitted(
+                    agent_name,
+                    content,
+                    source=source,
+                )
+                self._db.commit()
+                return version_id
+            except Exception:
+                self._db.rollback()
+                raise
 
     def get_soul_versions(self, agent_name: str, limit: int = 20) -> list[dict]:
         """List soul versions for an agent, newest first."""

--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -1938,6 +1938,13 @@ class AgentRegistry:
             if col not in existing:
                 self._db.execute(f"ALTER TABLE agents ADD COLUMN {col} {typedef}")
                 _log(f"agent_registry: migrated — added column {col}")
+        # Structural belt for the exact persisted-root case. Legacy placeholder
+        # values are excluded; resolved aliases and nested/enclosing roots still
+        # require the BEGIN IMMEDIATE overlap check in register().
+        self._db.execute(
+            "CREATE UNIQUE INDEX IF NOT EXISTS idx_agents_working_dir_owner_exact "
+            "ON agents(working_dir) WHERE working_dir NOT IN ('', '.')"
+        )
         self._db.commit()
         self._backfill_runtime_from_provider_url()
         self._warn_codex_runtime_mismatches()
@@ -2172,26 +2179,38 @@ class AgentRegistry:
             return
         if self._db.execute("SELECT 1 FROM agents WHERE name='barsik'").fetchone() is None:
             return
-        cursor = self._db.execute(
-            """INSERT INTO verified_contacts
-               (agent_name, platform, principal, name, role, added_at)
-               VALUES ('barsik', 'buzz', ?, 'Brad', 'owner', ?)
-               ON CONFLICT(agent_name, platform, principal) DO UPDATE SET
-                 name='Brad', role='owner'""",
-            (
-                "buzz:posspecialists:"
-                "90425c785cf23b60e57300658a7f4855938b3c2f661b3ef33acdb54831fcb44b",
-                time.time(),
-            ),
-        )
-        self._db.execute(
-            """INSERT INTO system_settings (key, value) VALUES (?, '1')
-               ON CONFLICT(key) DO UPDATE SET value='1'""",
-            (marker,),
-        )
-        self._db.commit()
+        try:
+            cursor = self._db.execute(
+                """INSERT INTO verified_contacts
+                   (agent_name, platform, principal, name, role, added_at)
+                   VALUES ('barsik', 'buzz', ?, 'Brad', 'owner', ?)
+                   ON CONFLICT(agent_name, platform, principal) DO UPDATE SET
+                     name='Brad', role='owner'""",
+                (
+                    "buzz:posspecialists:"
+                    "90425c785cf23b60e57300658a7f4855938b3c2f661b3ef33acdb54831fcb44b",
+                    time.time(),
+                ),
+            )
+            self._db.execute(
+                """INSERT INTO system_settings (key, value) VALUES (?, '1')
+                   ON CONFLICT(key) DO UPDATE SET value='1'""",
+                (marker,),
+            )
+            self._db.commit()
+        except Exception:
+            self._db.rollback()
+            raise
         if cursor.rowcount:
             _log("agent_registry: seeded barsik Buzz owner verified contact")
+
+    def finalize_registration(self, name: str) -> None:
+        """Publish bootstrap state only after every external registration stage."""
+        name = _validate_agent_name(name)
+        with self._rmw_lock:
+            if not self.get(name):
+                raise KeyError(f"Agent '{name}' not found")
+            self._seed_verified_contacts()
 
     def _backfill_runtime_from_provider_url(self) -> None:
         """One-shot migration from legacy provider_url runtime selection."""
@@ -2927,7 +2946,7 @@ except Exception as exc:
             raise SoulMutationRejectedError(summary)
         return summary
 
-    def update(self, name: str, **kwargs) -> Agent:
+    def update(self, name: str, *, _commit: bool = True, **kwargs) -> Agent:
         """Partially update an existing agent without creating one.
 
         Only explicitly supplied, allowlisted fields are changed.  This is
@@ -3012,9 +3031,11 @@ except Exception as exc:
                         f"UPDATE agents SET {set_clause} WHERE name=?",
                         list(updates.values()) + [name],
                     )
-                    self._db.commit()
+                    if _commit:
+                        self._db.commit()
                 except Exception:
-                    self._db.rollback()
+                    if _commit:
+                        self._db.rollback()
                     raise
 
         updated = self.get(name)
@@ -3031,10 +3052,18 @@ except Exception as exc:
         create_only: bool,
         work_dir: Path,
     ) -> None:
-        """Insert first, then initialize only the DB-winning workspace."""
+        """Atomically claim an owner root, insert, and initialize the winner."""
         with self._rmw_lock:
             insert_won = False
             try:
+                # The advisory preflight in register() is intentionally repeated
+                # under SQLite's cross-connection writer lock. Different names do
+                # not contend on the agents.name PRIMARY KEY, so BEGIN IMMEDIATE is
+                # the authority that serializes overlap-check + INSERT across
+                # daemon processes. The second writer observes the first commit
+                # before it can evaluate owner-root equality or nesting.
+                self._db.execute("BEGIN IMMEDIATE")
+                self._refuse_workspace_overlap(name, work_dir)
                 self._db.execute(sql, params)
                 insert_won = True
                 # A losing create-only request must not reinitialize files in
@@ -3046,10 +3075,22 @@ except Exception as exc:
                 self._db.commit()
             except sqlite3.IntegrityError as exc:
                 self._db.rollback()
-                if create_only and "agents.name" in str(exc):
-                    raise AgentAlreadyExistsError(
-                        f"Agent '{name}' already exists"
-                    ) from exc
+                if create_only:
+                    # The exact-root belt may be evaluated before the name
+                    # PRIMARY KEY when a same-name loser also reuses the
+                    # winner's root. Classify from committed DB state after
+                    # rollback instead of depending on SQLite's index order.
+                    if self._db.execute(
+                        "SELECT 1 FROM agents WHERE name=?",
+                        (name,),
+                    ).fetchone():
+                        raise AgentAlreadyExistsError(
+                            f"Agent '{name}' already exists"
+                        ) from exc
+                    if "agents.working_dir" in str(exc):
+                        raise AgentWorkspaceOverlapError(
+                            "agent workspace overlaps another registered agent"
+                        ) from exc
                 raise
             except Exception:
                 self._db.rollback()
@@ -3059,6 +3100,45 @@ except Exception as exc:
                         row_committed=False,
                     )
                 raise
+
+    def _update_existing_registration(
+        self,
+        name: str,
+        *,
+        working_dir: str | Path,
+        update_kwargs: dict,
+    ) -> Agent:
+        """Serialize a legacy register-update workspace claim across connections."""
+        root = self._resolve_workspace_root(name, working_dir)
+        # Preserve the early, side-effect-free refusal while making the repeated
+        # check inside BEGIN IMMEDIATE authoritative for concurrent writers.
+        self._refuse_workspace_overlap(name, root)
+        try:
+            self._db.execute("BEGIN IMMEDIATE")
+            existing = self.get(name)
+            if not existing:
+                raise KeyError(f"Agent '{name}' not found")
+            self._refuse_workspace_overlap(name, root)
+            if str(root) != existing.working_dir:
+                self._init_workspace(root, agent_name=name)
+
+            # update() owns soul-guard and snapshot semantics. Suppress its
+            # commit so those field mutations and the owner-root claim land in
+            # the same transaction, or all roll back on overlap/guard failure.
+            self.update(name, _commit=False, **update_kwargs)
+            self._db.execute(
+                "UPDATE agents SET working_dir=?, updated_at=? WHERE name=?",
+                (str(root), time.time(), name),
+            )
+            self._db.commit()
+        except Exception:
+            self._db.rollback()
+            raise
+
+        refreshed = self.get(name)
+        if not refreshed:  # Defensive against a concurrent delete.
+            raise KeyError(f"Agent '{name}' not found")
+        return refreshed
 
     @staticmethod
     def _resolve_workspace_root(name: str, working_dir: str | Path) -> Path:
@@ -3140,27 +3220,16 @@ except Exception as exc:
             # Keep the legacy workspace mutation on register(), whose admin
             # callers and path-handling contract predate the partial update
             # API. AgentRegistry.update() is intentionally path-free.
-            updated_working_dir = ""
-            if kwargs.get("working_dir"):
-                upd_dir_abs = self._resolve_workspace_root(name, kwargs["working_dir"])
-                self._refuse_workspace_overlap(name, upd_dir_abs)
-                if str(upd_dir_abs) != existing.working_dir:
-                    self._init_workspace(upd_dir_abs, agent_name=name)
-                updated_working_dir = str(upd_dir_abs)
-
             update_kwargs = dict(kwargs)
             update_kwargs.pop("working_dir", None)
-            updated = self.update(name, **update_kwargs)
-            if updated_working_dir:
-                self._db.execute(
-                    "UPDATE agents SET working_dir=?, updated_at=? WHERE name=?",
-                    (updated_working_dir, time.time(), name),
+            if kwargs.get("working_dir"):
+                updated = self._update_existing_registration(
+                    name,
+                    working_dir=kwargs["working_dir"],
+                    update_kwargs=update_kwargs,
                 )
-                self._db.commit()
-                refreshed = self.get(name)
-                if not refreshed:  # Defensive against a concurrent delete.
-                    raise KeyError(f"Agent '{name}' not found")
-                updated = refreshed
+            else:
+                updated = self.update(name, **update_kwargs)
             # Preserve register()'s historical signing-key backfill contract
             # for legacy rows even though the field mutation is delegated.
             self.get_or_create_signing_key(name)
@@ -3284,10 +3353,14 @@ except Exception as exc:
                 # Ensure the agent has a per-agent signing key (#623). Idempotent —
                 # returns the existing key on re-registration / update.
                 self.get_or_create_signing_key(name)
-                # Fresh databases initialize before any agents exist. Retry the
-                # caller-specified bootstrap after registration so the seed ships for
-                # both upgrades and new installs without weakening the unique key.
-                self._seed_verified_contacts()
+                # The HTTP create-only path has fallible provisioning and MCP
+                # publication stages after this registry commit. Defer its
+                # verified-contact bootstrap to finalize_registration() so a
+                # failed POST cannot leave the contact or migration marker.
+                # Direct legacy registrations have no later external stages and
+                # retain their historical bootstrap behavior.
+                if not create_only:
+                    self._seed_verified_contacts()
             except (AgentAlreadyExistsError, AgentRegistrationIncompleteError):
                 raise
             except Exception as exc:

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -50,7 +50,12 @@ from fastapi.staticfiles import StaticFiles
 
 from pinky_daemon.activity_store import ActivityStore
 from pinky_daemon.agent_comms import AgentComms
-from pinky_daemon.agent_registry import AgentRegistry, ScheduleNameConflictError
+from pinky_daemon.agent_registry import (
+    AgentAlreadyExistsError,
+    AgentRegistry,
+    ScheduleNameConflictError,
+    SoulMutationRejectedError,
+)
 from pinky_daemon.analytics_store import AnalyticsStore
 from pinky_daemon.api_models import (
     AddDirectiveRequest,
@@ -88,6 +93,7 @@ from pinky_daemon.api_models import (
     RecordHeartbeatRequest,
     RegisterAgentRequest,
     RestartResponse,
+    RestoreSoulVersionRequest,
     SearchResponse,
     SendAgentMessageRequest,
     SendMessageRequest,
@@ -109,6 +115,7 @@ from pinky_daemon.api_models import (
     UpdateMcpServerRequest,
     UpdatePasswordRequest,
     UpdateScheduleRequest,
+    WriteAgentFileRequest,
 )
 from pinky_daemon.app_store import AppStore
 from pinky_daemon.auth import (
@@ -6309,16 +6316,71 @@ npm run build</pre>
 
     # ── Agent Registry Endpoints ────────────────────────────
 
+    def _guard_soul_or_400(
+        agent,
+        old_content: str,
+        new_content: str,
+        *,
+        force_soul: bool,
+    ) -> None:
+        try:
+            agents.guard_soul_mutation(
+                agent.name,
+                old_content,
+                new_content,
+                display_name=agent.display_name,
+                force_soul=force_soul,
+            )
+        except SoulMutationRejectedError as exc:
+            # Deliberately content-free: HTTP errors routinely land in client
+            # logs, MCP transcripts, and operator consoles.
+            raise HTTPException(
+                400,
+                {
+                    "code": "soul_mutation_requires_force",
+                    **exc.summary.to_dict(),
+                },
+            ) from exc
+
+    def _write_guarded_soul_file(
+        agent,
+        path: Path,
+        content: str,
+        *,
+        force_soul: bool,
+        source: str,
+    ) -> bool:
+        """Snapshot and replace a CLAUDE.md, returning whether it changed."""
+        path_existed = path.exists()
+        old_content = path.read_text() if path_existed else agent.soul
+        if path_existed and old_content == content:
+            return False
+        _guard_soul_or_400(
+            agent,
+            old_content,
+            content,
+            force_soul=force_soul,
+        )
+        agents.snapshot_soul_before_mutation(
+            agent.name,
+            old_content,
+            source=f"{source}:before-file",
+        )
+        path.write_text(content)
+        return True
+
     @app.post("/agents")
     async def register_agent(req: RegisterAgentRequest, request: Request):
-        """Register a new agent or update an existing one."""
-        # #149: registering/upserting agents is an ADMIN capability. This is the
-        # agent-mint/upsert collection route — it has no target agent in the
+        """Register a new agent; existing names are updated only via PUT."""
+        # #149: registering agents is an ADMIN capability. This is the
+        # agent-mint collection route — it has no target agent in the
         # PATH, so the middleware's path-based isolation guard can't see it
         # (target is None → flows through). An isolated tenant reaching here with
         # a valid signature could mint a new full-trust agent OR upsert an
-        # existing record (including dropping its OWN isolated flag — a direct
-        # escape). Deny the whole route for isolated callers; agents are minted
+        # existing record under the historical upsert contract (including
+        # dropping its OWN isolated flag — a direct escape). POST is now
+        # create-only, but minting still remains admin-only. Deny the whole
+        # route for isolated callers; agents are minted
         # by an operator/admin, never self-served by a tenant. (Murzik #635
         # re-review catch.) Operator/browser sessions carry no internal-agent
         # header → caller "" → not isolated → unaffected.
@@ -6326,48 +6388,50 @@ npm run build</pre>
         if _is_isolated_agent(caller):
             _log(
                 f"isolation: denied isolated agent '{caller}' from POST /agents "
-                f"(admin mint/upsert, body name='{req.name}')"
+                f"(admin mint, body name='{req.name}')"
             )
             raise HTTPException(403, "isolated agent may not register or modify agents")
-        # POST /agents is an UPSERT — remember whether this name already
-        # existed so a provisioning failure below rolls back only a NEWLY
-        # created agent. Hard-deleting a pre-existing agent (row + signing
-        # key) over a transient podman error would destroy a live tenant.
-        agent_existed_before = agents.get(req.name) is not None
-        agent = agents.register(
-            req.name,
-            display_name=req.display_name,
-            model=req.model,
-            soul=req.soul,
-            users=req.users,
-            boundaries=req.boundaries,
-            system_prompt=req.system_prompt,
-            working_dir=req.working_dir,
-            permission_mode=req.permission_mode,
-            allowed_tools=req.allowed_tools,
-            max_turns=req.max_turns,
-            timeout=req.timeout,
-            max_sessions=req.max_sessions,
-            plain_text_fallback=req.plain_text_fallback,
-            groups=req.groups,
-            auto_start=req.auto_start,
-            role=req.role,
-            heartbeat_interval=req.heartbeat_interval,
-            runtime=req.runtime,
-            transport=req.transport,
-            provider_url=req.provider_url,
-            provider_key=req.provider_key,
-            provider_model=req.provider_model,
-            provider_ref=req.provider_ref,
-            codex_home=req.codex_home,
-            thinking_effort=req.thinking_effort,
-            strict_effort_enforcement=req.strict_effort_enforcement,
-            dedicated_config_dir=req.dedicated_config_dir,
-            watchdog_config=req.watchdog_config or {},
-            isolated=req.isolated,
-            isolation_mode=req.isolation_mode,
-            container_image=req.container_image,
-        )
+        # No availability read: agents.name is a PRIMARY KEY and the registry
+        # executes INSERT OR ABORT. That database decision is authoritative
+        # when concurrent clients race on the same name.
+        try:
+            agent = agents.register(
+                req.name,
+                create_only=True,
+                display_name=req.display_name,
+                model=req.model,
+                soul=req.soul,
+                users=req.users,
+                boundaries=req.boundaries,
+                system_prompt=req.system_prompt,
+                working_dir=req.working_dir,
+                permission_mode=req.permission_mode,
+                allowed_tools=req.allowed_tools,
+                max_turns=req.max_turns,
+                timeout=req.timeout,
+                max_sessions=req.max_sessions,
+                plain_text_fallback=req.plain_text_fallback,
+                groups=req.groups,
+                auto_start=req.auto_start,
+                role=req.role,
+                heartbeat_interval=req.heartbeat_interval,
+                runtime=req.runtime,
+                transport=req.transport,
+                provider_url=req.provider_url,
+                provider_key=req.provider_key,
+                provider_model=req.provider_model,
+                provider_ref=req.provider_ref,
+                codex_home=req.codex_home,
+                thinking_effort=req.thinking_effort,
+                strict_effort_enforcement=req.strict_effort_enforcement,
+                dedicated_config_dir=req.dedicated_config_dir,
+                watchdog_config=req.watchdog_config or {},
+                isolated=req.isolated,
+                isolation_mode=req.isolation_mode,
+                container_image=req.container_image,
+            )
+        except AgentAlreadyExistsError as exc:
+            raise HTTPException(409, f"Agent '{req.name}' already exists") from exc
         # Provision OS-level isolation resources. No-op for local (the default);
         # gated for container — when the runtime gate is OFF, get_provisioner
         # raises NotImplementedError and we skip (the start-time guard then
@@ -6398,19 +6462,10 @@ npm run build</pre>
                     ok=False, mode=agent.isolation_mode, message=str(e)
                 )
             if not result.ok:
-                if not agent_existed_before:
-                    agents.delete(agent.name)  # roll back the NEW registration
-                    raise HTTPException(
-                        500, f"provisioning failed for '{agent.name}': {result.message}"
-                    )
-                # Pre-existing agent: keep the (updated) record — the cold-start
-                # ensure_started path re-provisions lazily once the cause is
-                # fixed. Deleting here would destroy a live tenant over a
-                # transient runtime error.
+                agents.delete(agent.name)  # roll back the NEW registration
                 raise HTTPException(
                     500,
-                    f"provisioning failed for '{agent.name}': {result.message} "
-                    f"(existing agent kept; it will re-provision at next start)",
+                    f"provisioning failed for '{agent.name}': {result.message}",
                 )
         # Write .mcp.json so the agent gets default MCP servers (memory, self, messaging)
         work_dir = Path(agent.working_dir) if agent.working_dir else None
@@ -7121,6 +7176,7 @@ npm run build</pre>
             raise HTTPException(404, f"Agent '{name}' not found")
 
         kwargs = {k: v for k, v in req.model_dump().items() if v is not None}
+        force_soul = bool(kwargs.pop("force_soul", False))
         # #638: flipping an agent to a non-local isolation_mode implies
         # isolated=True (same coupling RegisterAgentRequest enforces) — without
         # it a container tenant updated via PUT would keep isolated=False and
@@ -7144,7 +7200,21 @@ npm run build</pre>
                 "(bring-your-own image, e.g. 'registry/image:tag')",
             )
         was_container = getattr(existing, "isolation_mode", "local") == "container"
-        agent = agents.register(name, **kwargs)
+        try:
+            agent = agents.register(
+                name,
+                **kwargs,
+                force_soul=force_soul,
+                soul_source="api-put-force" if force_soul else "api-put",
+            )
+        except SoulMutationRejectedError as exc:
+            raise HTTPException(
+                400,
+                {
+                    "code": "soul_mutation_requires_force",
+                    **exc.summary.to_dict(),
+                },
+            ) from exc
 
         isolation_touched = "isolation_mode" in kwargs or "container_image" in kwargs
         if isolation_touched:
@@ -7570,18 +7640,70 @@ npm run build</pre>
         return version
 
     @app.post("/agents/{name}/soul/versions/{version_id}/restore")
-    async def restore_soul_version(name: str, version_id: int):
+    async def restore_soul_version(
+        name: str,
+        version_id: int,
+        req: RestoreSoulVersionRequest | None = None,
+    ):
         """Restore an agent's soul from an archived version."""
         version = agents.get_soul_version(name, version_id)
         if not version:
             raise HTTPException(404, f"Soul version {version_id} not found for '{name}'")
-        agent = agents.register(name, soul=version["content"])
+        agent = agents.get(name)
+        if not agent:
+            raise HTTPException(404, f"Agent '{name}' not found")
+        force_soul = bool(req and req.force_soul)
         work_dir = Path(agent.working_dir or default_working_dir).resolve()
         work_dir.mkdir(parents=True, exist_ok=True)
-        (work_dir / "CLAUDE.md").write_text(version["content"])
-        agents.save_soul_version(name, version["content"], source=f"restore-v{version_id}")
+        claude_md = work_dir / "CLAUDE.md"
+
+        # Validate both durable representations before changing either. Inc 2
+        # will make the dedicated soul endpoint own cross-store consistency;
+        # this keeps the existing restore adapter from bypassing Inc 1 policy.
+        _guard_soul_or_400(
+            agent,
+            agent.soul,
+            version["content"],
+            force_soul=force_soul,
+        )
+        if claude_md.exists():
+            _guard_soul_or_400(
+                agent,
+                claude_md.read_text(),
+                version["content"],
+                force_soul=force_soul,
+            )
+
+        source = f"restore-v{version_id}" + ("-force" if force_soul else "")
+        try:
+            agents.register(
+                name,
+                soul=version["content"],
+                force_soul=force_soul,
+                soul_source=source,
+            )
+        except SoulMutationRejectedError as exc:  # defensive after preflight
+            raise HTTPException(
+                400,
+                {
+                    "code": "soul_mutation_requires_force",
+                    **exc.summary.to_dict(),
+                },
+            ) from exc
+        _write_guarded_soul_file(
+            agent,
+            claude_md,
+            version["content"],
+            force_soul=force_soul,
+            source=source,
+        )
         _log(f"api: restored soul version {version_id} for {name}")
-        return {"restored": True, "agent": name, "version_id": version_id}
+        return {
+            "restored": True,
+            "agent": name,
+            "version_id": version_id,
+            "force_soul": force_soul,
+        }
 
     @app.delete("/agents/{name}")
     async def retire_agent(name: str):
@@ -10242,7 +10364,7 @@ npm run build</pre>
         return {"name": filename, "content": file_path.read_text(errors="replace")}
 
     @app.put("/agents/{name}/files/{filename}")
-    async def write_agent_file(name: str, filename: str, req: SendMessageRequest):
+    async def write_agent_file(name: str, filename: str, req: WriteAgentFileRequest):
         """Write a heart file to the agent's working directory.
 
         Uses content field for file contents.
@@ -10256,9 +10378,22 @@ npm run build</pre>
         # Safety check (resolve first; is_relative_to avoids prefix pitfalls)
         if not file_path.resolve().is_relative_to(work_dir):
             raise HTTPException(403, "Access denied")
-        file_path.write_text(req.content)
-        if filename == "CLAUDE.md":
-            agents.save_soul_version(name, req.content, source="api")
+        claude_md = work_dir / "CLAUDE.md"
+        is_soul_file = filename.casefold() == "claude.md"
+        if not is_soul_file and file_path.exists() and claude_md.exists():
+            # A symlink or case-insensitive alias must not turn the generic
+            # heart-file writer into a CLAUDE.md guard bypass.
+            is_soul_file = file_path.samefile(claude_md)
+        if is_soul_file:
+            _write_guarded_soul_file(
+                agent,
+                file_path,
+                req.content,
+                force_soul=req.force_soul,
+                source="api-file-force" if req.force_soul else "api-file",
+            )
+        else:
+            file_path.write_text(req.content)
         _log(f"api: wrote {filename} to {work_dir} for agent {name}")
         return {"written": True, "name": filename, "size": len(req.content)}
 

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -20,6 +20,7 @@ import inspect
 import json
 import os
 import re
+import shutil
 import sys
 import tempfile
 import time
@@ -39,6 +40,8 @@ from fastapi import (
     UploadFile,
     WebSocket,
 )
+from fastapi.exception_handlers import request_validation_exception_handler
+from fastapi.exceptions import RequestValidationError
 from fastapi.responses import (
     FileResponse,
     HTMLResponse,
@@ -52,9 +55,16 @@ from pinky_daemon.activity_store import ActivityStore
 from pinky_daemon.agent_comms import AgentComms
 from pinky_daemon.agent_registry import (
     AgentAlreadyExistsError,
+    AgentPathContainmentError,
+    AgentRegistrationIncompleteError,
     AgentRegistry,
+    AgentWorkspaceOverlapError,
+    AgentWorkspacePathError,
     ScheduleNameConflictError,
     SoulMutationRejectedError,
+    _validate_agent_name,
+    replace_agent_text,
+    resolve_agent_path,
 )
 from pinky_daemon.analytics_store import AnalyticsStore
 from pinky_daemon.api_models import (
@@ -1189,6 +1199,7 @@ def _write_mcp_json(
     When PINKY_SHARED_MCP=1, all three core servers use SSE transport pointing
     at the shared MCP server. Memory uses a per-agent store pool for DB isolation.
     """
+    work_dir = resolve_agent_path(agent_name, work_dir)
     pinky_src = str(Path(__file__).resolve().parent.parent)
     mcp_config: dict = {"mcpServers": {}}
 
@@ -1285,9 +1296,9 @@ def _write_mcp_json(
         }
     else:
         # Memory: per-agent SQLite long-term memory with vector search (stdio)
-        data_dir = work_dir / "data"
+        data_dir = resolve_agent_path(agent_name, work_dir, "data")
         data_dir.mkdir(parents=True, exist_ok=True)
-        db_path = str(data_dir / "memory.db")
+        db_path = str(resolve_agent_path(agent_name, work_dir, "data", "memory.db"))
         mcp_config["mcpServers"]["pinky-memory"] = {
             "command": sys.executable,
             "args": ["-m", "pinky_memory", "--db", db_path],
@@ -1378,7 +1389,7 @@ def _write_mcp_json(
             mcp_config["mcpServers"][sname] = entry
 
     # Merge with existing .mcp.json if present
-    mcp_json = work_dir / ".mcp.json"
+    mcp_json = resolve_agent_path(agent_name, work_dir, ".mcp.json")
     if mcp_json.exists():
         try:
             existing = json.loads(mcp_json.read_text())
@@ -1388,7 +1399,12 @@ def _write_mcp_json(
             mcp_config = existing
         except Exception:
             pass
-    mcp_json.write_text(json.dumps(mcp_config, indent=2))
+    mcp_json = replace_agent_text(
+        agent_name,
+        work_dir,
+        mcp_json,
+        json.dumps(mcp_config, indent=2),
+    )
     # Contains the agent's PINKY_AGENT_KEY — restrict to owner-only (0600).
     try:
         os.chmod(mcp_json, 0o600)
@@ -1682,6 +1698,21 @@ def create_api(
         version="0.1.0",
     )
     app.state.ferry_listener = FerryListenerState.from_config(FerryConfig.from_env())
+
+    @app.exception_handler(RequestValidationError)
+    async def _request_validation_response(
+        request: Request,
+        error: RequestValidationError,
+    ):
+        if request.method == "POST" and request.url.path == "/agents" and any(
+            tuple(item.get("loc", ()))[:2] == ("body", "name")
+            for item in error.errors()
+        ):
+            return JSONResponse(
+                status_code=400,
+                content={"detail": {"code": "invalid_agent_name"}},
+            )
+        return await request_validation_exception_handler(request, error)
 
     @app.exception_handler(_IsolationDeniedError)
     async def _isolation_denied_response(
@@ -6316,6 +6347,218 @@ npm run build</pre>
 
     # ── Agent Registry Endpoints ────────────────────────────
 
+    def _agent_name_or_400(name: str) -> str:
+        """Validate request-derived names without echoing hostile content."""
+        try:
+            return _validate_agent_name(name)
+        except (TypeError, ValueError) as exc:
+            raise HTTPException(400, {"code": "invalid_agent_name"}) from exc
+
+    def _agent_path_or_400(agent, *parts: str | Path) -> Path:
+        """Resolve one path inside the persisted owner root or refuse it."""
+        try:
+            return resolve_agent_path(
+                agent.name,
+                agent.working_dir,
+                *parts,
+            )
+        except (AgentPathContainmentError, OSError, RuntimeError, ValueError) as exc:
+            raise HTTPException(
+                400,
+                {"code": "agent_path_outside_workspace"},
+            ) from exc
+
+    def _write_agent_text(agent, path: Path, content: str) -> Path:
+        """Atomically replace an agent-owned text file without following links."""
+        try:
+            return replace_agent_text(
+                agent.name,
+                agent.working_dir,
+                path,
+                content,
+            )
+        except (AgentPathContainmentError, OSError, RuntimeError, ValueError) as exc:
+            raise HTTPException(
+                400,
+                {"code": "agent_path_outside_workspace"},
+            ) from exc
+
+    registration_managed_dirs = ("data", "output", "workspace", ".claude")
+    registration_managed_files = (
+        ".mcp.json",
+        ".claude/hook_working.py",
+        ".claude/hook_idle.py",
+        ".claude/hook_verify_effort.py",
+        ".claude/hook_tmux_wake.py",
+        ".claude/hook_tmux_session_start.py",
+        ".claude/hook_tmux_pre_tool.py",
+        ".claude/hook_tmux_post_tool.py",
+        ".claude/hook_tmux_stop_failure.py",
+        ".claude/settings.json",
+    )
+
+    def _path_node_exists(path: Path) -> bool:
+        """Return true for ordinary nodes and broken symlinks."""
+        return path.is_symlink() or path.exists()
+
+    def _remove_path_node(path: Path) -> None:
+        """Remove one explicit node without following directory symlinks."""
+        if path.is_symlink() or path.is_file():
+            path.unlink(missing_ok=True)
+        elif path.exists():
+            shutil.rmtree(path)
+
+    def _backup_path_node(source: Path, destination: Path) -> None:
+        """Back up one managed node, preserving symlink and inode semantics."""
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        if source.is_symlink():
+            destination.symlink_to(os.readlink(source))
+        elif source.is_dir():
+            shutil.copytree(source, destination, symlinks=True)
+        else:
+            try:
+                os.link(source, destination, follow_symlinks=False)
+            except OSError:
+                shutil.copy2(source, destination, follow_symlinks=False)
+
+    def _restore_path_node(source: Path, destination: Path) -> None:
+        """Restore one managed node from a private registration backup."""
+        _remove_path_node(destination)
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        if source.is_symlink():
+            destination.symlink_to(os.readlink(source))
+        elif source.is_dir():
+            shutil.copytree(source, destination, symlinks=True)
+        else:
+            try:
+                os.link(source, destination, follow_symlinks=False)
+            except OSError:
+                shutil.copy2(source, destination, follow_symlinks=False)
+
+    def _capture_registration_workspace(agent_name: str, work_dir: Path) -> dict:
+        """Capture only the files registration may create or rewrite."""
+        backup_dir = Path(tempfile.mkdtemp(prefix="pinky-agent-registration-"))
+        try:
+            root_existed = _path_node_exists(work_dir)
+            dirs_existed = {}
+            for rel in registration_managed_dirs:
+                resolve_agent_path(agent_name, work_dir, rel)
+                dirs_existed[rel] = _path_node_exists(work_dir / rel)
+            files_existed = {}
+            file_targets = {}
+            if root_existed:
+                for rel in registration_managed_files:
+                    source = resolve_agent_path(agent_name, work_dir, rel)
+                    file_targets[rel] = source
+                    existed = _path_node_exists(source)
+                    files_existed[rel] = existed
+                    if existed:
+                        _backup_path_node(source, backup_dir / rel)
+            else:
+                files_existed = {
+                    rel: False for rel in registration_managed_files
+                }
+                file_targets = {
+                    rel: resolve_agent_path(agent_name, work_dir, rel)
+                    for rel in registration_managed_files
+                }
+            return {
+                "root": work_dir,
+                "root_existed": root_existed,
+                "dirs_existed": dirs_existed,
+                "files_existed": files_existed,
+                "file_targets": file_targets,
+                "backup_dir": backup_dir,
+            }
+        except Exception:
+            shutil.rmtree(backup_dir, ignore_errors=True)
+            raise
+
+    def _discard_registration_workspace_capture(state: dict) -> None:
+        shutil.rmtree(state["backup_dir"], ignore_errors=True)
+
+    def _restore_registration_workspace(state: dict) -> None:
+        """Remove registration artifacts and restore pre-existing managed files."""
+        work_dir = state["root"]
+        try:
+            if not state["root_existed"]:
+                _remove_path_node(work_dir)
+                return
+
+            backup_dir = state["backup_dir"]
+            for rel, existed in state["files_existed"].items():
+                target = state["file_targets"][rel]
+                if existed:
+                    _restore_path_node(backup_dir / rel, target)
+                else:
+                    _remove_path_node(target)
+            for rel in reversed(registration_managed_dirs):
+                if not state["dirs_existed"][rel]:
+                    _remove_path_node(work_dir / rel)
+        finally:
+            _discard_registration_workspace_capture(state)
+
+    async def _rollback_agent_registration(
+        *,
+        name: str,
+        agent,
+        main_agent_before: str,
+        provisioner,
+        provision_attempted: bool,
+        delete_registration_row: bool,
+        workspace_state: dict,
+    ) -> None:
+        """Best-effort compensation for every post-winner registration stage."""
+        rollback_agent = agent or agents.get(name)
+        if provision_attempted and provisioner is not None and rollback_agent is not None:
+            try:
+                await asyncio.to_thread(provisioner.deprovision, rollback_agent)
+            except Exception as exc:  # noqa: BLE001 - compensation must continue
+                _log(
+                    "api: registration compensation deprovision failed for "
+                    f"{name}: {type(exc).__name__}"
+                )
+        if delete_registration_row:
+            try:
+                agents.delete(name)
+            except Exception as exc:  # noqa: BLE001 - compensation must continue
+                _log(
+                    "api: registration compensation DB delete failed for "
+                    f"{name}: {type(exc).__name__}"
+                )
+            try:
+                if agents.get_main_agent() == name:
+                    if main_agent_before:
+                        agents.set_main_agent(main_agent_before)
+                    else:
+                        agents.delete_setting("main_agent")
+            except Exception as exc:  # noqa: BLE001 - compensation must continue
+                _log(
+                    "api: registration compensation main-agent restore failed for "
+                    f"{name}: {type(exc).__name__}"
+                )
+        restore_workspace = True
+        if not delete_registration_row:
+            current = agents.get(name)
+            if current and current.working_dir:
+                try:
+                    restore_workspace = (
+                        Path(current.working_dir).resolve()
+                        != workspace_state["root"]
+                    )
+                except (OSError, RuntimeError, ValueError):
+                    restore_workspace = False
+        if restore_workspace:
+            try:
+                _restore_registration_workspace(workspace_state)
+            except Exception as exc:  # noqa: BLE001 - compensation must continue
+                _log(
+                    "api: registration compensation workspace restore failed for "
+                    f"{name}: {type(exc).__name__}"
+                )
+        else:
+            _discard_registration_workspace_capture(workspace_state)
+
     def _guard_soul_or_400(
         agent,
         old_content: str,
@@ -6351,6 +6594,7 @@ npm run build</pre>
         source: str,
     ) -> bool:
         """Snapshot and replace a CLAUDE.md, returning whether it changed."""
+        path = _agent_path_or_400(agent, path)
         path_existed = path.exists()
         old_content = path.read_text() if path_existed else agent.soul
         if path_existed and old_content == content:
@@ -6366,12 +6610,13 @@ npm run build</pre>
             old_content,
             source=f"{source}:before-file",
         )
-        path.write_text(content)
+        _write_agent_text(agent, path, content)
         return True
 
     @app.post("/agents")
     async def register_agent(req: RegisterAgentRequest, request: Request):
         """Register a new agent; existing names are updated only via PUT."""
+        name = _agent_name_or_400(req.name)
         # #149: registering agents is an ADMIN capability. This is the
         # agent-mint collection route — it has no target agent in the
         # PATH, so the middleware's path-based isolation guard can't see it
@@ -6388,15 +6633,42 @@ npm run build</pre>
         if _is_isolated_agent(caller):
             _log(
                 f"isolation: denied isolated agent '{caller}' from POST /agents "
-                f"(admin mint, body name='{req.name}')"
+                "(admin mint, body name validated)"
             )
             raise HTTPException(403, "isolated agent may not register or modify agents")
+
+        raw_work_dir = req.working_dir or f"data/agents/{name}"
+        try:
+            registration_work_dir = agents.resolve_registration_workspace(
+                name,
+                raw_work_dir,
+            )
+        except AgentWorkspaceOverlapError as exc:
+            raise HTTPException(409, {"code": "agent_workspace_overlap"}) from exc
+        except (AgentPathContainmentError, AgentWorkspacePathError) as exc:
+            raise HTTPException(400, {"code": "invalid_agent_workspace"}) from exc
+        main_agent_before = agents.get_main_agent()
+        try:
+            workspace_state = _capture_registration_workspace(
+                name,
+                registration_work_dir
+            )
+        except AgentPathContainmentError as exc:
+            raise HTTPException(
+                400,
+                {"code": "agent_path_outside_workspace"},
+            ) from exc
+        except Exception as exc:
+            raise HTTPException(
+                500,
+                {"code": "agent_registration_failed"},
+            ) from exc
         # No availability read: agents.name is a PRIMARY KEY and the registry
         # executes INSERT OR ABORT. That database decision is authoritative
         # when concurrent clients race on the same name.
         try:
             agent = agents.register(
-                req.name,
+                name,
                 create_only=True,
                 display_name=req.display_name,
                 model=req.model,
@@ -6431,46 +6703,97 @@ npm run build</pre>
                 container_image=req.container_image,
             )
         except AgentAlreadyExistsError as exc:
-            raise HTTPException(409, f"Agent '{req.name}' already exists") from exc
+            _discard_registration_workspace_capture(workspace_state)
+            raise HTTPException(409, f"Agent '{name}' already exists") from exc
+        except AgentWorkspaceOverlapError as exc:
+            _discard_registration_workspace_capture(workspace_state)
+            raise HTTPException(409, {"code": "agent_workspace_overlap"}) from exc
+        except (AgentPathContainmentError, AgentWorkspacePathError) as exc:
+            _discard_registration_workspace_capture(workspace_state)
+            raise HTTPException(400, {"code": "invalid_agent_workspace"}) from exc
+        except AgentRegistrationIncompleteError as exc:
+            await _rollback_agent_registration(
+                name=name,
+                agent=agents.get(name),
+                main_agent_before=main_agent_before,
+                provisioner=None,
+                provision_attempted=False,
+                delete_registration_row=exc.row_committed,
+                workspace_state=workspace_state,
+            )
+            raise HTTPException(
+                500,
+                {"code": "agent_registration_failed"},
+            ) from exc
+        except Exception as exc:
+            _discard_registration_workspace_capture(workspace_state)
+            raise HTTPException(
+                500,
+                {"code": "agent_registration_failed"},
+            ) from exc
+
         # Provision OS-level isolation resources. No-op for local (the default);
         # gated for container — when the runtime gate is OFF, get_provisioner
         # raises NotImplementedError and we skip (the start-time guard then
-        # blocks the agent until an operator opts in). On a real provision
-        # failure we roll back the just-registered agent so we never leave a
-        # half-provisioned tenant behind.
+        # blocks the agent until an operator opts in). Every failure after the
+        # INSERT winner is compensated across DB state, main-agent assignment,
+        # provisioning, MCP publication, and the managed workspace surface.
         from pinky_daemon.provisioning import ProvisionResult, get_provisioner
 
+        provisioner = None
+        provision_attempted = False
         try:
-            provisioner = get_provisioner(
-                agent.isolation_mode, signing_key_provider=agents.get_or_create_signing_key
-            )
-        except NotImplementedError:
-            provisioner = None  # dormant mode (e.g. container gate off)
-        if provisioner is not None:
-            # to_thread: provision drives blocking podman subprocesses (incl.
-            # a possible multi-minute image pull) — inline it would freeze the
-            # entire event loop (every poller + hook POST + UI request).
-            # provision() is an idempotent reconcile, so the (rare) overlap
-            # with a cold-start ensure_started in another thread converges:
-            # the loser errors on a name conflict and the next attempt heals.
             try:
-                result = await asyncio.to_thread(provisioner.provision, agent)
-            except Exception as e:  # belt-and-braces: the ABC contract is
-                # "return ok=False", but a provisioner that raises instead
-                # must hit the same rollback logic, not skip it.
-                result = ProvisionResult(
-                    ok=False, mode=agent.isolation_mode, message=str(e)
+                provisioner = get_provisioner(
+                    agent.isolation_mode,
+                    signing_key_provider=agents.get_or_create_signing_key,
                 )
-            if not result.ok:
-                agents.delete(agent.name)  # roll back the NEW registration
-                raise HTTPException(
-                    500,
-                    f"provisioning failed for '{agent.name}': {result.message}",
-                )
-        # Write .mcp.json so the agent gets default MCP servers (memory, self, messaging)
-        work_dir = Path(agent.working_dir) if agent.working_dir else None
-        if work_dir:
-            _write_mcp_json(work_dir, req.name, agent_registry=agents, skill_store=skills)
+            except NotImplementedError:
+                provisioner = None  # dormant mode (e.g. container gate off)
+            if provisioner is not None:
+                # to_thread: provision drives blocking podman subprocesses
+                # (including a possible multi-minute image pull).
+                provision_attempted = True
+                try:
+                    result = await asyncio.to_thread(provisioner.provision, agent)
+                except Exception as exc:
+                    result = ProvisionResult(
+                        ok=False,
+                        mode=agent.isolation_mode,
+                        message=str(exc),
+                    )
+                if not result.ok:
+                    raise HTTPException(
+                        500,
+                        f"provisioning failed for '{agent.name}': {result.message}",
+                    )
+
+            # Publish MCP config only after provisioning succeeds. This is the
+            # final fallible stage before the POST winner is acknowledged.
+            _write_mcp_json(
+                registration_work_dir,
+                name,
+                agent_registry=agents,
+                skill_store=skills,
+            )
+        except Exception as exc:
+            await _rollback_agent_registration(
+                name=name,
+                agent=agent,
+                main_agent_before=main_agent_before,
+                provisioner=provisioner,
+                provision_attempted=provision_attempted,
+                delete_registration_row=True,
+                workspace_state=workspace_state,
+            )
+            if isinstance(exc, HTTPException):
+                raise
+            raise HTTPException(
+                500,
+                {"code": "agent_registration_failed"},
+            ) from exc
+
+        _discard_registration_workspace_capture(workspace_state)
         return agent.to_dict()
 
     @app.get("/agents")
@@ -7171,6 +7494,7 @@ npm run build</pre>
     @app.put("/agents/{name}")
     async def update_agent(name: str, req: UpdateAgentRequest):
         """Update an agent's configuration."""
+        name = _agent_name_or_400(name)
         existing = agents.get(name)
         if not existing:
             raise HTTPException(404, f"Agent '{name}' not found")
@@ -7215,6 +7539,10 @@ npm run build</pre>
                     **exc.summary.to_dict(),
                 },
             ) from exc
+        except AgentWorkspaceOverlapError as exc:
+            raise HTTPException(409, {"code": "agent_workspace_overlap"}) from exc
+        except (AgentPathContainmentError, AgentWorkspacePathError) as exc:
+            raise HTTPException(400, {"code": "invalid_agent_workspace"}) from exc
 
         isolation_touched = "isolation_mode" in kwargs or "container_image" in kwargs
         if isolation_touched:
@@ -7584,12 +7912,12 @@ npm run build</pre>
     @app.post("/agents/{name}/claude-md/rebuild")
     async def rebuild_claude_md(name: str):
         """Deprecated — CLAUDE.md is now agent-owned. Returns current file content."""
+        name = _agent_name_or_400(name)
         agent = agents.get(name)
         if not agent:
             raise HTTPException(404, f"Agent '{name}' not found")
 
-        work_dir = Path(agent.working_dir or default_working_dir).resolve()
-        claude_md = work_dir / "CLAUDE.md"
+        claude_md = _agent_path_or_400(agent, "CLAUDE.md")
         content = claude_md.read_text() if claude_md.exists() else agent.soul or ""
         return {"content": content, "size": len(content), "deprecated": True}
 
@@ -7625,6 +7953,7 @@ npm run build</pre>
     @app.get("/agents/{name}/soul/versions")
     async def list_soul_versions(name: str, limit: int = 20):
         """List archived soul versions for an agent."""
+        name = _agent_name_or_400(name)
         agent = agents.get(name)
         if not agent:
             raise HTTPException(404, f"Agent '{name}' not found")
@@ -7634,6 +7963,7 @@ npm run build</pre>
     @app.get("/agents/{name}/soul/versions/{version_id}")
     async def get_soul_version(name: str, version_id: int):
         """Get a specific soul version content."""
+        name = _agent_name_or_400(name)
         version = agents.get_soul_version(name, version_id)
         if not version:
             raise HTTPException(404, f"Soul version {version_id} not found for '{name}'")
@@ -7646,6 +7976,7 @@ npm run build</pre>
         req: RestoreSoulVersionRequest | None = None,
     ):
         """Restore an agent's soul from an archived version."""
+        name = _agent_name_or_400(name)
         version = agents.get_soul_version(name, version_id)
         if not version:
             raise HTTPException(404, f"Soul version {version_id} not found for '{name}'")
@@ -7653,9 +7984,9 @@ npm run build</pre>
         if not agent:
             raise HTTPException(404, f"Agent '{name}' not found")
         force_soul = bool(req and req.force_soul)
-        work_dir = Path(agent.working_dir or default_working_dir).resolve()
+        work_dir = _agent_path_or_400(agent)
         work_dir.mkdir(parents=True, exist_ok=True)
-        claude_md = work_dir / "CLAUDE.md"
+        claude_md = _agent_path_or_400(agent, "CLAUDE.md")
 
         # Validate both durable representations before changing either. Inc 2
         # will make the dedicated soul endpoint own cross-store consistency;
@@ -7736,6 +8067,7 @@ npm run build</pre>
     @app.post("/agents/{name}/restore")
     async def restore_agent(name: str):
         """Restore a retired agent back to active."""
+        name = _agent_name_or_400(name)
         restored = agents.restore(name)
         if not restored:
             raise HTTPException(404, f"Agent '{name}' not found")
@@ -10326,19 +10658,21 @@ npm run build</pre>
     @app.get("/agents/{name}/files")
     async def list_agent_files(name: str):
         """List heart files in the agent's working directory."""
+        name = _agent_name_or_400(name)
         agent = agents.get(name)
         if not agent:
             raise HTTPException(404, f"Agent '{name}' not found")
-        work_dir = Path(agent.working_dir).resolve()
+        work_dir = _agent_path_or_400(agent)
         if not work_dir.exists():
             return {"agent": name, "working_dir": str(work_dir), "files": [], "exists": False}
         # Heart file extensions — config, soul, and docs
         heart_exts = {".md", ".yaml", ".yml", ".toml", ".json", ".txt", ".cfg", ".ini"}
         files = []
-        for f in sorted(work_dir.iterdir()):
+        for entry in sorted(work_dir.iterdir()):
+            f = _agent_path_or_400(agent, entry.name)
             if f.is_file() and not f.name.startswith('.') and (f.suffix in heart_exts or f.name == "CLAUDE.md"):
                 files.append({
-                    "name": f.name,
+                    "name": entry.name,
                     "size": f.stat().st_size,
                     "modified": f.stat().st_mtime,
                     "is_claude_md": f.name == "CLAUDE.md",
@@ -10348,17 +10682,11 @@ npm run build</pre>
     @app.get("/agents/{name}/files/{filename}")
     async def read_agent_file(name: str, filename: str):
         """Read a heart file from the agent's working directory."""
+        name = _agent_name_or_400(name)
         agent = agents.get(name)
         if not agent:
             raise HTTPException(404, f"Agent '{name}' not found")
-        work_dir = Path(agent.working_dir).resolve()
-        file_path = work_dir / filename
-        # Safety: don't serve files outside the working dir. Resolve first so
-        # a symlink inside the dir pointing elsewhere is rejected too, and
-        # check containment before existence so outside paths 403, not 404.
-        # is_relative_to avoids the '/dir' vs '/dir-evil' prefix pitfall.
-        if not file_path.resolve().is_relative_to(work_dir):
-            raise HTTPException(403, "Access denied")
+        file_path = _agent_path_or_400(agent, filename)
         if not file_path.exists() or not file_path.is_file():
             raise HTTPException(404, f"File '{filename}' not found")
         return {"name": filename, "content": file_path.read_text(errors="replace")}
@@ -10369,22 +10697,21 @@ npm run build</pre>
 
         Uses content field for file contents.
         """
+        name = _agent_name_or_400(name)
         agent = agents.get(name)
         if not agent:
             raise HTTPException(404, f"Agent '{name}' not found")
-        work_dir = Path(agent.working_dir).resolve()
+        work_dir = _agent_path_or_400(agent)
         work_dir.mkdir(parents=True, exist_ok=True)
-        file_path = work_dir / filename
-        # Safety check (resolve first; is_relative_to avoids prefix pitfalls)
-        if not file_path.resolve().is_relative_to(work_dir):
-            raise HTTPException(403, "Access denied")
-        claude_md = work_dir / "CLAUDE.md"
+        file_path = _agent_path_or_400(agent, filename)
+        claude_md = _agent_path_or_400(agent, "CLAUDE.md")
         is_soul_file = filename.casefold() == "claude.md"
         if not is_soul_file and file_path.exists() and claude_md.exists():
             # A symlink or case-insensitive alias must not turn the generic
             # heart-file writer into a CLAUDE.md guard bypass.
             is_soul_file = file_path.samefile(claude_md)
         if is_soul_file:
+            file_path = claude_md
             _write_guarded_soul_file(
                 agent,
                 file_path,
@@ -10393,7 +10720,7 @@ npm run build</pre>
                 source="api-file-force" if req.force_soul else "api-file",
             )
         else:
-            file_path.write_text(req.content)
+            _write_agent_text(agent, file_path, req.content)
         _log(f"api: wrote {filename} to {work_dir} for agent {name}")
         return {"written": True, "name": filename, "size": len(req.content)}
 
@@ -10407,6 +10734,7 @@ npm run build</pre>
         tools, permissions, and active directives. Writes CLAUDE.md to
         the agent's working directory before spawning.
         """
+        name = _agent_name_or_400(name)
         agent = agents.get(name)
         if not agent:
             raise HTTPException(404, f"Agent '{name}' not found")
@@ -10417,13 +10745,18 @@ npm run build</pre>
         system_prompt = agents.build_system_prompt(name, skill_store=skills)
 
         # Ensure working directory exists and write CLAUDE.md
-        work_dir = Path(agent.working_dir or default_working_dir).resolve()
+        work_dir = _agent_path_or_400(agent)
         work_dir.mkdir(parents=True, exist_ok=True)
-        claude_md = work_dir / "CLAUDE.md"
-        # Snapshot on-disk content before overwriting (catches agent self-edits)
+        claude_md = _agent_path_or_400(agent, "CLAUDE.md")
+        # Accepted-by-design publication semantics: CLAUDE.md is a compiled
+        # artifact from the DB-authoritative soul plus current directives and
+        # skills. Spawn intentionally overwrites it without the shrink/anchor
+        # guard, while the common writer still enforces owner-root containment
+        # and atomically replaces links instead of writing through their inode.
+        # Snapshot on-disk content before overwriting (catches agent self-edits).
         if claude_md.exists():
             agents.save_soul_version(name, claude_md.read_text(), source="agent")
-        claude_md.write_text(system_prompt)
+        _write_agent_text(agent, claude_md, system_prompt)
         agents.save_soul_version(name, system_prompt, source="spawn")
         _log(f"api: wrote CLAUDE.md ({len(system_prompt)} chars) to {work_dir}")
 

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -6768,14 +6768,18 @@ npm run build</pre>
                         f"provisioning failed for '{agent.name}': {result.message}",
                     )
 
-            # Publish MCP config only after provisioning succeeds. This is the
-            # final fallible stage before the POST winner is acknowledged.
+            # Publish MCP config only after provisioning succeeds.
             _write_mcp_json(
                 registration_work_dir,
                 name,
                 agent_registry=agents,
                 skill_store=skills,
             )
+            # The verified-contact bootstrap and its migration marker are the
+            # final registration stage. AgentRegistry makes those two writes
+            # atomic; ordering them after provisioning and MCP publication means
+            # no durable bootstrap state exists for a failed POST winner.
+            agents.finalize_registration(name)
         except Exception as exc:
             await _rollback_agent_registration(
                 name=name,

--- a/src/pinky_daemon/api_models.py
+++ b/src/pinky_daemon/api_models.py
@@ -310,20 +310,9 @@ class RegisterAgentRequest(BaseModel):
     @field_validator("name")
     @classmethod
     def _name_safe(cls, v: str) -> str:
-        """Reject agent names that don't match the safe-char allowlist.
-
-        The name becomes part of filesystem paths (working_dir, hook scripts,
-        settings.json) downstream. Blocking unsafe characters at request
-        parse time short-circuits any path-construction code in
-        agent_registry from ever seeing tainted input. See _AGENT_NAME_RE
-        for the allowed shape.
-        """
+        """Reject agent names that don't match the shared safe allowlist."""
         if not _AGENT_NAME_RE.fullmatch(v):
-            raise ValueError(
-                "agent name must match ^[a-z0-9][a-z0-9_-]{0,62}$ "
-                "(lowercase alphanumeric, underscore, hyphen; "
-                "starts with letter or digit; up to 63 chars)"
-            )
+            raise ValueError("invalid agent name")
         return v
 
     model: str = "opus"

--- a/src/pinky_daemon/api_models.py
+++ b/src/pinky_daemon/api_models.py
@@ -53,6 +53,13 @@ class SendMessageRequest(BaseModel):
     content: str
 
 
+class WriteAgentFileRequest(BaseModel):
+    """Write an agent-owned file, with an explicit soul safety override."""
+
+    content: str
+    force_soul: bool = False
+
+
 class AuthSetupRequest(BaseModel):
     """Create the initial UI password."""
 
@@ -443,6 +450,9 @@ class UpdateAgentRequest(BaseModel):
     # refuses to actually *run* a mode whose provisioner isn't implemented yet.
     isolation_mode: str | None = None
     container_image: str | None = None  # bring-your-own image for mode=container; None = leave unchanged
+    # Safety override for an explicitly supplied soul replacement. This is an
+    # API control only and is never persisted as agent configuration.
+    force_soul: bool = False
 
     @field_validator("isolation_mode")
     @classmethod
@@ -455,6 +465,12 @@ class UpdateAgentRequest(BaseModel):
                 f"isolation_mode must be one of {sorted(allowed)} (got {v!r})"
             )
         return v
+
+
+class RestoreSoulVersionRequest(BaseModel):
+    """Restore an archived soul, optionally accepting destructive shrink."""
+
+    force_soul: bool = False
 
 
 class ContainerizeRequest(BaseModel):

--- a/src/pinky_self/server.py
+++ b/src/pinky_self/server.py
@@ -2233,6 +2233,10 @@ description: Auto-generated from task completion. {task_description[:120].rstrip
                 "isolation_mode": isolation_mode,
             })
             if isinstance(create, dict) and "error" in create:
+                if create.get("status") == 400 and "invalid_agent_name" in str(
+                    create.get("error", "")
+                ):
+                    return "Failed to register agent (HTTP 400): invalid_agent_name"
                 if create.get("status") == 409:
                     return (
                         f"Refusing to register '{name}': HTTP 409 — an agent with "

--- a/src/pinky_self/server.py
+++ b/src/pinky_self/server.py
@@ -2216,28 +2216,10 @@ description: Auto-generated from task completion. {task_description[:120].rstrip
                     f"grants cross-agent memory read+write over the entire fleet "
                     f"— pass confirm_privileged_role=True to proceed deliberately."
                 )
-            # Create-only guard. POST /agents is an UPSERT — register() merges
-            # the provided fields and UPDATEs when the name already exists. Since
-            # this tool always sends soul/model/role/groups/transport, calling it
-            # with an existing name would silently overwrite that agent (blank its
-            # soul, reset role, empty groups) and still return 200. Refuse on
-            # collision instead; existing agents are modified via the dashboard /
-            # update path, which keeps the upsert semantics intact there.
-            existing = _api("GET", f"/agents/{name}")
-            if isinstance(existing, dict) and "error" not in existing:
-                return (
-                    f"Refusing to register '{name}': an agent with that name "
-                    f"already exists. register_agent is create-only — to change "
-                    f"an existing agent, use the dashboard or update path (POST "
-                    f"/agents is an upsert and would overwrite its soul, model, "
-                    f"role, and groups)."
-                )
-            if isinstance(existing, dict) and existing.get("status") != 404:
-                return (
-                    f"Refusing to register '{name}': couldn't verify name availability "
-                    f"(GET /agents/{name} returned unexpected error: "
-                    f"{existing.get('error', 'unknown')}) — try again."
-                )
+            # POST /agents is now create-only at the database boundary. Do not
+            # reintroduce a GET availability precheck: it is advisory and races
+            # another creator. The authoritative INSERT-or-abort result below
+            # decides which caller won.
             caller = str(agent_name)
             create = _api("POST", "/agents", {
                 "name": name,
@@ -2251,7 +2233,14 @@ description: Auto-generated from task completion. {task_description[:120].rstrip
                 "isolation_mode": isolation_mode,
             })
             if isinstance(create, dict) and "error" in create:
-                return f"Failed to register agent '{name}': {create['error']}"
+                if create.get("status") == 409:
+                    return (
+                        f"Refusing to register '{name}': HTTP 409 — an agent with "
+                        f"that name already exists. register_agent is create-only; "
+                        f"use PUT /agents/{name} for updates."
+                    )
+                status = f" (HTTP {create['status']})" if create.get("status") else ""
+                return f"Failed to register agent '{name}'{status}: {create['error']}"
 
             assigned, failed = [], []
             for sk in (skills or []):

--- a/tests/test_agent_registry.py
+++ b/tests/test_agent_registry.py
@@ -6,14 +6,18 @@ import json
 import os
 import tempfile
 import threading
+import time
 
 import pytest
 
 from pinky_daemon.agent_registry import (
     AgentAlreadyExistsError,
     AgentContext,
+    AgentPathContainmentError,
     AgentRegistry,
+    AgentWorkspaceOverlapError,
     SoulMutationRejectedError,
+    resolve_agent_path,
 )
 
 
@@ -579,6 +583,67 @@ class TestAgentCRUD:
         assert winner.working_dir == str(tmp_path / "winner")
         assert not (tmp_path / "loser").exists()
 
+    @pytest.mark.parametrize("relation", ["equal", "nested", "enclosing"])
+    def test_register_refuses_cross_agent_workspace_overlap_without_side_effects(
+        self,
+        registry,
+        tmp_path,
+        relation,
+    ):
+        victim_root = tmp_path / "victim"
+        registry.register("victim", working_dir=str(victim_root), model="opus")
+        marker = victim_root / "identity-marker"
+        marker.write_text("victim-private")
+        candidate = {
+            "equal": victim_root,
+            "nested": victim_root / "nested-attacker",
+            "enclosing": tmp_path,
+        }[relation]
+
+        with pytest.raises(AgentWorkspaceOverlapError):
+            registry.register(
+                "attacker",
+                working_dir=str(candidate),
+                model="haiku",
+                soul="must-not-land",
+            )
+
+        assert registry.get("attacker") is None
+        assert registry.get("victim").model == "opus"
+        assert marker.read_text() == "victim-private"
+        if relation == "nested":
+            assert not candidate.exists()
+
+    @pytest.mark.parametrize("relation", ["equal", "nested", "enclosing"])
+    def test_update_refuses_cross_agent_workspace_overlap_before_other_mutations(
+        self,
+        registry,
+        tmp_path,
+        relation,
+    ):
+        victim_root = tmp_path / "victim"
+        mover_root = tmp_path / "mover"
+        registry.register("victim", working_dir=str(victim_root))
+        registry.register("mover", working_dir=str(mover_root), model="opus")
+        candidate = {
+            "equal": victim_root,
+            "nested": victim_root / "nested-mover",
+            "enclosing": tmp_path,
+        }[relation]
+
+        with pytest.raises(AgentWorkspaceOverlapError):
+            registry.register(
+                "mover",
+                working_dir=str(candidate),
+                model="haiku",
+            )
+
+        mover = registry.get("mover")
+        assert mover.working_dir == str(mover_root)
+        assert mover.model == "opus"
+        if relation == "nested":
+            assert not candidate.exists()
+
     def test_soul_update_snapshots_replaced_value_before_write(
         self, registry, monkeypatch,
     ):
@@ -643,6 +708,42 @@ class TestAgentCRUD:
 
         forced = registry.update("oleg", soul=replacement, force_soul=True)
         assert forced.soul == replacement
+
+    def test_soul_anchor_scan_is_linear_on_codeql_pathological_shape(
+        self,
+        monkeypatch,
+    ):
+        def regex_must_not_run(*_args, **_kwargs):
+            raise AssertionError("anchor detection must not use backtracking regexes")
+
+        monkeypatch.setattr("pinky_daemon.agent_registry.re.fullmatch", regex_must_not_run)
+        # Near-suffix family from Murzik's r1 probe. The old lazy multiline
+        # regex explored the spaces/hash suffix quadratically (~4x for 2x n).
+        pathological = "# a" + " " * 100_000 + "#" * 100_000 + "!"
+        started = time.perf_counter()
+
+        anchors = AgentRegistry._soul_identity_anchors(
+            pathological,
+            agent_name="alice",
+        )
+
+        assert anchors == set()
+        # Deliberately generous: the structural no-regex assertion proves the
+        # algorithmic fix; this only catches accidental synchronous blowups.
+        assert time.perf_counter() - started < 5.0
+
+    def test_soul_anchor_scan_preserves_legacy_markdown_forms(self):
+        anchors = AgentRegistry._soul_identity_anchors(
+            "# Oleg ###\n## IDENTITY ##\n**Name:** Oleg\n***Role:** Lead",
+            agent_name="oleg",
+        )
+
+        assert anchors == {
+            "agent_heading",
+            "identity_heading",
+            "name_label",
+            "role_label",
+        }
 
     def test_update_is_partial_and_preserves_unset_fields(self, registry):
         registry.register(
@@ -960,6 +1061,25 @@ class TestAgentNameValidation:
     def test_register_accepts_safe_name(self, registry, good_name):
         agent = registry.register(good_name)
         assert agent.name == good_name
+
+
+def test_resolve_agent_path_refuses_out_of_tree_alias(tmp_path):
+    owner_root = tmp_path / "alice"
+    owner_root.mkdir()
+    outside = tmp_path / "victim-soul"
+    outside.write_text("victim-private")
+    (owner_root / "CLAUDE.md").symlink_to(outside)
+
+    with pytest.raises(AgentPathContainmentError):
+        resolve_agent_path("alice", owner_root, "CLAUDE.md")
+
+    assert outside.read_text() == "victim-private"
+
+
+@pytest.mark.parametrize("owner_root", ["", "relative/agent-root"])
+def test_resolve_agent_path_requires_persisted_absolute_owner_root(owner_root):
+    with pytest.raises(AgentPathContainmentError):
+        resolve_agent_path("alice", owner_root, "CLAUDE.md")
 
 
 class TestDirectives:

--- a/tests/test_agent_registry.py
+++ b/tests/test_agent_registry.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import sqlite3
 import tempfile
 import threading
 import time
@@ -29,6 +30,101 @@ def registry():
     yield r
     r.close()
     os.unlink(path)
+
+
+class TestVerifiedContactBootstrap:
+    def test_finalize_rolls_back_state_bit_and_contact_if_marker_write_fails(
+        self,
+        tmp_path,
+    ):
+        registry = AgentRegistry(db_path=str(tmp_path / "agents.db"))
+        try:
+            registry.register(
+                "barsik",
+                create_only=True,
+                working_dir=str(tmp_path / "barsik"),
+            )
+            registry._db.execute(
+                """CREATE TRIGGER fail_registration_marker
+                   BEFORE INSERT ON system_settings
+                   WHEN NEW.key='migration:verified_contacts_brad_owner_seed_v1'
+                   BEGIN
+                     SELECT RAISE(ABORT, 'injected marker failure');
+                   END"""
+            )
+            registry._db.commit()
+
+            with pytest.raises(sqlite3.IntegrityError, match="injected marker failure"):
+                registry.finalize_registration("barsik")
+
+            finalized = registry._db.execute(
+                "SELECT registration_finalized FROM agents WHERE name='barsik'"
+            ).fetchone()[0]
+            assert finalized == 0
+            assert registry.list_verified_contacts("barsik") == []
+            assert registry.get_setting(
+                "migration:verified_contacts_brad_owner_seed_v1"
+            ) == ""
+        finally:
+            registry.close()
+
+    def test_legacy_reregister_cannot_seed_unfinalized_http_claim(self, tmp_path):
+        registry = AgentRegistry(db_path=str(tmp_path / "agents.db"))
+        try:
+            registry.register(
+                "barsik",
+                create_only=True,
+                working_dir=str(tmp_path / "barsik"),
+            )
+
+            finalized = registry._db.execute(
+                "SELECT registration_finalized FROM agents WHERE name='barsik'"
+            ).fetchone()[0]
+            assert finalized == 0
+
+            # The historical upsert-style register path also invokes the seed.
+            # It must not publish bootstrap state for an HTTP claim whose
+            # provisioning/MCP stages have not finalized yet.
+            registry.register("barsik", model="sonnet")
+
+            assert registry.list_verified_contacts("barsik") == []
+            assert registry.get_setting(
+                "migration:verified_contacts_brad_owner_seed_v1"
+            ) == ""
+        finally:
+            registry.close()
+
+    def test_upgrade_backfills_existing_agent_before_migration_seed(self, tmp_path):
+        db_path = tmp_path / "agents.db"
+        legacy = AgentRegistry(db_path=str(db_path))
+        try:
+            legacy.register("barsik", working_dir=str(tmp_path / "barsik"))
+            legacy._db.execute("DELETE FROM verified_contacts WHERE agent_name='barsik'")
+            legacy._db.execute(
+                "DELETE FROM system_settings WHERE key=?",
+                ("migration:verified_contacts_brad_owner_seed_v1",),
+            )
+            legacy._db.commit()
+        finally:
+            legacy.close()
+
+        # Model a pre-R4 database: its durable Barsik row is a completed legacy
+        # registration, but neither the finalized column nor seed marker exists.
+        with sqlite3.connect(db_path) as db:
+            db.execute("ALTER TABLE agents DROP COLUMN registration_finalized")
+
+        upgraded = AgentRegistry(db_path=str(db_path))
+        try:
+            finalized = upgraded._db.execute(
+                "SELECT registration_finalized FROM agents WHERE name='barsik'"
+            ).fetchone()[0]
+            assert finalized == 1
+            assert len(upgraded.list_verified_contacts("barsik")) == 1
+            assert upgraded.get_setting(
+                "migration:verified_contacts_brad_owner_seed_v1"
+            ) == "1"
+        finally:
+            upgraded.close()
 
 
 class TestOwnerNotificationDestinations:

--- a/tests/test_agent_registry.py
+++ b/tests/test_agent_registry.py
@@ -9,7 +9,12 @@ import threading
 
 import pytest
 
-from pinky_daemon.agent_registry import AgentContext, AgentRegistry
+from pinky_daemon.agent_registry import (
+    AgentAlreadyExistsError,
+    AgentContext,
+    AgentRegistry,
+    SoulMutationRejectedError,
+)
 
 
 @pytest.fixture
@@ -548,6 +553,96 @@ class TestAgentCRUD:
         registry.register("oleg", model="sonnet")
         agent = registry.register("oleg", model="opus")
         assert agent.model == "opus"
+
+    def test_create_only_collision_preserves_winner(self, registry, tmp_path):
+        original = "# Oleg\n\n## IDENTITY\n- **Name:** Oleg\n- **Role:** Lead\n"
+        registry.register(
+            "oleg",
+            create_only=True,
+            model="opus",
+            soul=original,
+            working_dir=str(tmp_path / "winner"),
+        )
+
+        with pytest.raises(AgentAlreadyExistsError, match="already exists"):
+            registry.register(
+                "oleg",
+                create_only=True,
+                model="haiku",
+                soul="loser",
+                working_dir=str(tmp_path / "loser"),
+            )
+
+        winner = registry.get("oleg")
+        assert winner.model == "opus"
+        assert winner.soul == original
+        assert winner.working_dir == str(tmp_path / "winner")
+        assert not (tmp_path / "loser").exists()
+
+    def test_soul_update_snapshots_replaced_value_before_write(
+        self, registry, monkeypatch,
+    ):
+        original = "A" * 100
+        replacement = "B" * 75
+        registry.register("oleg", soul=original)
+        insert = registry._insert_soul_version_uncommitted
+
+        def assert_old_value_is_still_live(agent_name, content, *, source):
+            assert registry.get(agent_name).soul == original
+            assert content == original
+            assert source == "unit-test:before"
+            return insert(agent_name, content, source=source)
+
+        monkeypatch.setattr(
+            registry,
+            "_insert_soul_version_uncommitted",
+            assert_old_value_is_still_live,
+        )
+
+        updated = registry.update(
+            "oleg",
+            soul=replacement,
+            soul_source="unit-test",
+        )
+
+        assert updated.soul == replacement
+        versions = registry.get_soul_versions("oleg")
+        assert len(versions) == 1
+        assert registry.get_soul_version("oleg", versions[0]["id"])["content"] == original
+
+    def test_soul_shrink_threshold_is_strictly_more_than_half(self, registry):
+        registry.register("oleg", soul="x" * 100)
+
+        assert registry.update("oleg", soul="y" * 50).soul == "y" * 50
+
+        with pytest.raises(SoulMutationRejectedError) as rejected:
+            registry.update("oleg", soul="z" * 24)
+        assert rejected.value.summary.old_length == 50
+        assert rejected.value.summary.new_length == 24
+        assert rejected.value.summary.shrink_percent == 52.0
+        assert registry.get("oleg").soul == "y" * 50
+
+    def test_soul_identity_anchor_loss_requires_force(self, registry):
+        original = (
+            "# Oleg\n\n## IDENTITY\n- **Name:** Oleg\n- **Role:** Lead\n\n"
+            + "x" * 80
+        )
+        replacement = "# Notes\n" + "y" * (len(original) - len("# Notes\n"))
+        registry.register("oleg", display_name="Oleg", soul=original)
+
+        with pytest.raises(SoulMutationRejectedError) as rejected:
+            registry.update("oleg", soul=replacement)
+
+        assert rejected.value.summary.missing_anchors == (
+            "agent_heading",
+            "identity_heading",
+            "name_label",
+            "role_label",
+        )
+        assert registry.get("oleg").soul == original
+
+        forced = registry.update("oleg", soul=replacement, force_soul=True)
+        assert forced.soul == replacement
 
     def test_update_is_partial_and_preserves_unset_fields(self, registry):
         registry.register(

--- a/tests/test_agent_registry.py
+++ b/tests/test_agent_registry.py
@@ -644,6 +644,98 @@ class TestAgentCRUD:
         if relation == "nested":
             assert not candidate.exists()
 
+    @pytest.mark.parametrize("relation", ["equal", "nested", "enclosing"])
+    def test_concurrent_register_updates_serialize_workspace_claims(
+        self,
+        tmp_path,
+        relation,
+    ):
+        db_path = tmp_path / "agents.db"
+        registry_a = AgentRegistry(db_path=str(db_path))
+        registry_b = AgentRegistry(db_path=str(db_path))
+        try:
+            alice_root = tmp_path / "alice-original"
+            bob_root = tmp_path / "bob-original"
+            shared_root = tmp_path / "shared"
+            alice_candidate, bob_candidate = {
+                "equal": (shared_root, shared_root),
+                "nested": (shared_root, shared_root / "sub"),
+                "enclosing": (shared_root / "sub", shared_root),
+            }[relation]
+            registry_a.register("alice", working_dir=str(alice_root), model="opus")
+            registry_a.register("bob", working_dir=str(bob_root), model="opus")
+
+            phase_barrier = threading.Barrier(2)
+
+            def gate_advisory_check(candidate_registry):
+                original = candidate_registry._refuse_workspace_overlap
+                call_count = 0
+
+                def wrapped(name, root):
+                    nonlocal call_count
+                    original(name, root)
+                    call_count += 1
+                    if call_count == 1:
+                        phase_barrier.wait(timeout=5)
+
+                candidate_registry._refuse_workspace_overlap = wrapped
+
+            gate_advisory_check(registry_a)
+            gate_advisory_check(registry_b)
+            outcomes = {}
+
+            def move(candidate_registry, name, candidate_root):
+                try:
+                    outcomes[name] = candidate_registry.register(
+                        name,
+                        working_dir=str(candidate_root),
+                        model="haiku",
+                    )
+                except BaseException as exc:
+                    outcomes[name] = exc
+
+            threads = [
+                threading.Thread(
+                    target=move,
+                    args=(registry_a, "alice", alice_candidate),
+                ),
+                threading.Thread(
+                    target=move,
+                    args=(registry_b, "bob", bob_candidate),
+                ),
+            ]
+            for thread in threads:
+                thread.start()
+            for thread in threads:
+                thread.join(timeout=10)
+
+            assert all(not thread.is_alive() for thread in threads)
+            winners = [
+                name for name, outcome in outcomes.items()
+                if not isinstance(outcome, BaseException)
+            ]
+            losers = [
+                name for name, outcome in outcomes.items()
+                if isinstance(outcome, AgentWorkspaceOverlapError)
+            ]
+            assert len(winners) == 1
+            assert len(losers) == 1
+
+            winner = registry_a.get(winners[0])
+            loser = registry_a.get(losers[0])
+            winner_root = (
+                alice_candidate if winners[0] == "alice" else bob_candidate
+            )
+            assert winner.working_dir == str(winner_root)
+            assert winner.model == "haiku"
+            assert loser.working_dir == str(
+                alice_root if losers[0] == "alice" else bob_root
+            )
+            assert loser.model == "opus"
+        finally:
+            registry_a.close()
+            registry_b.close()
+
     def test_soul_update_snapshots_replaced_value_before_write(
         self, registry, monkeypatch,
     ):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1456,17 +1456,16 @@ class TestAPI:
                 assert "boom" in r.text
                 assert client.get("/agents/tenant").status_code == 404  # rolled back
 
-    def test_register_upsert_keeps_existing_agent_on_provision_failure(self, monkeypatch):
-        """#638: POST /agents is an UPSERT — a provision failure must only roll
-        back a NEWLY created agent. A pre-existing agent re-POSTed through a
-        failing provisioner is KEPT (500 says so explicitly): hard-deleting it
-        over a transient podman error would destroy a live tenant."""
+    def test_register_collision_never_reprovisions_existing_agent(self, monkeypatch):
+        """Create rollback remains, while collisions stop before provisioning."""
         from pinky_daemon import provisioning
 
         fail = {"on": False}
+        provision_calls = []
 
         class _TogglableProv:
             def provision(self, agent):
+                provision_calls.append(agent.name)
                 if fail["on"]:
                     return provisioning.ProvisionResult(
                         ok=False, mode="container", message="podman flaked"
@@ -1491,18 +1490,20 @@ class TestAPI:
                 assert "existing agent kept" not in r.text  # new-agent branch
                 assert client.get("/agents/newbie").status_code == 404
 
-                # Case B: agent exists (provision succeeded), then a re-POST
-                # hits a failing provisioner -> 500 but the agent SURVIVES.
+                # Case B: once the agent exists, re-POST is a DB collision.
+                # It never reaches the now-failing provisioner and the winner
+                # remains unchanged.
                 fail["on"] = False
                 r = client.post("/agents", json={"name": "tenant", "model": "sonnet"})
                 assert r.status_code == 200
+                calls_before_collision = list(provision_calls)
 
                 fail["on"] = True
-                r = client.post("/agents", json={"name": "tenant", "model": "sonnet"})
-                assert r.status_code == 500
-                assert "podman flaked" in r.text
-                assert "existing agent kept" in r.text
+                r = client.post("/agents", json={"name": "tenant", "model": "haiku"})
+                assert r.status_code == 409
+                assert provision_calls == calls_before_collision
                 assert client.get("/agents/tenant").status_code == 200  # NOT deleted
+                assert client.get("/agents/tenant").json()["model"] == "sonnet"
 
     def test_container_agent_mcp_json_carries_bearer_auth(self, monkeypatch):
         """#638/#623: a container agent's .mcp.json points every pinky-* server
@@ -5660,6 +5661,243 @@ class TestAgentCRUD:
         data = resp.json()
         assert data["display_name"] == "Bob"
         assert data["soul"] == "You are Bob, a helpful assistant."
+
+    def test_post_existing_returns_409_without_mutation(self, tmp_path):
+        client = self._make_client()
+        original = "winner-private-soul"
+        payload = {
+            "name": "alice",
+            "model": "opus",
+            "soul": original,
+            "working_dir": str(tmp_path / "alice"),
+        }
+        assert client.post("/agents", json=payload).status_code == 200
+
+        collision = client.post(
+            "/agents",
+            json={
+                **payload,
+                "model": "haiku",
+                "soul": "loser-must-not-land",
+                "working_dir": str(tmp_path / "loser"),
+            },
+        )
+
+        assert collision.status_code == 409
+        current = client.get("/agents/alice").json()
+        assert current["model"] == "opus"
+        assert current["soul"] == original
+        assert current["working_dir"] == str(tmp_path / "alice")
+        assert not (tmp_path / "loser").exists()
+
+    def test_concurrent_double_post_has_one_db_winner(self, tmp_path):
+        from pinky_daemon.api import create_api
+
+        db_path = str(tmp_path / "agents.db")
+        app_a = create_api(
+            max_sessions=10,
+            default_working_dir=str(tmp_path),
+            db_path=db_path,
+        )
+        app_b = create_api(
+            max_sessions=10,
+            default_working_dir=str(tmp_path),
+            db_path=db_path,
+        )
+        barrier = threading.Barrier(2)
+        responses = []
+        payloads = [
+            {
+                "name": "race",
+                "display_name": "First",
+                "model": "opus",
+                "soul": "first-private-soul",
+                "working_dir": str(tmp_path / "first"),
+            },
+            {
+                "name": "race",
+                "display_name": "Second",
+                "model": "haiku",
+                "soul": "second-private-soul",
+                "working_dir": str(tmp_path / "second"),
+            },
+        ]
+
+        def post(client, payload):
+            barrier.wait(timeout=5)
+            responses.append((payload, client.post("/agents", json=payload)))
+
+        with TestClient(app_a) as client_a, TestClient(app_b) as client_b:
+            threads = [
+                threading.Thread(target=post, args=(client_a, payloads[0])),
+                threading.Thread(target=post, args=(client_b, payloads[1])),
+            ]
+            for thread in threads:
+                thread.start()
+            for thread in threads:
+                thread.join(timeout=10)
+            assert all(not thread.is_alive() for thread in threads)
+
+            assert sorted(response.status_code for _, response in responses) == [200, 409]
+            winning_payload, winning_response = next(
+                pair for pair in responses if pair[1].status_code == 200
+            )
+            losing_payload, _ = next(
+                pair for pair in responses if pair[1].status_code == 409
+            )
+            current = client_a.get("/agents/race").json()
+            assert winning_response.json()["soul"] == winning_payload["soul"]
+            assert current["display_name"] == winning_payload["display_name"]
+            assert current["model"] == winning_payload["model"]
+            assert current["soul"] == winning_payload["soul"]
+            assert current["working_dir"] == winning_payload["working_dir"]
+            assert not Path(losing_payload["working_dir"]).exists()
+
+    def test_absent_soul_is_noop_empty_rejects_and_force_snapshots(self, tmp_path):
+        client = self._make_client()
+        original = (
+            "# Alice\n\n## IDENTITY\n- **Name:** Alice\n- **Role:** Lead\n\n"
+            + "private-old-soul-" * 12
+        )
+        assert client.post(
+            "/agents",
+            json={
+                "name": "alice",
+                "display_name": "Alice",
+                "soul": original,
+                "working_dir": str(tmp_path / "alice"),
+            },
+        ).status_code == 200
+        registry = client.app.state.agents
+        assert registry.get_soul_versions("alice") == []
+
+        absent = client.put("/agents/alice", json={"model": "sonnet"})
+        assert absent.status_code == 200
+        assert absent.json()["soul"] == original
+        assert registry.get_soul_versions("alice") == []
+
+        rejected = client.put("/agents/alice", json={"soul": ""})
+        assert rejected.status_code == 400
+        detail = rejected.json()["detail"]
+        assert detail == {
+            "code": "soul_mutation_requires_force",
+            "old_length": len(original),
+            "new_length": 0,
+            "shrink_percent": 100.0,
+            "missing_anchors": [
+                "agent_heading",
+                "identity_heading",
+                "name_label",
+                "role_label",
+            ],
+        }
+        assert "private-old-soul" not in rejected.text
+        assert registry.get("alice").soul == original
+        assert registry.get_soul_versions("alice") == []
+
+        forced = client.put(
+            "/agents/alice",
+            json={"soul": "", "force_soul": True},
+        )
+        assert forced.status_code == 200
+        assert forced.json()["soul"] == ""
+        versions = registry.get_soul_versions("alice")
+        assert len(versions) == 1
+        assert versions[0]["source"] == "api-put-force:before"
+        assert registry.get_soul_version("alice", versions[0]["id"])["content"] == original
+
+    def test_direct_claude_md_write_uses_guard_and_force_snapshot(self, tmp_path):
+        client = self._make_client()
+        work_dir = tmp_path / "alice"
+        original = "private-file-soul-" * 10
+        assert client.post(
+            "/agents",
+            json={
+                "name": "alice",
+                "soul": original,
+                "working_dir": str(work_dir),
+            },
+        ).status_code == 200
+        claude_md = work_dir / "CLAUDE.md"
+        assert not claude_md.exists()
+
+        rejected = client.put(
+            "/agents/alice/files/CLAUDE.md",
+            json={"content": "short"},
+        )
+        assert rejected.status_code == 400
+        assert "private-file-soul" not in rejected.text
+        assert not claude_md.exists()
+        assert client.app.state.agents.get_soul_versions("alice") == []
+
+        forced = client.put(
+            "/agents/alice/files/CLAUDE.md",
+            json={"content": "short", "force_soul": True},
+        )
+        assert forced.status_code == 200
+        assert claude_md.read_text() == "short"
+        versions = client.app.state.agents.get_soul_versions("alice")
+        assert len(versions) == 1
+        assert versions[0]["source"] == "api-file-force:before-file"
+        assert client.app.state.agents.get_soul_version(
+            "alice", versions[0]["id"]
+        )["content"] == original
+
+        alias = work_dir / "soul-link"
+        alias.symlink_to(claude_md.name)
+        alias_rejected = client.put(
+            "/agents/alice/files/soul-link",
+            json={"content": ""},
+        )
+        assert alias_rejected.status_code == 400
+        assert claude_md.read_text() == "short"
+        assert len(client.app.state.agents.get_soul_versions("alice")) == 1
+
+        lowercase_rejected = client.put(
+            "/agents/alice/files/claude.md",
+            json={"content": ""},
+        )
+        assert lowercase_rejected.status_code == 400
+        assert claude_md.read_text() == "short"
+        assert len(client.app.state.agents.get_soul_versions("alice")) == 1
+
+    def test_restore_shorter_soul_requires_explicit_force(self, tmp_path):
+        client = self._make_client()
+        work_dir = tmp_path / "alice"
+        original = "private-current-soul-" * 12
+        target = "old-short-soul"
+        assert client.post(
+            "/agents",
+            json={
+                "name": "alice",
+                "soul": original,
+                "working_dir": str(work_dir),
+            },
+        ).status_code == 200
+        work_dir.mkdir(parents=True, exist_ok=True)
+        claude_md = work_dir / "CLAUDE.md"
+        claude_md.write_text(original)
+        registry = client.app.state.agents
+        version_id = registry.save_soul_version("alice", target, source="fixture")
+
+        rejected = client.post(f"/agents/alice/soul/versions/{version_id}/restore")
+        assert rejected.status_code == 400
+        assert "private-current-soul" not in rejected.text
+        assert registry.get("alice").soul == original
+        assert claude_md.read_text() == original
+        assert len(registry.get_soul_versions("alice")) == 1
+
+        restored = client.post(
+            f"/agents/alice/soul/versions/{version_id}/restore",
+            json={"force_soul": True},
+        )
+        assert restored.status_code == 200
+        assert restored.json()["force_soul"] is True
+        assert registry.get("alice").soul == target
+        assert claude_md.read_text() == target
+        sources = [row["source"] for row in registry.get_soul_versions("alice")]
+        assert "restore-v%d-force:before" % version_id in sources
+        assert "restore-v%d-force:before-file" % version_id in sources
 
     def test_list_agents_empty(self):
         client = self._make_client()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -5695,9 +5695,11 @@ class TestAgentCRUD:
     ):
         import pinky_daemon.api as api_module
         from pinky_daemon import provisioning
+        from pinky_daemon.agent_registry import AgentRegistry
 
         provisioned = []
         deprovisioned = []
+        observed_at_mcp_gap = {}
 
         class SuccessfulProvisioner:
             def provision(self, agent):
@@ -5715,6 +5717,24 @@ class TestAgentCRUD:
         )
 
         def fail_mcp(*_args, **_kwargs):
+            # Reproduce the migration race: a second registry starts after the
+            # HTTP claim committed and provisioning succeeded, but before MCP
+            # publication fails and compensation removes the claim row.
+            concurrent_registry = AgentRegistry(db_path=registry._db_path)
+            try:
+                observed_at_mcp_gap.update(
+                    agent_exists=concurrent_registry.get("barsik") is not None,
+                    finalized=concurrent_registry._db.execute(
+                        "SELECT registration_finalized FROM agents "
+                        "WHERE name='barsik'"
+                    ).fetchone()[0],
+                    contacts=concurrent_registry.list_verified_contacts("barsik"),
+                    marker=concurrent_registry.get_setting(
+                        "migration:verified_contacts_brad_owner_seed_v1"
+                    ),
+                )
+            finally:
+                concurrent_registry.close()
             raise RuntimeError("injected MCP publication failure")
 
         monkeypatch.setattr(api_module, "_write_mcp_json", fail_mcp)
@@ -5730,6 +5750,12 @@ class TestAgentCRUD:
         assert response.status_code == 500
         assert provisioned == ["barsik"]
         assert deprovisioned == ["barsik"]
+        assert observed_at_mcp_gap == {
+            "agent_exists": True,
+            "finalized": 0,
+            "contacts": [],
+            "marker": "",
+        }
         self._assert_failed_registration_left_no_state(
             client,
             "barsik",
@@ -5742,6 +5768,8 @@ class TestAgentCRUD:
         ) == ""
 
     def test_successful_barsik_registration_finalizes_bootstrap_state(self, tmp_path):
+        from pinky_daemon.agent_registry import AgentRegistry
+
         client = self._make_client()
         registry = client.app.state.agents
 
@@ -5759,6 +5787,22 @@ class TestAgentCRUD:
         assert registry.get_setting(
             "migration:verified_contacts_brad_owner_seed_v1"
         ) == "1"
+        finalized = registry._db.execute(
+            "SELECT registration_finalized FROM agents WHERE name='barsik'"
+        ).fetchone()[0]
+        assert finalized == 1
+
+        # A post-success registry startup runs migration seeding again. The
+        # marker/unique key make that pass idempotent, as is a repeat finalize.
+        concurrent_registry = AgentRegistry(db_path=registry._db_path)
+        try:
+            concurrent_registry.finalize_registration("barsik")
+            assert len(concurrent_registry.list_verified_contacts("barsik")) == 1
+            assert concurrent_registry.get_setting(
+                "migration:verified_contacts_brad_owner_seed_v1"
+            ) == "1"
+        finally:
+            concurrent_registry.close()
 
     def test_register_failure_restores_preexisting_workspace_files(
         self,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -5615,6 +5615,164 @@ class TestAgentCRUD:
         app = create_api(max_sessions=10, default_working_dir="/tmp", db_path=path)
         return TestClient(app)
 
+    @staticmethod
+    def _assert_failed_registration_left_no_state(
+        client,
+        name,
+        work_dir,
+        main_agent_before,
+    ):
+        registry = client.app.state.agents
+        assert registry.get(name) is None
+        assert registry.get_signing_key(name) is None
+        assert registry.get_main_agent() == main_agent_before
+        assert not work_dir.exists()
+
+    def test_register_signing_key_failure_compensates_every_winner_side_effect(
+        self,
+        monkeypatch,
+        tmp_path,
+    ):
+        client = self._make_client()
+        registry = client.app.state.agents
+        work_dir = tmp_path / "signing-failure"
+        main_agent_before = registry.get_main_agent()
+
+        def fail_signing_key(_name):
+            raise RuntimeError("injected signing-key failure")
+
+        monkeypatch.setattr(registry, "get_or_create_signing_key", fail_signing_key)
+
+        response = client.post(
+            "/agents",
+            json={"name": "signing-failure", "working_dir": str(work_dir)},
+        )
+
+        assert response.status_code == 500
+        assert response.json()["detail"] == {"code": "agent_registration_failed"}
+        self._assert_failed_registration_left_no_state(
+            client,
+            "signing-failure",
+            work_dir,
+            main_agent_before,
+        )
+
+    def test_register_mcp_failure_compensates_every_winner_side_effect(
+        self,
+        monkeypatch,
+        tmp_path,
+    ):
+        import pinky_daemon.api as api_module
+
+        client = self._make_client()
+        registry = client.app.state.agents
+        work_dir = tmp_path / "mcp-failure"
+        main_agent_before = registry.get_main_agent()
+
+        def fail_mcp(*_args, **_kwargs):
+            raise RuntimeError("injected MCP publication failure")
+
+        monkeypatch.setattr(api_module, "_write_mcp_json", fail_mcp)
+
+        response = client.post(
+            "/agents",
+            json={"name": "mcp-failure", "working_dir": str(work_dir)},
+        )
+
+        assert response.status_code == 500
+        assert response.json()["detail"] == {"code": "agent_registration_failed"}
+        self._assert_failed_registration_left_no_state(
+            client,
+            "mcp-failure",
+            work_dir,
+            main_agent_before,
+        )
+
+    def test_register_failure_restores_preexisting_workspace_files(
+        self,
+        monkeypatch,
+        tmp_path,
+    ):
+        import pinky_daemon.api as api_module
+
+        client = self._make_client()
+        registry = client.app.state.agents
+        work_dir = tmp_path / "preexisting"
+        claude_dir = work_dir / ".claude"
+        claude_dir.mkdir(parents=True)
+        marker = work_dir / "operator-marker"
+        marker.write_text("operator-private")
+        settings = claude_dir / "settings.json"
+        settings.write_text('{"operator": true}\n')
+
+        def fail_mcp(*_args, **_kwargs):
+            raise RuntimeError("injected MCP publication failure")
+
+        monkeypatch.setattr(api_module, "_write_mcp_json", fail_mcp)
+
+        response = client.post(
+            "/agents",
+            json={"name": "preexisting", "working_dir": str(work_dir)},
+        )
+
+        assert response.status_code == 500
+        assert registry.get("preexisting") is None
+        assert registry.get_signing_key("preexisting") is None
+        assert registry.get_main_agent() == ""
+        assert marker.read_text() == "operator-private"
+        assert settings.read_text() == '{"operator": true}\n'
+        assert sorted(path.name for path in claude_dir.iterdir()) == ["settings.json"]
+        assert not (work_dir / ".mcp.json").exists()
+        assert not (work_dir / "data").exists()
+        assert not (work_dir / "output").exists()
+        assert not (work_dir / "workspace").exists()
+
+    def test_register_provision_failure_compensates_every_winner_side_effect(
+        self,
+        monkeypatch,
+        tmp_path,
+    ):
+        from pinky_daemon import provisioning
+
+        deprovisioned = []
+
+        class FailingProvisioner:
+            def provision(self, agent):
+                return provisioning.ProvisionResult(
+                    ok=False,
+                    mode="container",
+                    message="injected provision failure",
+                )
+
+            def deprovision(self, agent):
+                deprovisioned.append(agent.name)
+                return provisioning.ProvisionResult(ok=True, mode="container")
+
+        monkeypatch.setattr(
+            provisioning,
+            "get_provisioner",
+            lambda _mode, **_kwargs: FailingProvisioner(),
+        )
+        client = self._make_client()
+        registry = client.app.state.agents
+        work_dir = tmp_path / "provision-failure"
+        main_agent_before = registry.get_main_agent()
+
+        response = client.post(
+            "/agents",
+            json={"name": "provision-failure", "working_dir": str(work_dir)},
+        )
+
+        assert response.status_code == 500
+        assert "injected provision failure" in response.text
+        assert deprovisioned == ["provision-failure"]
+        self._assert_failed_registration_left_no_state(
+            client,
+            "provision-failure",
+            work_dir,
+            main_agent_before,
+        )
+
     def test_register_agent(self):
         client = self._make_client()
         resp = client.post("/agents", json={
@@ -5632,6 +5790,100 @@ class TestAgentCRUD:
         assert data["transport"] == "sdk"
         assert data["provider_url"] == "codex_cli"
         assert data["provider_model"] == "gpt-5-codex"
+
+    def test_invalid_agent_name_is_content_free_400_at_every_mutation_surface(self):
+        client = self._make_client()
+        responses = [
+            client.post("/agents", json={"name": "../victim"}),
+            client.put("/agents/BAD", json={"model": "haiku"}),
+            client.post("/agents/BAD/soul/versions/1/restore"),
+            client.put(
+                "/agents/BAD/files/CLAUDE.md",
+                json={"content": "must-not-land", "force_soul": True},
+            ),
+        ]
+
+        for response in responses:
+            assert response.status_code == 400
+            assert response.json()["detail"] == {"code": "invalid_agent_name"}
+            assert "victim" not in response.text
+            assert "BAD" not in response.text
+
+    @pytest.mark.parametrize("relation", ["equal", "nested", "enclosing"])
+    def test_register_refuses_cross_agent_workspace_overlap_without_side_effects(
+        self,
+        tmp_path,
+        relation,
+    ):
+        client = self._make_client()
+        victim_root = tmp_path / "victim"
+        assert client.post(
+            "/agents",
+            json={"name": "victim", "working_dir": str(victim_root)},
+        ).status_code == 200
+        marker = victim_root / "identity-marker"
+        marker.write_text("victim-private")
+        candidate = {
+            "equal": victim_root,
+            "nested": victim_root / "nested-attacker",
+            "enclosing": tmp_path,
+        }[relation]
+
+        refused = client.post(
+            "/agents",
+            json={
+                "name": "attacker",
+                "working_dir": str(candidate),
+                "soul": "must-not-land",
+            },
+        )
+
+        assert refused.status_code == 409
+        assert refused.json()["detail"] == {"code": "agent_workspace_overlap"}
+        assert client.app.state.agents.get("attacker") is None
+        assert marker.read_text() == "victim-private"
+        if relation == "nested":
+            assert not candidate.exists()
+
+    @pytest.mark.parametrize("relation", ["equal", "nested", "enclosing"])
+    def test_update_refuses_cross_agent_workspace_overlap_before_config_mutation(
+        self,
+        tmp_path,
+        relation,
+    ):
+        client = self._make_client()
+        victim_root = tmp_path / "victim"
+        mover_root = tmp_path / "mover"
+        assert client.post(
+            "/agents",
+            json={"name": "victim", "working_dir": str(victim_root)},
+        ).status_code == 200
+        assert client.post(
+            "/agents",
+            json={
+                "name": "mover",
+                "working_dir": str(mover_root),
+                "model": "opus",
+            },
+        ).status_code == 200
+        candidate = {
+            "equal": victim_root,
+            "nested": victim_root / "nested-mover",
+            "enclosing": tmp_path,
+        }[relation]
+
+        refused = client.put(
+            "/agents/mover",
+            json={"working_dir": str(candidate), "model": "haiku"},
+        )
+
+        assert refused.status_code == 409
+        assert refused.json()["detail"] == {"code": "agent_workspace_overlap"}
+        mover = client.app.state.agents.get("mover")
+        assert mover.working_dir == str(mover_root)
+        assert mover.model == "opus"
+        if relation == "nested":
+            assert not candidate.exists()
 
     def test_update_agent_runtime(self):
         client = self._make_client()
@@ -5853,6 +6105,16 @@ class TestAgentCRUD:
         assert claude_md.read_text() == "short"
         assert len(client.app.state.agents.get_soul_versions("alice")) == 1
 
+        hardlink = work_dir / "soul-hardlink"
+        os.link(claude_md, hardlink)
+        hardlink_rejected = client.put(
+            "/agents/alice/files/soul-hardlink",
+            json={"content": ""},
+        )
+        assert hardlink_rejected.status_code == 400
+        assert claude_md.read_text() == "short"
+        assert len(client.app.state.agents.get_soul_versions("alice")) == 1
+
         lowercase_rejected = client.put(
             "/agents/alice/files/claude.md",
             json={"content": ""},
@@ -5860,6 +6122,112 @@ class TestAgentCRUD:
         assert lowercase_rejected.status_code == 400
         assert claude_md.read_text() == "short"
         assert len(client.app.state.agents.get_soul_versions("alice")) == 1
+
+        outside_soul = tmp_path / "outside-soul"
+        outside_soul.write_text("outside-private")
+        outside_alias = work_dir / "outside-link"
+        outside_alias.symlink_to(outside_soul)
+        outside_rejected = client.put(
+            "/agents/alice/files/outside-link",
+            json={"content": "must-not-land", "force_soul": True},
+        )
+        assert outside_rejected.status_code == 400
+        assert outside_rejected.json()["detail"] == {
+            "code": "agent_path_outside_workspace"
+        }
+        assert outside_soul.read_text() == "outside-private"
+        assert len(client.app.state.agents.get_soul_versions("alice")) == 1
+
+    def test_guarded_write_replaces_hardlink_without_mutating_external_inode(
+        self,
+        tmp_path,
+    ):
+        client = self._make_client()
+        work_dir = tmp_path / "alice"
+        original = "external-private-soul-" * 8
+        replacement = "compiled-safe-replacement"
+        assert client.post(
+            "/agents",
+            json={
+                "name": "alice",
+                "soul": original,
+                "working_dir": str(work_dir),
+            },
+        ).status_code == 200
+        outside = tmp_path / "external-claude"
+        outside.write_text(original)
+        claude_md = work_dir / "CLAUDE.md"
+        os.link(outside, claude_md)
+        shared_inode = outside.stat().st_ino
+        assert claude_md.stat().st_ino == shared_inode
+
+        written = client.put(
+            "/agents/alice/files/CLAUDE.md",
+            json={"content": replacement, "force_soul": True},
+        )
+
+        assert written.status_code == 200
+        assert claude_md.read_text() == replacement
+        assert outside.read_text() == original
+        assert outside.stat().st_ino == shared_inode
+        assert claude_md.stat().st_ino != shared_inode
+
+    def test_restore_refuses_outside_claude_symlink_before_db_or_file_mutation(
+        self,
+        tmp_path,
+    ):
+        client = self._make_client()
+        registry = client.app.state.agents
+        work_dir = tmp_path / "alice"
+        current = "current-private-soul-" * 8
+        target = "archived-target-soul"
+        assert client.post(
+            "/agents",
+            json={
+                "name": "alice",
+                "soul": current,
+                "working_dir": str(work_dir),
+            },
+        ).status_code == 200
+        version_id = registry.save_soul_version("alice", target, source="test")
+        outside = tmp_path / "outside-restore-target"
+        outside.write_text("outside-byte-identical")
+        (work_dir / "CLAUDE.md").symlink_to(outside)
+
+        restored = client.post(
+            f"/agents/alice/soul/versions/{version_id}/restore",
+            json={"force_soul": True},
+        )
+
+        assert restored.status_code == 400
+        assert restored.json()["detail"] == {
+            "code": "agent_path_outside_workspace"
+        }
+        assert registry.get("alice").soul == current
+        assert outside.read_text() == "outside-byte-identical"
+
+    def test_spawn_publication_refuses_outside_claude_symlink(self, tmp_path):
+        client = self._make_client()
+        work_dir = tmp_path / "alice"
+        assert client.post(
+            "/agents",
+            json={
+                "name": "alice",
+                "soul": "db-authoritative-soul",
+                "working_dir": str(work_dir),
+            },
+        ).status_code == 200
+        outside = tmp_path / "outside-spawn-target"
+        outside.write_text("outside-byte-identical")
+        (work_dir / "CLAUDE.md").symlink_to(outside)
+
+        spawned = client.post("/agents/alice/sessions", json={})
+
+        assert spawned.status_code == 400
+        assert spawned.json()["detail"] == {
+            "code": "agent_path_outside_workspace"
+        }
+        assert outside.read_text() == "outside-byte-identical"
 
     def test_restore_shorter_soul_requires_explicit_force(self, tmp_path):
         client = self._make_client()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -5688,6 +5688,78 @@ class TestAgentCRUD:
             main_agent_before,
         )
 
+    def test_register_mcp_failure_leaves_no_barsik_bootstrap_state(
+        self,
+        monkeypatch,
+        tmp_path,
+    ):
+        import pinky_daemon.api as api_module
+        from pinky_daemon import provisioning
+
+        provisioned = []
+        deprovisioned = []
+
+        class SuccessfulProvisioner:
+            def provision(self, agent):
+                provisioned.append(agent.name)
+                return provisioning.ProvisionResult(ok=True, mode="local")
+
+            def deprovision(self, agent):
+                deprovisioned.append(agent.name)
+                return provisioning.ProvisionResult(ok=True, mode="local")
+
+        monkeypatch.setattr(
+            provisioning,
+            "get_provisioner",
+            lambda _mode, **_kwargs: SuccessfulProvisioner(),
+        )
+
+        def fail_mcp(*_args, **_kwargs):
+            raise RuntimeError("injected MCP publication failure")
+
+        monkeypatch.setattr(api_module, "_write_mcp_json", fail_mcp)
+        client = self._make_client()
+        registry = client.app.state.agents
+        work_dir = tmp_path / "barsik"
+
+        response = client.post(
+            "/agents",
+            json={"name": "barsik", "working_dir": str(work_dir)},
+        )
+
+        assert response.status_code == 500
+        assert provisioned == ["barsik"]
+        assert deprovisioned == ["barsik"]
+        self._assert_failed_registration_left_no_state(
+            client,
+            "barsik",
+            work_dir,
+            "",
+        )
+        assert registry.list_verified_contacts("barsik") == []
+        assert registry.get_setting(
+            "migration:verified_contacts_brad_owner_seed_v1"
+        ) == ""
+
+    def test_successful_barsik_registration_finalizes_bootstrap_state(self, tmp_path):
+        client = self._make_client()
+        registry = client.app.state.agents
+
+        response = client.post(
+            "/agents",
+            json={"name": "barsik", "working_dir": str(tmp_path / "barsik")},
+        )
+
+        assert response.status_code == 200
+        contacts = registry.list_verified_contacts("barsik")
+        assert len(contacts) == 1
+        assert contacts[0]["platform"] == "buzz"
+        assert contacts[0]["name"] == "Brad"
+        assert contacts[0]["role"] == "owner"
+        assert registry.get_setting(
+            "migration:verified_contacts_brad_owner_seed_v1"
+        ) == "1"
+
     def test_register_failure_restores_preexisting_workspace_files(
         self,
         monkeypatch,
@@ -6004,6 +6076,115 @@ class TestAgentCRUD:
             assert current["soul"] == winning_payload["soul"]
             assert current["working_dir"] == winning_payload["working_dir"]
             assert not Path(losing_payload["working_dir"]).exists()
+
+    @pytest.mark.parametrize("relation", ["equal", "nested", "enclosing"])
+    def test_concurrent_different_names_same_workspace_has_one_owner(
+        self,
+        tmp_path,
+        relation,
+    ):
+        from pinky_daemon.api import create_api
+
+        db_path = str(tmp_path / "agents.db")
+        shared_root = tmp_path / "shared"
+        alice_root, bob_root = {
+            "equal": (shared_root, shared_root),
+            "nested": (shared_root, shared_root / "sub"),
+            "enclosing": (shared_root / "sub", shared_root),
+        }[relation]
+        app_a = create_api(
+            max_sessions=10,
+            default_working_dir=str(tmp_path),
+            db_path=db_path,
+        )
+        app_b = create_api(
+            max_sessions=10,
+            default_working_dir=str(tmp_path),
+            db_path=db_path,
+        )
+        phase_barrier = threading.Barrier(2)
+        alice_done = threading.Event()
+
+        def gate_advisory_checks(registry, *, wait_for_alice):
+            original = registry._refuse_workspace_overlap
+            call_count = 0
+
+            def wrapped(name, root):
+                nonlocal call_count
+                original(name, root)
+                call_count += 1
+                # Both route and registry pre-insert checks must observe the
+                # empty DB before either request reaches BEGIN IMMEDIATE. The
+                # third call is the authoritative in-transaction recheck.
+                if call_count <= 2:
+                    phase_barrier.wait(timeout=5)
+                if call_count == 2 and wait_for_alice:
+                    assert alice_done.wait(timeout=10)
+
+            registry._refuse_workspace_overlap = wrapped
+
+        gate_advisory_checks(app_a.state.agents, wait_for_alice=False)
+        gate_advisory_checks(app_b.state.agents, wait_for_alice=True)
+        payloads = [
+            {
+                "name": "alice",
+                "display_name": "Alice",
+                "model": "opus",
+                "soul": "alice-private-soul",
+                "working_dir": str(alice_root),
+            },
+            {
+                "name": "bob",
+                "display_name": "Bob",
+                "model": "haiku",
+                "soul": "bob-private-soul",
+                "working_dir": str(bob_root),
+            },
+        ]
+        responses = {}
+
+        def post(client, payload):
+            try:
+                responses[payload["name"]] = client.post("/agents", json=payload)
+            finally:
+                if payload["name"] == "alice":
+                    alice_done.set()
+
+        with TestClient(app_a) as client_a, TestClient(app_b) as client_b:
+            threads = [
+                threading.Thread(target=post, args=(client_a, payloads[0])),
+                threading.Thread(target=post, args=(client_b, payloads[1])),
+            ]
+            for thread in threads:
+                thread.start()
+            for thread in threads:
+                thread.join(timeout=10)
+
+            assert all(not thread.is_alive() for thread in threads)
+            assert sorted(response.status_code for response in responses.values()) == [200, 409]
+            winner_name = next(
+                name for name, response in responses.items()
+                if response.status_code == 200
+            )
+            loser_name = next(
+                name for name, response in responses.items()
+                if response.status_code == 409
+            )
+            assert responses[loser_name].json() == {
+                "detail": {"code": "agent_workspace_overlap"}
+            }
+
+            registry = app_a.state.agents
+            assert [agent.name for agent in registry.list()] == [winner_name]
+            winner_root = alice_root if winner_name == "alice" else bob_root
+            assert registry.get(winner_name).working_dir == str(winner_root)
+            assert registry.get(loser_name) is None
+            assert registry.get_signing_key(winner_name)
+            assert registry.get_signing_key(loser_name) is None
+            assert registry.get_main_agent() == winner_name
+            assert registry.get_soul_versions(loser_name) == []
+            assert registry.list_tokens(loser_name) == []
+            assert (winner_root / ".mcp.json").is_file()
 
     def test_absent_soul_is_noop_empty_rejects_and_force_snapshots(self, tmp_path):
         client = self._make_client()

--- a/tests/test_grandfather_migration.py
+++ b/tests/test_grandfather_migration.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
 import pytest
 
@@ -23,7 +24,7 @@ from pinky_daemon.sessions import SessionManager
 def migration_stores(tmp_path):
     registry = AgentRegistry(db_path=str(tmp_path / "agents.db"))
     conversations = ConversationStore(db_path=str(tmp_path / "conversations.db"))
-    registry.register("kuzya", working_dir=str(tmp_path))
+    registry.register("kuzya", working_dir=str(tmp_path / "kuzya"))
     yield registry, conversations
     conversations.close()
     registry.close()
@@ -89,8 +90,9 @@ def test_migration_unions_active_groups_and_tool_sends_only(migration_stores):
 
 def test_outbound_history_uses_exact_agent_main_session(migration_stores):
     registry, conversations = migration_stores
+    agents_root = Path(registry.get("kuzya").working_dir).parent
     for agent_name in ("foo", "foo-bar", "a_b", "axb"):
-        registry.register(agent_name, working_dir=registry.get("kuzya").working_dir)
+        registry.register(agent_name, working_dir=str(agents_root / agent_name))
     _tool_send(conversations, "FROM_FOO_BAR", agent_name="foo-bar")
     _tool_send(conversations, "FROM_AXB", agent_name="axb")
 

--- a/tests/test_pinky_self_tools.py
+++ b/tests/test_pinky_self_tools.py
@@ -2357,11 +2357,20 @@ class TestRegisterAgent:
         # POST /agents genuinely fails on e.g. an invalid name
         # (_validate_agent_name → 400), and the error must surface.
         with _mock_api({
-            "/agents": {"error": "invalid agent name", "status": 400},
+            "/agents": {
+                "error": '{"detail":{"code":"invalid_agent_name"}}',
+                "status": 400,
+            },
             "*": {},
         }):
-            out = _tools(srv)["register_agent"](name="mora", role="worker")
+            out = _tools(srv)["register_agent"](
+                name="../victim",
+                role="worker",
+            )
         assert "Failed to register" in out
+        assert "HTTP 400" in out
+        assert "invalid_agent_name" in out
+        assert "victim" not in out
 
     def test_existing_name_refused(self, srv):
         # The API's DB-level collision is authoritative; MCP surfaces its 409.

--- a/tests/test_pinky_self_tools.py
+++ b/tests/test_pinky_self_tools.py
@@ -2319,11 +2319,9 @@ class TestRegisterAgent:
     def test_creates_and_assigns_skills(self, srv):
         # Mock ordering (matched in insertion order, method-blind):
         #   /skills/      → skill-assign POSTs
-        #   /agents/mora  → the create-only GET pre-check; "error" body = not found
         #   /agents       → the POST create
         with _mock_api({
             "/skills/": {"assigned": True},
-            "/agents/mora": {"error": "not found", "status": 404},
             "/agents": {"name": "mora", "display_name": "Mora", "model": "opus"},
             "*": {},
         }):
@@ -2345,7 +2343,6 @@ class TestRegisterAgent:
     def test_privileged_role_with_confirm_proceeds(self, srv):
         with _mock_api({
             "/skills/": {"assigned": True},
-            "/agents/mora": {"error": "not found", "status": 404},
             "/agents": {"name": "mora", "display_name": "Mora", "model": "opus"},
             "*": {},
         }):
@@ -2358,13 +2355,8 @@ class TestRegisterAgent:
 
     def test_create_error_surfaces(self, srv):
         # POST /agents genuinely fails on e.g. an invalid name
-        # (_validate_agent_name → 400). The create-only GET pre-check returns
-        # not-found so we reach the create call, whose error must surface.
-        # (Previously this mocked a "name taken" error that the upsert endpoint
-        # never returns; collisions are now handled by the create-only guard —
-        # see test_existing_name_refused.)
+        # (_validate_agent_name → 400), and the error must surface.
         with _mock_api({
-            "/agents/mora": {"error": "not found", "status": 404},
             "/agents": {"error": "invalid agent name", "status": 400},
             "*": {},
         }):
@@ -2372,34 +2364,31 @@ class TestRegisterAgent:
         assert "Failed to register" in out
 
     def test_existing_name_refused(self, srv):
-        # Create-only guard: an existing name is refused, not silently upserted.
-        # The GET pre-check returns an agent dict (no "error") → refuse before
-        # any POST, so register_agent('barsik') can't blank Barsik's soul/role.
+        # The API's DB-level collision is authoritative; MCP surfaces its 409.
         with _mock_api({
-            "/agents/barsik": {"name": "barsik", "role": "sidekick", "soul": "x"},
+            "/agents": {"error": "already exists", "status": 409},
             "*": {},
         }):
             out = _tools(srv)["register_agent"](
                 name="barsik", role="worker", soul="would-overwrite",
             )
         assert "Refusing to register 'barsik'" in out
+        assert "HTTP 409" in out
         assert "already exists" in out
         assert "Registered agent" not in out
 
-    def test_non_404_get_error_aborts(self, srv):
-        # Guard must fail-closed on non-404 errors (500/timeout), not proceed to create.
+    def test_create_transport_error_aborts(self, srv):
         with _mock_api({
-            "/agents/mora": {"error": "internal server error", "status": 500},
+            "/agents": {"error": "internal server error", "status": 500},
             "*": {},
         }):
             out = _tools(srv)["register_agent"](name="mora", role="worker")
-        assert "couldn't verify name availability" in out
+        assert "HTTP 500" in out
         assert "Registered agent" not in out
 
     def test_skill_failure_reported(self, srv):
         with _mock_api({
             "/skills/": {"error": "no such skill"},
-            "/agents/mora": {"error": "not found", "status": 404},
             "/agents": {"name": "mora"},
             "*": {},
         }):


### PR DESCRIPTION
## Summary

- make `POST /agents` database-authoritative and create-only with `INSERT OR ABORT`; concurrent name collisions return 409 before provisioning or filesystem setup
- compensate every winning-registration failure through signing-key creation, main-agent assignment, provisioning, MCP publication, and managed workspace changes
- validate request-derived agent names with the existing strict allowlist and contain every resolved agent-owned path under its persisted, resolved `working_dir`
- refuse registration/update owner roots that equal, nest inside, or enclose another registered agent root
- make `AgentRegistry.update()` the soul-mutation kernel: snapshot the replaced DB value before the update, reject strict >50% shrink or loss of recognized identity anchors, and accept only an explicit `force_soul` override
- guard restore and direct `CLAUDE.md` writes (including symlink, hard-link, and case aliases), with content-free 400 summaries and force-labelled audit sources
- replace the polynomial anchor regex with a deterministic line parser and make the pinky-self `register_agent` tool trust the authoritative POST result

## Why

Registration and soul writes had different safety contracts. POST used update-on-collision semantics, DB soul updates had no pre-mutation history, file writes archived the new content after replacement, and restore bypassed destructive-change policy. A mistaken create or an empty `soul` field could therefore replace a live identity without a useful recovery point.

R1 also left the winning POST partially durable after later failures and built mutation paths from request-derived values without a common owner-root boundary. R2 adds winner compensation and applies the same guard philosophy to where identity content is written.

This is increment 1 of #1076; increment 2 will follow only after this PR merges.

## Surface audit

Routed through the guard/snapshot kernel:

- `AgentRegistry.register()` updates delegate to `AgentRegistry.update()`; the migration importer inherits that path
- `PUT /agents/{name}` distinguishes an absent `soul` from explicit empty content and forwards `force_soul`
- `POST /agents/{name}/soul/versions/{id}/restore` applies the same policy to both DB and `CLAUDE.md`, with explicit force audit labels
- `PUT /agents/{name}/files/{filename}` guards direct `CLAUDE.md` targets and filesystem aliases before writing
- pinky-self exposes no separate soul-update tool at this parent; its `register_agent` creation surface relies on DB-level POST collision handling

Path and registration invariants:

- the persisted, resolved `agent.working_dir` is the owner root; arbitrary operator-configured roots remain supported
- one shared helper resolves every agent-owned target and refuses out-of-root symlinks/aliases before reads, snapshots, or writes
- guarded writes use atomic temp-file plus `os.replace`, so hard links are replaced rather than writing through a shared inode
- a proposed registration/update root is refused if it overlaps any other registered owner root
- a winning POST failure removes the row and signing key, restores the prior main-agent setting and managed workspace state, and deprovisions any attempted runtime

## Spawn overwrite semantics (accepted by design)

Legacy agent-session spawn intentionally keeps compile-overwrite semantics for `CLAUDE.md`. The file is a generated/compiled artifact from the DB-authoritative soul plus current directives and skills, so spawn does **not** apply the shrink/anchor mutation guard. It still snapshots the previous on-disk artifact, publishes the installed version, and uses the common contained atomic writer. Out-of-root symlinks are refused, and hard-linked external inode content is not modified.

Other justified exclusions:

- isolated Codex spawn publishes generated `AGENTS.md` atomically and replaces linked entries rather than following them
- skill file templates and `pinky init` create only when the target is absent; they do not overwrite a registered agent soul
- session-store `soul` values are per-session configuration, not registered-agent identity
- arbitrary writes through shared host filesystem access remain the #149/#580 isolation class and cannot be intercepted by the daemon mutation kernel

## API behavior

- collision: HTTP 409; the winner's DB row and workspace remain untouched
- invalid name/path/root overlap: structured, content-free 400/409 refusal
- risky mutation: HTTP 400 with only `old_length`, `new_length`, `shrink_percent`, and missing anchor names—never soul text
- exact 50% shrink is allowed; only shrink strictly greater than 50% requires force
- identity-anchor loss is checked only when recognized anchors existed before
- force is request-scoped (`force_soul`) and recorded in the snapshot source

## R2 verification at `ae137719f2f2e91f8a46e756ad14596134d02cdf`

- Python 3.13.14: `tests/test_api.py` — 430 passed
- Python 3.13.14: broad non-API — 4730 passed, 1 skipped with the approved #1072 deselect
- Python 3.11.15: all four changed test files — 774 passed
- `tests/test_agent_registry.py` — 134 passed
- blocker-1 injected failures: `test_register_signing_key_failure_compensates_every_winner_side_effect`, `test_register_mcp_failure_compensates_every_winner_side_effect`, and `test_register_provision_failure_compensates_every_winner_side_effect`
- parser parity: 300,023 legacy shapes, 0 mismatches; Murzik near-suffix family completed in 0.000177s
- `ruff check .`
- `python -m compileall -q src tests`
- `git diff --check`

CodeQL green is a required post-push merge gate; alerts are not dismissed locally.

Part of #1076.

🤖 Opened by Kuzya
