### PR TITLE
Reap scheduler wake outbox: abandoned-state transitions, retention windows, payload trim

### DIFF
--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -5855,19 +5855,35 @@ except Exception as exc:
             for agent_name, count in active_rows:
                 _agent_metrics(str(agent_name))["retained_active"] = int(count)
 
+        def _emit_log(
+            message: str,
+            *,
+            emission_errors: list[Exception] | None = None,
+        ) -> None:
+            if emission_errors is None:
+                _log(message)
+                return
+            try:
+                _log(message)
+            except Exception as exc:
+                emission_errors.append(exc)
+
         def _emit_metrics(
-            *, failed_phase: str | None = None
+            *,
+            failed_phase: str | None = None,
+            emission_errors: list[Exception] | None = None,
         ) -> list[dict[str, int | str]]:
             result = [metrics[name] for name in sorted(metrics)]
             for row in result:
-                _log(
+                _emit_log(
                     f"outbox-reaper: agent={row['agent_name']} "
                     f"abandoned=+{row['abandoned']} "
                     f"accepted_reaped={row['accepted_reaped']} "
                     f"abandoned_reaped={row['abandoned_reaped']} "
                     f"parked_reaped={row['parked_reaped']} "
                     f"payloads_trimmed={row['payloads_trimmed']} "
-                    f"retained_active={row['retained_active']}"
+                    f"retained_active={row['retained_active']}",
+                    emission_errors=emission_errors,
                 )
             totals = {
                 field: sum(int(row[field]) for row in result)
@@ -5878,14 +5894,15 @@ except Exception as exc:
                 if failed_phase is not None
                 else ""
             )
-            _log(
+            _emit_log(
                 f"outbox-reaper: summary{partial} agents={len(result)} "
                 f"abandoned=+{totals['abandoned']} "
                 f"accepted_reaped={totals['accepted_reaped']} "
                 f"abandoned_reaped={totals['abandoned_reaped']} "
                 f"parked_reaped={totals['parked_reaped']} "
                 f"payloads_trimmed={totals['payloads_trimmed']} "
-                f"retained_active={totals['retained_active']}"
+                f"retained_active={totals['retained_active']}",
+                emission_errors=emission_errors,
             )
             return result
 
@@ -6062,8 +6079,28 @@ except Exception as exc:
                     # Preserve and report the maintenance failure even if the
                     # diagnostic read is unavailable on a broken connection.
                     pass
-                _emit_metrics(failed_phase=failed_phase)
-                _log("outbox-reaper: ERROR maintenance pass failed")
+                emission_errors: list[Exception] = []
+                try:
+                    _emit_metrics(
+                        failed_phase=failed_phase,
+                        emission_errors=emission_errors,
+                    )
+                except Exception as exc:
+                    emission_errors.append(exc)
+                _emit_log(
+                    "outbox-reaper: ERROR maintenance pass failed",
+                    emission_errors=emission_errors,
+                )
+                for emission_error in tuple(emission_errors):
+                    try:
+                        _log(
+                            "outbox-reaper: emission ERROR while reporting "
+                            "maintenance failure: "
+                            f"{type(emission_error).__name__}: "
+                            f"{emission_error}"
+                        )
+                    except Exception:
+                        pass
                 raise
 
         return _emit_metrics()

--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -23,6 +23,7 @@ Hierarchy:
 from __future__ import annotations
 
 import json
+import math
 import os
 import re
 import secrets
@@ -54,6 +55,8 @@ _BARSIK_BUZZ_RELAY_SIGNING_PUBKEY = (
 )
 BUZZ_OWNER_SILENCE_DAYS = 14
 BUZZ_INBOUND_CLAIM_LEASE_SECONDS = 5 * 60
+OUTBOX_REAPER_BATCH_SIZE = 10_000
+OUTBOX_REAPER_PAYLOAD_TRIMMED = "[payload trimmed by outbox reaper]"
 
 
 def _validate_buzz_pubkey(value: str, *, field_name: str = "pubkey") -> str:
@@ -759,8 +762,8 @@ class PendingScheduleWake:
     """One durable exact-fire scheduler ledger record.
 
     The historical class name is retained because active rows are also the
-    replay outbox.  ``accepted_at`` and ``parked_at`` make the terminal state
-    explicit without deleting the forensic receipt.
+    replay outbox.  ``accepted_at``, ``parked_at``, and ``abandoned_at`` make
+    terminal states explicit without deleting the forensic receipt.
     """
 
     id: int = 0
@@ -775,6 +778,7 @@ class PendingScheduleWake:
     accepted_at: float = 0.0
     failed_at: float = 0.0
     last_error: str = ""
+    abandoned_at: float = 0.0
 
     @property
     def name(self) -> str:
@@ -786,6 +790,8 @@ class PendingScheduleWake:
         """Return the exact operational outcome used by fleet health."""
         if self.accepted_at > 0:
             return "receipted-ran-once"
+        if self.abandoned_at > 0:
+            return "abandoned"
         if self.parked_at > 0:
             return "quarantined"
         return "pending"
@@ -804,6 +810,7 @@ class PendingScheduleWake:
             "accepted_at": self.accepted_at,
             "failed_at": self.failed_at,
             "last_error": self.last_error,
+            "abandoned_at": self.abandoned_at,
             "state": self.ledger_state,
         }
 
@@ -1489,6 +1496,7 @@ class AgentRegistry:
                 accepted_at REAL NOT NULL DEFAULT 0,
                 failed_at REAL NOT NULL DEFAULT 0,
                 last_error TEXT NOT NULL DEFAULT '',
+                abandoned_at REAL NOT NULL DEFAULT 0,
                 FOREIGN KEY (agent_name) REFERENCES agents(name) ON DELETE CASCADE,
                 UNIQUE(schedule_id, fired_at)
             );
@@ -1984,6 +1992,7 @@ class AgentRegistry:
             ("accepted_at", "REAL NOT NULL DEFAULT 0"),
             ("failed_at", "REAL NOT NULL DEFAULT 0"),
             ("last_error", "TEXT NOT NULL DEFAULT ''"),
+            ("abandoned_at", "REAL NOT NULL DEFAULT 0"),
         ]
         for col, typedef in wake_migrations:
             if col not in wake_existing:
@@ -1998,6 +2007,12 @@ class AgentRegistry:
             """CREATE INDEX IF NOT EXISTS idx_schedule_wake_ledger_state
                ON pending_schedule_wakes(
                    agent_name, accepted_at, parked_at, fired_at
+               )"""
+        )
+        self._db.execute(
+            """CREATE INDEX IF NOT EXISTS idx_schedule_wake_reaper_state
+               ON pending_schedule_wakes(
+                   accepted_at, parked_at, abandoned_at, fired_at
                )"""
         )
         self._db.commit()
@@ -5304,7 +5319,7 @@ except Exception as exc:
         return self._db.execute(
             """SELECT id, schedule_id, agent_name, schedule_name, prompt,
                       fired_at, created_at, attempts, parked_at, accepted_at,
-                      failed_at, last_error
+                      failed_at, last_error, abandoned_at
                FROM pending_schedule_wakes
                WHERE schedule_id=? AND fired_at=?""",
             (schedule_id, fired_at),
@@ -5348,7 +5363,7 @@ except Exception as exc:
             row = self._db.execute(
                 """SELECT id, schedule_id, agent_name, schedule_name, prompt,
                           fired_at, created_at, attempts, parked_at, accepted_at,
-                          failed_at, last_error
+                          failed_at, last_error, abandoned_at
                    FROM pending_schedule_wakes
                    WHERE schedule_id=? AND fired_at=?""",
                 (schedule_id, fired_at),
@@ -5364,13 +5379,13 @@ except Exception as exc:
     ) -> list[PendingScheduleWake]:
         """Return pending scheduler wakes oldest-first.
 
-        Accepted receipts are always excluded. Quarantined rows are excluded
-        by default; pass ``include_parked=True`` to inspect those terminal
-        records alongside the active replay outbox.
+        Accepted receipts are always excluded. Quarantined and abandoned rows
+        are excluded by default; pass ``include_parked=True`` to inspect those
+        terminal records alongside the active replay outbox.
         """
         sql = """SELECT id, schedule_id, agent_name, schedule_name, prompt,
                         fired_at, created_at, attempts, parked_at, accepted_at,
-                        failed_at, last_error
+                        failed_at, last_error, abandoned_at
                  FROM pending_schedule_wakes"""
         conditions: list[str] = []
         params: list = []
@@ -5379,7 +5394,7 @@ except Exception as exc:
             params.append(agent_name)
         conditions.append("accepted_at=0")
         if not include_parked:
-            conditions.append("parked_at=0")
+            conditions.extend(("parked_at=0", "abandoned_at=0"))
         if conditions:
             sql += " WHERE " + " AND ".join(conditions)
         sql += " ORDER BY fired_at ASC, id ASC"
@@ -5392,12 +5407,17 @@ except Exception as exc:
         *,
         now: float | None = None,
     ) -> list[dict]:
-        """Return active outbox count and oldest-row age per agent.
+        """Return active outbox debt and abandoned history per agent.
 
-        Accepted receipts and quarantined rows are terminal ledger history,
-        not stranded replay work, so they are intentionally excluded.
+        Accepted receipts and quarantined rows are terminal ledger history and
+        remain excluded. Explicitly abandoned rows surface as their own count,
+        never as active replay debt.
         """
-        sql = """SELECT agent_name, COUNT(*), MIN(fired_at), MAX(fired_at)
+        sql = """SELECT agent_name,
+                        SUM(CASE WHEN abandoned_at=0 THEN 1 ELSE 0 END),
+                        MIN(CASE WHEN abandoned_at=0 THEN fired_at END),
+                        MAX(CASE WHEN abandoned_at=0 THEN fired_at END),
+                        SUM(CASE WHEN abandoned_at>0 THEN 1 ELSE 0 END)
                  FROM pending_schedule_wakes
                  WHERE accepted_at=0 AND parked_at=0"""
         params: list = []
@@ -5407,16 +5427,25 @@ except Exception as exc:
         sql += " GROUP BY agent_name ORDER BY agent_name"
         rows = self._db.execute(sql, params).fetchall()
         observed_at = time.time() if now is None else float(now)
-        return [
-            {
-                "agent_name": str(row[0]),
-                "count": int(row[1]),
-                "oldest_fired_at": float(row[2]),
-                "newest_fired_at": float(row[3]),
-                "oldest_age_seconds": max(0.0, observed_at - float(row[2])),
-            }
-            for row in rows
-        ]
+        result = []
+        for row in rows:
+            oldest_fired_at = float(row[2]) if row[2] is not None else 0.0
+            newest_fired_at = float(row[3]) if row[3] is not None else 0.0
+            result.append(
+                {
+                    "agent_name": str(row[0]),
+                    "count": int(row[1]),
+                    "abandoned_count": int(row[4]),
+                    "oldest_fired_at": oldest_fired_at,
+                    "newest_fired_at": newest_fired_at,
+                    "oldest_age_seconds": (
+                        max(0.0, observed_at - oldest_fired_at)
+                        if oldest_fired_at > 0
+                        else 0.0
+                    ),
+                }
+            )
+        return result
 
     def list_schedule_wake_ledger(
         self,
@@ -5432,11 +5461,12 @@ except Exception as exc:
             "pending",
             "receipted-ran-once",
             "quarantined",
+            "abandoned",
         }:
             raise ValueError(f"invalid scheduler wake ledger state: {state}")
         sql = """SELECT id, schedule_id, agent_name, schedule_name, prompt,
                         fired_at, created_at, attempts, parked_at, accepted_at,
-                        failed_at, last_error
+                        failed_at, last_error, abandoned_at
                  FROM pending_schedule_wakes"""
         conditions: list[str] = []
         params: list = []
@@ -5447,11 +5477,19 @@ except Exception as exc:
             conditions.append("fired_at>=?")
             params.append(fired_after)
         if state == "pending":
-            conditions.extend(("accepted_at=0", "parked_at=0"))
+            conditions.extend(
+                ("accepted_at=0", "parked_at=0", "abandoned_at=0")
+            )
         elif state == "receipted-ran-once":
             conditions.append("accepted_at>0")
         elif state == "quarantined":
-            conditions.extend(("accepted_at=0", "parked_at>0"))
+            conditions.extend(
+                ("accepted_at=0", "parked_at>0", "abandoned_at=0")
+            )
+        elif state == "abandoned":
+            conditions.extend(
+                ("accepted_at=0", "parked_at=0", "abandoned_at>0")
+            )
         if conditions:
             sql += " WHERE " + " AND ".join(conditions)
         sql += " ORDER BY fired_at DESC, id DESC LIMIT ?"
@@ -5480,14 +5518,19 @@ except Exception as exc:
             if row is None:
                 return None, False
             current = PendingScheduleWake(*row)
-            if current.accepted_at > 0 or current.parked_at > 0:
+            if (
+                current.accepted_at > 0
+                or current.parked_at > 0
+                or current.abandoned_at > 0
+            ):
                 return current, False
             first_failure = current.failed_at == 0
             self._db.execute(
                 """UPDATE pending_schedule_wakes
                    SET failed_at=CASE WHEN failed_at=0 THEN ? ELSE failed_at END,
                        last_error=?
-                   WHERE id=? AND accepted_at=0 AND parked_at=0""",
+                   WHERE id=? AND accepted_at=0 AND parked_at=0
+                     AND abandoned_at=0""",
                 (timestamp, reason, current.id),
             )
             row = self._select_schedule_wake_by_fire(schedule_id, fired_at)
@@ -5502,7 +5545,8 @@ except Exception as exc:
             cursor = self._db.execute(
                 """UPDATE pending_schedule_wakes
                    SET attempts=attempts + 1
-                   WHERE id=? AND parked_at=0""",
+                   WHERE id=? AND accepted_at=0 AND parked_at=0
+                     AND abandoned_at=0""",
                 (pending_id,),
             )
             if cursor.rowcount == 0:
@@ -5530,7 +5574,35 @@ except Exception as exc:
                    SET parked_at=?,
                        failed_at=CASE WHEN failed_at=0 THEN ? ELSE failed_at END,
                        last_error=?
-                   WHERE id=? AND parked_at=0 AND accepted_at=0""",
+                   WHERE id=? AND parked_at=0 AND accepted_at=0
+                     AND abandoned_at=0""",
+                (timestamp, timestamp, reason, pending_id),
+            )
+            self._db.commit()
+        return cursor.rowcount > 0
+
+    def abandon_pending_schedule_wake(
+        self,
+        pending_id: int,
+        *,
+        abandoned_at: float = 0.0,
+        reason: str = "receipt confirmation ceiling exceeded",
+    ) -> bool:
+        """Atomically move an active wake to explicit abandonment once.
+
+        Abandonment is distinct from delivery quarantine: it records the
+        ambiguous receipt-gap outcome without replaying or discarding the row.
+        A later positive receipt remains authoritative and clears this marker.
+        """
+        timestamp = abandoned_at or time.time()
+        with self._rmw_lock:
+            cursor = self._db.execute(
+                """UPDATE pending_schedule_wakes
+                   SET abandoned_at=?,
+                       failed_at=CASE WHEN failed_at=0 THEN ? ELSE failed_at END,
+                       last_error=?
+                   WHERE id=? AND parked_at=0 AND accepted_at=0
+                     AND abandoned_at=0""",
                 (timestamp, timestamp, reason, pending_id),
             )
             self._db.commit()
@@ -5555,7 +5627,8 @@ except Exception as exc:
                    SET parked_at=?,
                        failed_at=CASE WHEN failed_at=0 THEN ? ELSE failed_at END,
                        last_error=?
-                   WHERE id=? AND parked_at=0 AND accepted_at=0""",
+                   WHERE id=? AND parked_at=0 AND accepted_at=0
+                     AND abandoned_at=0""",
                 (timestamp, timestamp, reason, pending_id),
             )
             self._db.commit()
@@ -5585,6 +5658,7 @@ except Exception as exc:
                    SET accepted_at=CASE
                            WHEN accepted_at=0 THEN ? ELSE accepted_at END,
                        parked_at=0,
+                       abandoned_at=0,
                        last_error=''
                    WHERE id=?""",
                 (timestamp, pending_id),
@@ -5620,6 +5694,7 @@ except Exception as exc:
                    SET accepted_at=CASE
                            WHEN accepted_at=0 THEN ? ELSE accepted_at END,
                        parked_at=0,
+                       abandoned_at=0,
                        last_error=''
                    WHERE schedule_id=? AND fired_at=?""",
                 (timestamp, schedule_id, fired_at),
@@ -5653,14 +5728,16 @@ except Exception as exc:
         re-created nor re-delivered.
 
         ``agent_name`` scopes self-service callers to their own outbox. Rows that
-        are already accepted or parked are terminal evidence and are left as-is.
+        are already accepted, parked, or abandoned are terminal evidence and
+        are left as-is.
 
         Parked tombstones accumulate until a terminal-row reaper prunes them
         (tracked separately; accepted rows already accumulate the same way).
         """
         sql = """UPDATE pending_schedule_wakes
                  SET parked_at=?, last_error=?
-                 WHERE id=? AND accepted_at=0 AND parked_at=0"""
+                 WHERE id=? AND accepted_at=0 AND parked_at=0
+                   AND abandoned_at=0"""
         params: list = [time.time(), "retired via discard", pending_id]
         if agent_name is not None:
             sql += " AND agent_name=?"
@@ -5677,17 +5754,292 @@ except Exception as exc:
         of frequently-recurring schedules — tombstoning there would accumulate
         rows unboundedly without a reaper. Deliberate/manual retirement uses
         ``discard_pending_schedule_wake`` (which tombstones) so a retired fire
-        cannot be re-created by a later reconciliation. Accepted or already
-        parked rows are terminal and are left as-is.
+        cannot be re-created by a later reconciliation. Accepted, parked, or
+        abandoned rows are terminal and are left as-is.
         """
         with self._rmw_lock:
             cursor = self._db.execute(
                 """DELETE FROM pending_schedule_wakes
-                   WHERE id=? AND accepted_at=0 AND parked_at=0""",
+                   WHERE id=? AND accepted_at=0 AND parked_at=0
+                     AND abandoned_at=0""",
                 (pending_id,),
             )
             self._db.commit()
             return cursor.rowcount > 0
+
+    def reap_pending_schedule_wakes(
+        self,
+        *,
+        now: float,
+        abandon_after: float,
+        retain_accepted: float,
+        retain_abandoned: float,
+        retain_parked: float,
+        payload_trim_after: float,
+        batch_size: int = OUTBOX_REAPER_BATCH_SIZE,
+    ) -> list[dict[str, int | str]]:
+        """Transition stranded wakes and prune bounded terminal history.
+
+        This maintenance pass never delivers or re-queues work. Active rows
+        cross into explicit abandonment only after the strict fired-at
+        ceiling. Legacy ``RECEIPT_ABANDONED`` quarantine markers are reclassified
+        into the same explicit state. Retention is measured from each transition,
+        so every newly backfilled abandonment survives its full forensic window.
+        Large populations are committed in bounded chunks while the registry's
+        mutation lock prevents in-process replay races.
+        """
+        observed_at = float(now)
+        windows = {
+            "abandon_after": float(abandon_after),
+            "retain_accepted": float(retain_accepted),
+            "retain_abandoned": float(retain_abandoned),
+            "retain_parked": float(retain_parked),
+            "payload_trim_after": float(payload_trim_after),
+        }
+        if not math.isfinite(observed_at) or observed_at <= 0:
+            raise ValueError("outbox reaper now must be positive")
+        if any(
+            not math.isfinite(value) or value <= 0
+            for value in windows.values()
+        ):
+            raise ValueError("outbox reaper windows must be positive")
+        if batch_size <= 0:
+            raise ValueError("outbox reaper batch_size must be positive")
+
+        metric_fields = (
+            "abandoned",
+            "accepted_reaped",
+            "abandoned_reaped",
+            "parked_reaped",
+            "payloads_trimmed",
+            "retained_active",
+        )
+        metrics: dict[str, dict[str, int | str]] = {}
+
+        def _agent_metrics(agent_name: str) -> dict[str, int | str]:
+            if agent_name not in metrics:
+                metrics[agent_name] = {
+                    "agent_name": agent_name,
+                    **{field: 0 for field in metric_fields},
+                }
+            return metrics[agent_name]
+
+        def _apply_batched(
+            sql: str,
+            params: tuple,
+            metric_field: str,
+        ) -> None:
+            while True:
+                rows = self._db.execute(
+                    sql,
+                    (*params, int(batch_size)),
+                ).fetchall()
+                self._db.commit()
+                for row in rows:
+                    agent_metrics = _agent_metrics(str(row[0]))
+                    agent_metrics[metric_field] = (
+                        int(agent_metrics[metric_field]) + 1
+                    )
+                if len(rows) < batch_size:
+                    return
+
+        discard_reason = "retired via discard"
+        abandon_cutoff = observed_at - windows["abandon_after"]
+        accepted_cutoff = observed_at - windows["retain_accepted"]
+        abandoned_cutoff = observed_at - windows["retain_abandoned"]
+        parked_cutoff = observed_at - windows["retain_parked"]
+        trim_cutoff = observed_at - windows["payload_trim_after"]
+
+        with self._rmw_lock:
+            try:
+                for row in self._db.execute(
+                    "SELECT DISTINCT agent_name FROM pending_schedule_wakes"
+                ).fetchall():
+                    _agent_metrics(str(row[0]))
+
+                _apply_batched(
+                    """UPDATE pending_schedule_wakes
+                       SET abandoned_at=?, parked_at=0
+                       WHERE id IN (
+                           SELECT id FROM pending_schedule_wakes
+                           WHERE accepted_at=0 AND abandoned_at=0
+                             AND (
+                                 (parked_at=0 AND fired_at < ?)
+                                 OR (
+                                     parked_at>0
+                                     AND last_error LIKE 'RECEIPT_ABANDONED:%'
+                                 )
+                             )
+                           ORDER BY id ASC LIMIT ?
+                       )
+                       RETURNING agent_name""",
+                    (observed_at, abandon_cutoff),
+                    "abandoned",
+                )
+                _apply_batched(
+                    """DELETE FROM pending_schedule_wakes
+                       WHERE id IN (
+                           SELECT id FROM pending_schedule_wakes
+                           WHERE accepted_at>0 AND accepted_at < ?
+                           ORDER BY id ASC LIMIT ?
+                       )
+                       RETURNING agent_name""",
+                    (accepted_cutoff,),
+                    "accepted_reaped",
+                )
+                _apply_batched(
+                    """DELETE FROM pending_schedule_wakes
+                       WHERE id IN (
+                           SELECT id FROM pending_schedule_wakes
+                           WHERE (
+                               accepted_at=0 AND parked_at=0
+                               AND abandoned_at>0 AND abandoned_at < ?
+                           ) OR (
+                               accepted_at=0 AND abandoned_at=0
+                               AND parked_at>0 AND parked_at < ?
+                               AND last_error=?
+                           )
+                           ORDER BY id ASC LIMIT ?
+                       )
+                       RETURNING agent_name""",
+                    (abandoned_cutoff, abandoned_cutoff, discard_reason),
+                    "abandoned_reaped",
+                )
+                _apply_batched(
+                    """DELETE FROM pending_schedule_wakes AS parked
+                       WHERE parked.id IN (
+                           SELECT candidate.id
+                           FROM pending_schedule_wakes AS candidate
+                           WHERE candidate.accepted_at=0
+                             AND candidate.abandoned_at=0
+                             AND candidate.parked_at>0
+                             AND candidate.parked_at < ?
+                             AND candidate.last_error<>?
+                             AND EXISTS (
+                                 SELECT 1
+                                 FROM pending_schedule_wakes AS newer
+                                 WHERE newer.schedule_id=candidate.schedule_id
+                                   AND newer.accepted_at=0
+                                   AND newer.abandoned_at=0
+                                   AND newer.parked_at>0
+                                   AND newer.last_error<>?
+                                   AND (
+                                       newer.parked_at > candidate.parked_at
+                                       OR (
+                                           newer.parked_at=candidate.parked_at
+                                           AND newer.id > candidate.id
+                                       )
+                                   )
+                             )
+                           ORDER BY candidate.id ASC LIMIT ?
+                       )
+                       RETURNING agent_name""",
+                    (parked_cutoff, discard_reason, discard_reason),
+                    "parked_reaped",
+                )
+                _apply_batched(
+                    """UPDATE pending_schedule_wakes AS terminal
+                       SET prompt=?
+                       WHERE terminal.id IN (
+                           SELECT candidate.id
+                           FROM pending_schedule_wakes AS candidate
+                           WHERE candidate.prompt<>?
+                             AND (
+                                 (
+                                     candidate.accepted_at>0
+                                     AND candidate.accepted_at < ?
+                                 ) OR (
+                                     candidate.accepted_at=0
+                                     AND candidate.parked_at=0
+                                     AND candidate.abandoned_at>0
+                                     AND candidate.abandoned_at < ?
+                                 ) OR (
+                                     candidate.accepted_at=0
+                                     AND candidate.abandoned_at=0
+                                     AND candidate.parked_at>0
+                                     AND candidate.parked_at < ?
+                                     AND candidate.last_error=?
+                                 ) OR (
+                                     candidate.accepted_at=0
+                                     AND candidate.abandoned_at=0
+                                     AND candidate.parked_at>0
+                                     AND candidate.parked_at < ?
+                                     AND candidate.last_error<>?
+                                     AND EXISTS (
+                                         SELECT 1
+                                         FROM pending_schedule_wakes AS newer
+                                         WHERE newer.schedule_id=candidate.schedule_id
+                                           AND newer.accepted_at=0
+                                           AND newer.abandoned_at=0
+                                           AND newer.parked_at>0
+                                           AND newer.last_error<>?
+                                           AND (
+                                               newer.parked_at > candidate.parked_at
+                                               OR (
+                                                   newer.parked_at=candidate.parked_at
+                                                   AND newer.id > candidate.id
+                                               )
+                                           )
+                                     )
+                                 )
+                             )
+                           ORDER BY candidate.id ASC LIMIT ?
+                       )
+                       RETURNING agent_name""",
+                    (
+                        OUTBOX_REAPER_PAYLOAD_TRIMMED,
+                        OUTBOX_REAPER_PAYLOAD_TRIMMED,
+                        trim_cutoff,
+                        trim_cutoff,
+                        trim_cutoff,
+                        discard_reason,
+                        trim_cutoff,
+                        discard_reason,
+                        discard_reason,
+                    ),
+                    "payloads_trimmed",
+                )
+
+                active_rows = self._db.execute(
+                    """SELECT agent_name, COUNT(*)
+                       FROM pending_schedule_wakes
+                       WHERE accepted_at=0 AND parked_at=0 AND abandoned_at=0
+                       GROUP BY agent_name"""
+                ).fetchall()
+                for agent_name, count in active_rows:
+                    _agent_metrics(str(agent_name))["retained_active"] = int(
+                        count
+                    )
+            except Exception:
+                self._db.rollback()
+                _log("outbox-reaper: ERROR maintenance pass failed")
+                raise
+
+        result = [metrics[name] for name in sorted(metrics)]
+        for row in result:
+            _log(
+                f"outbox-reaper: agent={row['agent_name']} "
+                f"abandoned=+{row['abandoned']} "
+                f"accepted_reaped={row['accepted_reaped']} "
+                f"abandoned_reaped={row['abandoned_reaped']} "
+                f"parked_reaped={row['parked_reaped']} "
+                f"payloads_trimmed={row['payloads_trimmed']} "
+                f"retained_active={row['retained_active']}"
+            )
+        totals = {
+            field: sum(int(row[field]) for row in result)
+            for field in metric_fields
+        }
+        _log(
+            f"outbox-reaper: summary agents={len(result)} "
+            f"abandoned=+{totals['abandoned']} "
+            f"accepted_reaped={totals['accepted_reaped']} "
+            f"abandoned_reaped={totals['abandoned_reaped']} "
+            f"parked_reaped={totals['parked_reaped']} "
+            f"payloads_trimmed={totals['payloads_trimmed']} "
+            f"retained_active={totals['retained_active']}"
+        )
+        return result
 
     # ── Heartbeats ─────────────────────────────────────────
 

--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -5843,6 +5843,52 @@ except Exception as exc:
                 if len(rows) < batch_size:
                     return
 
+        def _refresh_retained_active() -> None:
+            for agent_metrics in metrics.values():
+                agent_metrics["retained_active"] = 0
+            active_rows = self._db.execute(
+                """SELECT agent_name, COUNT(*)
+                   FROM pending_schedule_wakes
+                   WHERE accepted_at=0 AND parked_at=0 AND abandoned_at=0
+                   GROUP BY agent_name"""
+            ).fetchall()
+            for agent_name, count in active_rows:
+                _agent_metrics(str(agent_name))["retained_active"] = int(count)
+
+        def _emit_metrics(
+            *, failed_phase: str | None = None
+        ) -> list[dict[str, int | str]]:
+            result = [metrics[name] for name in sorted(metrics)]
+            for row in result:
+                _log(
+                    f"outbox-reaper: agent={row['agent_name']} "
+                    f"abandoned=+{row['abandoned']} "
+                    f"accepted_reaped={row['accepted_reaped']} "
+                    f"abandoned_reaped={row['abandoned_reaped']} "
+                    f"parked_reaped={row['parked_reaped']} "
+                    f"payloads_trimmed={row['payloads_trimmed']} "
+                    f"retained_active={row['retained_active']}"
+                )
+            totals = {
+                field: sum(int(row[field]) for row in result)
+                for field in metric_fields
+            }
+            partial = (
+                f" PARTIAL failed_phase={failed_phase}"
+                if failed_phase is not None
+                else ""
+            )
+            _log(
+                f"outbox-reaper: summary{partial} agents={len(result)} "
+                f"abandoned=+{totals['abandoned']} "
+                f"accepted_reaped={totals['accepted_reaped']} "
+                f"abandoned_reaped={totals['abandoned_reaped']} "
+                f"parked_reaped={totals['parked_reaped']} "
+                f"payloads_trimmed={totals['payloads_trimmed']} "
+                f"retained_active={totals['retained_active']}"
+            )
+            return result
+
         discard_reason = "retired via discard"
         abandon_cutoff = observed_at - windows["abandon_after"]
         accepted_cutoff = observed_at - windows["retain_accepted"]
@@ -5850,6 +5896,7 @@ except Exception as exc:
         parked_cutoff = observed_at - windows["retain_parked"]
         trim_cutoff = observed_at - windows["payload_trim_after"]
 
+        failed_phase = "agent_scan"
         with self._rmw_lock:
             try:
                 for row in self._db.execute(
@@ -5857,6 +5904,7 @@ except Exception as exc:
                 ).fetchall():
                     _agent_metrics(str(row[0]))
 
+                failed_phase = "abandon"
                 _apply_batched(
                     """UPDATE pending_schedule_wakes
                        SET abandoned_at=?, parked_at=0
@@ -5876,6 +5924,7 @@ except Exception as exc:
                     (observed_at, abandon_cutoff),
                     "abandoned",
                 )
+                failed_phase = "accepted_reap"
                 _apply_batched(
                     """DELETE FROM pending_schedule_wakes
                        WHERE id IN (
@@ -5887,6 +5936,7 @@ except Exception as exc:
                     (accepted_cutoff,),
                     "accepted_reaped",
                 )
+                failed_phase = "abandoned_reap"
                 _apply_batched(
                     """DELETE FROM pending_schedule_wakes
                        WHERE id IN (
@@ -5905,6 +5955,7 @@ except Exception as exc:
                     (abandoned_cutoff, abandoned_cutoff, discard_reason),
                     "abandoned_reaped",
                 )
+                failed_phase = "parked_reap"
                 _apply_batched(
                     """DELETE FROM pending_schedule_wakes AS parked
                        WHERE parked.id IN (
@@ -5937,6 +5988,7 @@ except Exception as exc:
                     (parked_cutoff, discard_reason, discard_reason),
                     "parked_reaped",
                 )
+                failed_phase = "payload_trim"
                 _apply_batched(
                     """UPDATE pending_schedule_wakes AS terminal
                        SET prompt=?
@@ -6000,46 +6052,21 @@ except Exception as exc:
                     "payloads_trimmed",
                 )
 
-                active_rows = self._db.execute(
-                    """SELECT agent_name, COUNT(*)
-                       FROM pending_schedule_wakes
-                       WHERE accepted_at=0 AND parked_at=0 AND abandoned_at=0
-                       GROUP BY agent_name"""
-                ).fetchall()
-                for agent_name, count in active_rows:
-                    _agent_metrics(str(agent_name))["retained_active"] = int(
-                        count
-                    )
+                failed_phase = "retained_active"
+                _refresh_retained_active()
             except Exception:
                 self._db.rollback()
+                try:
+                    _refresh_retained_active()
+                except Exception:
+                    # Preserve and report the maintenance failure even if the
+                    # diagnostic read is unavailable on a broken connection.
+                    pass
+                _emit_metrics(failed_phase=failed_phase)
                 _log("outbox-reaper: ERROR maintenance pass failed")
                 raise
 
-        result = [metrics[name] for name in sorted(metrics)]
-        for row in result:
-            _log(
-                f"outbox-reaper: agent={row['agent_name']} "
-                f"abandoned=+{row['abandoned']} "
-                f"accepted_reaped={row['accepted_reaped']} "
-                f"abandoned_reaped={row['abandoned_reaped']} "
-                f"parked_reaped={row['parked_reaped']} "
-                f"payloads_trimmed={row['payloads_trimmed']} "
-                f"retained_active={row['retained_active']}"
-            )
-        totals = {
-            field: sum(int(row[field]) for row in result)
-            for field in metric_fields
-        }
-        _log(
-            f"outbox-reaper: summary agents={len(result)} "
-            f"abandoned=+{totals['abandoned']} "
-            f"accepted_reaped={totals['accepted_reaped']} "
-            f"abandoned_reaped={totals['abandoned_reaped']} "
-            f"parked_reaped={totals['parked_reaped']} "
-            f"payloads_trimmed={totals['payloads_trimmed']} "
-            f"retained_active={totals['retained_active']}"
-        )
-        return result
+        return _emit_metrics()
 
     # ── Heartbeats ─────────────────────────────────────────
 

--- a/src/pinky_daemon/scheduler.py
+++ b/src/pinky_daemon/scheduler.py
@@ -72,10 +72,14 @@ _OUTBOX_REAPER_RETAIN_PARKED_ENV = "PINKY_OUTBOX_REAPER_RETAIN_PARKED_SEC"
 _OUTBOX_REAPER_PAYLOAD_TRIM_ENV = (
     "PINKY_OUTBOX_REAPER_PAYLOAD_TRIM_AFTER_SEC"
 )
+_OUTBOX_REAPER_FAILURE_BACKOFF_ENV = (
+    "PINKY_OUTBOX_REAPER_FAILURE_BACKOFF_SEC"
+)
 _OUTBOX_REAPER_RETAIN_ACCEPTED_SEC = 7 * 24 * 60 * 60
 _OUTBOX_REAPER_RETAIN_ABANDONED_SEC = 14 * 24 * 60 * 60
 _OUTBOX_REAPER_RETAIN_PARKED_SEC = 30 * 24 * 60 * 60
 _OUTBOX_REAPER_PAYLOAD_TRIM_AFTER_SEC = 48 * 60 * 60
+_OUTBOX_REAPER_FAILURE_BACKOFF_SEC = 60 * 60
 
 
 class _ReceiptAbandonedError(RuntimeError):
@@ -367,6 +371,10 @@ class AgentScheduler:
             _OUTBOX_REAPER_PAYLOAD_TRIM_ENV,
             _OUTBOX_REAPER_PAYLOAD_TRIM_AFTER_SEC,
         )
+        self._outbox_reaper_failure_backoff_sec = _positive_env_seconds(
+            _OUTBOX_REAPER_FAILURE_BACKOFF_ENV,
+            _OUTBOX_REAPER_FAILURE_BACKOFF_SEC,
+        )
         self._running = False
         self._task: asyncio.Task | None = None
         self._last_clock_slot: dict[str, int] = {}  # agent_name -> last fired clock slot (minutes since midnight)
@@ -398,6 +406,7 @@ class AgentScheduler:
         self._last_schedule_prompt_warn_at: float | None = None
         self._last_pending_wake_liveness_drain_at: float | None = None
         self._last_outbox_reaper_day: date | None = None
+        self._last_outbox_reaper_failed_at: float | None = None
         # Resurrection rate-limit: agent_name -> list[timestamp] of recent attempts.
         # Used by _check_heartbeats to cap how often we ping the heartbeat_callback
         # for a stuck agent (avoid thrashing on a persistently-broken session).
@@ -521,9 +530,12 @@ class AgentScheduler:
         current_day = date.fromtimestamp(now)
         if self._last_outbox_reaper_day == current_day:
             return False
-        # Record the attempt before entering storage so a persistent failure
-        # emits one loud daily error instead of flooding every scheduler tick.
-        self._last_outbox_reaper_day = current_day
+        if (
+            self._last_outbox_reaper_failed_at is not None
+            and now - self._last_outbox_reaper_failed_at
+            < self._outbox_reaper_failure_backoff_sec
+        ):
+            return False
         try:
             self._registry.reap_pending_schedule_wakes(
                 now=now,
@@ -536,11 +548,14 @@ class AgentScheduler:
                 ),
             )
         except Exception as exc:
+            self._last_outbox_reaper_failed_at = now
             _log(
                 "scheduler: outbox reaper failed: "
                 f"{type(exc).__name__}: {exc}"
             )
             return False
+        self._last_outbox_reaper_day = current_day
+        self._last_outbox_reaper_failed_at = None
         return True
 
     def _warn_oversized_schedule_prompts(

--- a/src/pinky_daemon/scheduler.py
+++ b/src/pinky_daemon/scheduler.py
@@ -62,10 +62,40 @@ _RECEIPT_EXTENSION_MAX_AGE_ENV = "PINKY_SCHEDULE_RECEIPT_EXTENSION_MAX_AGE_SEC"
 _RECEIPT_EXTENSION_MAX_AGE_SEC = 60 * 60
 _ABANDONED_RECEIPT_OBSERVER_INTERVAL_SEC = 1.0
 _PENDING_WAKE_LIVENESS_DRAIN_INTERVAL_SEC = 60
+_OUTBOX_REAPER_RETAIN_ACCEPTED_ENV = (
+    "PINKY_OUTBOX_REAPER_RETAIN_ACCEPTED_SEC"
+)
+_OUTBOX_REAPER_RETAIN_ABANDONED_ENV = (
+    "PINKY_OUTBOX_REAPER_RETAIN_ABANDONED_SEC"
+)
+_OUTBOX_REAPER_RETAIN_PARKED_ENV = "PINKY_OUTBOX_REAPER_RETAIN_PARKED_SEC"
+_OUTBOX_REAPER_PAYLOAD_TRIM_ENV = (
+    "PINKY_OUTBOX_REAPER_PAYLOAD_TRIM_AFTER_SEC"
+)
+_OUTBOX_REAPER_RETAIN_ACCEPTED_SEC = 7 * 24 * 60 * 60
+_OUTBOX_REAPER_RETAIN_ABANDONED_SEC = 14 * 24 * 60 * 60
+_OUTBOX_REAPER_RETAIN_PARKED_SEC = 30 * 24 * 60 * 60
+_OUTBOX_REAPER_PAYLOAD_TRIM_AFTER_SEC = 48 * 60 * 60
 
 
 class _ReceiptAbandonedError(RuntimeError):
     """An already-pasted wake exceeded its original-fire receipt deadline."""
+
+
+def _positive_env_seconds(name: str, default: float) -> float:
+    """Read one finite positive duration, falling back loudly."""
+    raw_value = os.environ.get(name, str(default))
+    try:
+        value = float(raw_value)
+        if not math.isfinite(value) or value <= 0:
+            raise ValueError("duration must be finite and positive")
+    except (TypeError, ValueError):
+        _log(
+            f"scheduler: invalid {name} duration {raw_value!r}; "
+            f"using {default:g}s"
+        )
+        return float(default)
+    return value
 
 
 def _is_claude_code_agent(agent, registry: AgentRegistry) -> bool:
@@ -276,8 +306,8 @@ class AgentScheduler:
         # A pasted-unresolved prompt cannot be safely cancelled and replayed,
         # but it also cannot hold the per-agent lock forever. Receipt waiting
         # is therefore capped against the wake's durable original fired_at.
-        # At the ceiling the waiter detaches, the exact row is quarantined as
-        # RECEIPT_ABANDONED, and a later positive receipt can still win.
+        # At the ceiling the waiter detaches, the exact row is explicitly
+        # abandoned, and a later positive receipt can still win.
         self._delivery_inflight_fn = delivery_inflight_fn
         # async fn(agent_name, text) -> bool. Delivers operator-facing owner
         # alerts for terminal dead-letter events (PERSISTED_WAKE_PARKED, stale
@@ -321,6 +351,22 @@ class AgentScheduler:
         self._receipt_extension_max_age_sec = float(
             receipt_extension_max_age_sec
         )
+        self._outbox_reaper_retain_accepted_sec = _positive_env_seconds(
+            _OUTBOX_REAPER_RETAIN_ACCEPTED_ENV,
+            _OUTBOX_REAPER_RETAIN_ACCEPTED_SEC,
+        )
+        self._outbox_reaper_retain_abandoned_sec = _positive_env_seconds(
+            _OUTBOX_REAPER_RETAIN_ABANDONED_ENV,
+            _OUTBOX_REAPER_RETAIN_ABANDONED_SEC,
+        )
+        self._outbox_reaper_retain_parked_sec = _positive_env_seconds(
+            _OUTBOX_REAPER_RETAIN_PARKED_ENV,
+            _OUTBOX_REAPER_RETAIN_PARKED_SEC,
+        )
+        self._outbox_reaper_payload_trim_after_sec = _positive_env_seconds(
+            _OUTBOX_REAPER_PAYLOAD_TRIM_ENV,
+            _OUTBOX_REAPER_PAYLOAD_TRIM_AFTER_SEC,
+        )
         self._running = False
         self._task: asyncio.Task | None = None
         self._last_clock_slot: dict[str, int] = {}  # agent_name -> last fired clock slot (minutes since midnight)
@@ -351,6 +397,7 @@ class AgentScheduler:
         self._owner_alert_tasks: set[asyncio.Task] = set()
         self._last_schedule_prompt_warn_at: float | None = None
         self._last_pending_wake_liveness_drain_at: float | None = None
+        self._last_outbox_reaper_day: date | None = None
         # Resurrection rate-limit: agent_name -> list[timestamp] of recent attempts.
         # Used by _check_heartbeats to cap how often we ping the heartbeat_callback
         # for a stuck agent (avoid thrashing on a persistently-broken session).
@@ -361,7 +408,9 @@ class AgentScheduler:
         if self._running:
             return
         self._running = True
-        self._warn_oversized_schedule_prompts(time.time(), force=True)
+        now = time.time()
+        self._run_outbox_reaper_if_due(now)
+        self._warn_oversized_schedule_prompts(now, force=True)
         for pending in self._registry.list_pending_schedule_wakes():
             self.replay_pending_for_agent(pending.agent_name)
         # Queue startup catch-up before the first live tick can enqueue newer
@@ -432,6 +481,7 @@ class AgentScheduler:
         """Single scheduler tick — check schedules, heartbeats, clock-aligned wakes, auto-sleep, idle sessions, expired messages, dreams, and url watchers."""
         now = time.time()
 
+        self._run_outbox_reaper_if_due(now)
         self._warn_oversized_schedule_prompts(now)
 
         # Check cron schedules
@@ -465,6 +515,33 @@ class AgentScheduler:
 
         # Check URL watcher triggers
         await self._check_url_watchers(now)
+
+    def _run_outbox_reaper_if_due(self, now: float) -> bool:
+        """Run host-owned outbox maintenance once per local calendar day."""
+        current_day = date.fromtimestamp(now)
+        if self._last_outbox_reaper_day == current_day:
+            return False
+        # Record the attempt before entering storage so a persistent failure
+        # emits one loud daily error instead of flooding every scheduler tick.
+        self._last_outbox_reaper_day = current_day
+        try:
+            self._registry.reap_pending_schedule_wakes(
+                now=now,
+                abandon_after=self._receipt_extension_max_age_sec,
+                retain_accepted=self._outbox_reaper_retain_accepted_sec,
+                retain_abandoned=self._outbox_reaper_retain_abandoned_sec,
+                retain_parked=self._outbox_reaper_retain_parked_sec,
+                payload_trim_after=(
+                    self._outbox_reaper_payload_trim_after_sec
+                ),
+            )
+        except Exception as exc:
+            _log(
+                "scheduler: outbox reaper failed: "
+                f"{type(exc).__name__}: {exc}"
+            )
+            return False
+        return True
 
     def _warn_oversized_schedule_prompts(
         self,
@@ -772,13 +849,17 @@ class AgentScheduler:
                 prompt=self._wake_prompt(schedule),
                 fired_at=schedule.last_run,
             )
-            # A retired (parked) or already-accepted fire must not be delivered:
+            # A terminal or already-accepted fire must not be delivered:
             # an operator may have discarded this fire while its cohort task
             # waited behind the per-agent delivery lock. Delivering would
             # resurrect the tombstone (and the delivery-confirm would clear it).
             # Set the cohort-start event first so ``_check_schedules`` does not
             # wait out its timeout on a discarded first cohort member.
-            if row is not None and (row.parked_at > 0 or row.accepted_at > 0):
+            if row is not None and (
+                row.parked_at > 0
+                or row.abandoned_at > 0
+                or row.accepted_at > 0
+            ):
                 if attempt_started is not None:
                     attempt_started.set()
                 return
@@ -957,6 +1038,15 @@ class AgentScheduler:
                         "duplicate undelivered verdict"
                     )
                     return
+                if row is not None and row.abandoned_at > 0:
+                    _log(
+                        f"scheduler: schedule '{schedule.name}' "
+                        f"(#{schedule.id}) for agent "
+                        f"'{schedule.agent_name}' is already abandoned "
+                        f"(fired_at={schedule.last_run}); suppressing "
+                        "duplicate undelivered verdict"
+                    )
+                    return
             except Exception as exc:
                 _log(
                     f"scheduler: SCHEDULER_WAKE_PERSIST_FAILURE schedule "
@@ -1101,7 +1191,7 @@ class AgentScheduler:
         stale_drop_notices: list[RecurringScheduleStaleDrop],
     ) -> None:
         """Release the delivery lock while retaining late-receipt authority."""
-        schedule_id, fired_at, _ = self._quarantine_abandoned_receipt(
+        schedule_id, fired_at, _ = self._mark_abandoned_receipt(
             schedule, age=age
         )
 
@@ -1133,10 +1223,10 @@ class AgentScheduler:
 
         self._track_detached_receipt_task(_observe_late_receipt())
 
-    def _quarantine_abandoned_receipt(
+    def _mark_abandoned_receipt(
         self, schedule, *, age: float
     ) -> tuple[int, float, bool]:
-        """Quarantine one unrecallable fire without submitting new work."""
+        """Abandon one unrecallable fire without submitting new work."""
         reason = (
             "RECEIPT_ABANDONED: original fired_at exceeded receipt-extension "
             f"ceiling ({age:.1f}s >= {self._receipt_extension_max_age_sec:.1f}s)"
@@ -1146,10 +1236,11 @@ class AgentScheduler:
         row = self._registry.get_schedule_wake_by_fire(
             schedule_id, fired_at
         )
-        parked = bool(
+        abandoned = bool(
             row is not None
-            and self._registry.park_pending_schedule_wake(
+            and self._registry.abandon_pending_schedule_wake(
                 row.id,
+                abandoned_at=time.time(),
                 reason=reason,
             )
         )
@@ -1158,7 +1249,7 @@ class AgentScheduler:
             f"(#{schedule_id}) for agent '{schedule.agent_name}' "
             f"fired_at={fired_at} age_s={age:.1f} "
             f"ceiling_s={self._receipt_extension_max_age_sec:.1f} "
-            f"quarantined={parked}"
+            f"abandoned={abandoned}"
         )
         if self._activity:
             try:
@@ -1170,7 +1261,7 @@ class AgentScheduler:
                 )
             except Exception:
                 pass
-        return schedule_id, fired_at, parked
+        return schedule_id, fired_at, abandoned
 
     def _abandon_inflight_replay(
         self,
@@ -1186,16 +1277,16 @@ class AgentScheduler:
         callback.  Polling only observes that existing authority; it never
         creates another transport turn.
         """
-        schedule_id, fired_at, parked = self._quarantine_abandoned_receipt(
+        schedule_id, fired_at, abandoned = self._mark_abandoned_receipt(
             schedule, age=age
         )
         row = self._registry.get_schedule_wake_by_fire(schedule_id, fired_at)
         retained = bool(
-            parked
+            abandoned
             or (
                 row is not None
                 and row.accepted_at == 0
-                and row.parked_at > 0
+                and row.abandoned_at > 0
                 and row.last_error.startswith("RECEIPT_ABANDONED")
             )
         )
@@ -1420,11 +1511,12 @@ class AgentScheduler:
         health = self._registry.get_pending_schedule_wake_health(
             agent_name, now=replay_now
         )
-        if health:
+        if health and health[0]["count"] > 0:
             summary = health[0]
             _log(
                 f"scheduler: PERSISTED_WAKE_OUTBOX_HEALTH agent="
                 f"'{agent_name}' count={summary['count']} "
+                f"abandoned_count={summary['abandoned_count']} "
                 f"oldest_age_s={summary['oldest_age_seconds']:.1f} "
                 f"oldest_fired_at={summary['oldest_fired_at']}"
             )
@@ -1440,7 +1532,7 @@ class AgentScheduler:
         abandoned_schedule_ids = set()
         for pending in all_pending_wakes:
             if (
-                pending.parked_at > 0
+                pending.abandoned_at > 0
                 and pending.last_error.startswith("RECEIPT_ABANDONED")
                 and self._wake_prompt_inflight(
                     pending,
@@ -1465,7 +1557,7 @@ class AgentScheduler:
             elif not current_schedule.enabled and not current_schedule.one_shot:
                 zombie_reason = "schedule disabled"
             if zombie_reason:
-                if pending.parked_at != 0:
+                if pending.parked_at != 0 or pending.abandoned_at != 0:
                     continue
                 quarantined = self._registry.park_pending_schedule_wake(
                     pending.id,
@@ -1486,7 +1578,7 @@ class AgentScheduler:
                         "park returned no state change"
                     )
                 continue
-            if pending.parked_at != 0:
+            if pending.parked_at != 0 or pending.abandoned_at != 0:
                 continue
             if pending.schedule_id in abandoned_schedule_ids:
                 _log(
@@ -1504,7 +1596,7 @@ class AgentScheduler:
             )
             # Invariant: abandonment precedes both stale deletion and
             # recurrence collapse. Once a prompt is physically pasted it
-            # cannot be recalled, so replay must quarantine that exact fire
+            # cannot be recalled, so replay must abandon that exact fire
             # in place and retain its existing durable acceptance authority.
             # Calling _wait_for_wake_confirmation here would paste a duplicate.
             past_receipt_ceiling = (

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -5515,18 +5515,44 @@ class TestAgentScheduleEndpoints:
         assert body["records"][0]["state"] == "receipted-ran-once"
         assert body["records"][0]["fired_at"] == 100.0
 
+        abandoned, _ = registry.persist_schedule_wake(
+            created["id"],
+            agent_name="alice",
+            schedule_name="morning",
+            prompt="Ambiguous receipt",
+            fired_at=200.0,
+        )
+        assert registry.abandon_pending_schedule_wake(
+            abandoned.id, abandoned_at=210.0
+        )
+        response = client.get(
+            "/scheduler/wake-ledger",
+            params={"agent_name": "alice", "state": "abandoned"},
+        )
+        assert response.status_code == 200
+        assert response.json()["records"][0]["state"] == "abandoned"
+        assert response.json()["records"][0]["abandoned_at"] == 210.0
+
     def test_scheduler_status_surfaces_pending_count_and_age(self):
         client = self._make_client()
         self._register(client, "alice")
         created = self._create_schedule(client).json()
         registry = client.app.state.agents
-        registry.persist_schedule_wake(
+        active, _ = registry.persist_schedule_wake(
             created["id"],
             agent_name="alice",
             schedule_name="morning",
             prompt="frozen",
             fired_at=time.time() - 120.0,
         )
+        abandoned, _ = registry.persist_schedule_wake(
+            created["id"],
+            agent_name="alice",
+            schedule_name="morning",
+            prompt="ambiguous",
+            fired_at=active.fired_at - 120.0,
+        )
+        assert registry.abandon_pending_schedule_wake(abandoned.id)
 
         response = client.get("/scheduler/status")
 
@@ -5535,6 +5561,7 @@ class TestAgentScheduleEndpoints:
         assert body["pending_schedule_wake_count"] == 1
         assert body["pending_schedule_wakes"][0]["agent_name"] == "alice"
         assert body["pending_schedule_wakes"][0]["count"] == 1
+        assert body["pending_schedule_wakes"][0]["abandoned_count"] == 1
         assert body["pending_schedule_wakes"][0]["oldest_age_seconds"] >= 119
 
     def test_discard_pending_wake_is_agent_scoped(self):

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1222,6 +1222,154 @@ class TestOutboxReaper:
             "payloads_trimmed=0 retained_active=0"
         ]
 
+    def test_late_phase_failure_reports_commits_and_retry_matches_clean_run(
+        self, registry, tmp_path, monkeypatch, capsys
+    ):
+        now = 2_000_000_000.0
+        backoff = 100.0
+
+        def seed(reg):
+            reg.register("fault")
+            schedule = reg.add_schedule(
+                "fault", "0 1 * * *", name="fault", prompt="run"
+            )
+            expired, _ = reg.persist_schedule_wake(
+                schedule.id,
+                agent_name="fault",
+                schedule_name=schedule.name,
+                prompt="delete me",
+                fired_at=now - 8 * self.DAY,
+            )
+            retained, _ = reg.persist_schedule_wake(
+                schedule.id,
+                agent_name="fault",
+                schedule_name=schedule.name,
+                prompt="trim me",
+                fired_at=now - 3 * self.DAY,
+            )
+            assert reg.confirm_pending_schedule_wake(
+                expired.id, delivered_at=now - 7 * self.DAY - 1
+            )
+            assert reg.confirm_pending_schedule_wake(
+                retained.id, delivered_at=now - 3 * self.DAY
+            )
+            return expired, retained
+
+        expired, retained = seed(registry)
+        registry._db.execute(
+            f"""CREATE TRIGGER fail_outbox_payload_trim
+               BEFORE UPDATE OF prompt ON pending_schedule_wakes
+               WHEN NEW.prompt={OUTBOX_REAPER_PAYLOAD_TRIMMED!r}
+                    AND OLD.prompt<>NEW.prompt
+               BEGIN
+                 SELECT RAISE(ABORT, 'injected payload trim failure');
+               END"""
+        )
+        registry._db.commit()
+
+        monkeypatch.setenv(
+            "PINKY_OUTBOX_REAPER_FAILURE_BACKOFF_SEC", str(backoff)
+        )
+        scheduler = AgentScheduler(registry)
+        actual_reap = registry.reap_pending_schedule_wakes
+        failures: list[type[Exception]] = []
+        successes: list[list[dict[str, int | str]]] = []
+
+        def observe_reap(**kwargs):
+            try:
+                result = actual_reap(**kwargs)
+            except Exception as exc:
+                failures.append(type(exc))
+                raise
+            successes.append(result)
+            return result
+
+        monkeypatch.setattr(
+            registry, "reap_pending_schedule_wakes", observe_reap
+        )
+        capsys.readouterr()
+
+        assert scheduler._run_outbox_reaper_if_due(now) is False
+        assert failures == [sqlite3.IntegrityError]
+        assert scheduler._last_outbox_reaper_day is None
+        assert scheduler._last_outbox_reaper_failed_at == now
+        assert registry.get_schedule_wake_by_fire(
+            expired.schedule_id, expired.fired_at
+        ) is None
+        assert registry.get_schedule_wake_by_fire(
+            retained.schedule_id, retained.fired_at
+        ).prompt == "trim me"
+        partial_logs = capsys.readouterr().err
+        assert (
+            "outbox-reaper: agent=fault abandoned=+0 accepted_reaped=1 "
+            "abandoned_reaped=0 parked_reaped=0 payloads_trimmed=0 "
+            "retained_active=0"
+        ) in partial_logs
+        assert (
+            "outbox-reaper: summary PARTIAL failed_phase=payload_trim "
+            "agents=1 abandoned=+0 accepted_reaped=1 "
+            "abandoned_reaped=0 parked_reaped=0 payloads_trimmed=0 "
+            "retained_active=0"
+        ) in partial_logs
+
+        assert scheduler._run_outbox_reaper_if_due(
+            now + backoff - 1
+        ) is False
+        assert failures == [sqlite3.IntegrityError]
+        assert successes == []
+        assert capsys.readouterr().err == ""
+
+        registry._db.execute("DROP TRIGGER fail_outbox_payload_trim")
+        registry._db.commit()
+        assert scheduler._run_outbox_reaper_if_due(
+            now + backoff
+        ) is True
+        assert scheduler._run_outbox_reaper_if_due(
+            now + backoff + 1
+        ) is False
+        assert scheduler._last_outbox_reaper_failed_at is None
+        assert len(successes) == 1
+        retry_metrics = successes[0][0]
+        assert retry_metrics["accepted_reaped"] == 0
+        assert retry_metrics["payloads_trimmed"] == 1
+        assert registry.get_schedule_wake_by_fire(
+            retained.schedule_id, retained.fired_at
+        ).prompt == OUTBOX_REAPER_PAYLOAD_TRIMMED
+
+        clean_registry = AgentRegistry(
+            db_path=str(tmp_path / "clean-reaper.db")
+        )
+        try:
+            seed(clean_registry)
+            clean_metrics = self._reap(
+                clean_registry,
+                now=now + backoff,
+                payload_trim_after=2 * self.DAY,
+            )[0]
+
+            def snapshot(reg):
+                return reg._db.execute(
+                    """SELECT agent_name, schedule_name, prompt, fired_at,
+                              accepted_at, parked_at, abandoned_at, last_error
+                       FROM pending_schedule_wakes
+                       ORDER BY id"""
+                ).fetchall()
+
+            assert snapshot(registry) == snapshot(clean_registry)
+            partial_commits = {
+                "abandoned": 0,
+                "accepted_reaped": 1,
+                "abandoned_reaped": 0,
+                "parked_reaped": 0,
+                "payloads_trimmed": 0,
+            }
+            for field, partial_count in partial_commits.items():
+                assert clean_metrics[field] == (
+                    partial_count + int(retry_metrics[field])
+                )
+        finally:
+            clean_registry.close()
+
     @pytest.mark.asyncio
     async def test_inflight_drain_and_reap_converge_to_one_receipt(
         self, registry, monkeypatch
@@ -1387,6 +1535,9 @@ class TestOutboxReaper:
         monkeypatch.setenv(
             "PINKY_OUTBOX_REAPER_PAYLOAD_TRIM_AFTER_SEC", "404"
         )
+        monkeypatch.setenv(
+            "PINKY_OUTBOX_REAPER_FAILURE_BACKOFF_SEC", "505"
+        )
         calls: list[dict] = []
         monkeypatch.setattr(
             registry,
@@ -1414,6 +1565,7 @@ class TestOutboxReaper:
             "retain_parked": 303.0,
             "payload_trim_after": 404.0,
         }
+        assert scheduler._outbox_reaper_failure_backoff_sec == 505.0
 
 
 # ── Agent Heartbeat Tests ──────────────────────────────────

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -13,6 +13,7 @@ from datetime import datetime
 
 import pytest
 
+import pinky_daemon.agent_registry as agent_registry_module
 from pinky_daemon.agent_registry import (
     OUTBOX_REAPER_PAYLOAD_TRIMMED,
     AgentRegistry,
@@ -1230,8 +1231,12 @@ class TestOutboxReaper:
 
         def seed(reg):
             reg.register("fault")
+            reg.register("witness")
             schedule = reg.add_schedule(
                 "fault", "0 1 * * *", name="fault", prompt="run"
+            )
+            witness_schedule = reg.add_schedule(
+                "witness", "0 2 * * *", name="witness", prompt="run"
             )
             expired, _ = reg.persist_schedule_wake(
                 schedule.id,
@@ -1253,6 +1258,13 @@ class TestOutboxReaper:
             assert reg.confirm_pending_schedule_wake(
                 retained.id, delivered_at=now - 3 * self.DAY
             )
+            reg.persist_schedule_wake(
+                witness_schedule.id,
+                agent_name="witness",
+                schedule_name=witness_schedule.name,
+                prompt="stay active",
+                fired_at=now - 10,
+            )
             return expired, retained
 
         expired, retained = seed(registry)
@@ -1272,14 +1284,14 @@ class TestOutboxReaper:
         )
         scheduler = AgentScheduler(registry)
         actual_reap = registry.reap_pending_schedule_wakes
-        failures: list[type[Exception]] = []
+        failures: list[Exception] = []
         successes: list[list[dict[str, int | str]]] = []
 
         def observe_reap(**kwargs):
             try:
                 result = actual_reap(**kwargs)
             except Exception as exc:
-                failures.append(type(exc))
+                failures.append(exc)
                 raise
             successes.append(result)
             return result
@@ -1287,10 +1299,28 @@ class TestOutboxReaper:
         monkeypatch.setattr(
             registry, "reap_pending_schedule_wakes", observe_reap
         )
+        original_log = agent_registry_module._log
+        emitted: list[str] = []
+        failed_once = False
+
+        def flaky_log(message: str) -> None:
+            nonlocal failed_once
+            if not failed_once and message.startswith(
+                "outbox-reaper: agent="
+            ):
+                failed_once = True
+                raise OSError("injected one-shot disposition failure")
+            emitted.append(message)
+            original_log(message)
+
+        monkeypatch.setattr(agent_registry_module, "_log", flaky_log)
         capsys.readouterr()
 
         assert scheduler._run_outbox_reaper_if_due(now) is False
-        assert failures == [sqlite3.IntegrityError]
+        assert failed_once is True
+        assert len(failures) == 1
+        assert type(failures[0]) is sqlite3.IntegrityError
+        assert "injected payload trim failure" in str(failures[0])
         assert scheduler._last_outbox_reaper_day is None
         assert scheduler._last_outbox_reaper_failed_at == now
         assert registry.get_schedule_wake_by_fire(
@@ -1301,21 +1331,29 @@ class TestOutboxReaper:
         ).prompt == "trim me"
         partial_logs = capsys.readouterr().err
         assert (
-            "outbox-reaper: agent=fault abandoned=+0 accepted_reaped=1 "
+            "outbox-reaper: agent=witness abandoned=+0 accepted_reaped=0 "
             "abandoned_reaped=0 parked_reaped=0 payloads_trimmed=0 "
-            "retained_active=0"
+            "retained_active=1"
         ) in partial_logs
         assert (
             "outbox-reaper: summary PARTIAL failed_phase=payload_trim "
-            "agents=1 abandoned=+0 accepted_reaped=1 "
+            "agents=2 abandoned=+0 accepted_reaped=1 "
             "abandoned_reaped=0 parked_reaped=0 payloads_trimmed=0 "
-            "retained_active=0"
+            "retained_active=1"
         ) in partial_logs
+        assert "outbox-reaper: ERROR maintenance pass failed" in emitted
+        assert any(
+            line.startswith(
+                "outbox-reaper: emission ERROR while reporting "
+                "maintenance failure: OSError: "
+            )
+            for line in emitted
+        )
 
         assert scheduler._run_outbox_reaper_if_due(
             now + backoff - 1
         ) is False
-        assert failures == [sqlite3.IntegrityError]
+        assert len(failures) == 1
         assert successes == []
         assert capsys.readouterr().err == ""
 

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -13,7 +13,11 @@ from datetime import datetime
 
 import pytest
 
-from pinky_daemon.agent_registry import AgentRegistry, ScheduleNameConflictError
+from pinky_daemon.agent_registry import (
+    OUTBOX_REAPER_PAYLOAD_TRIMMED,
+    AgentRegistry,
+    ScheduleNameConflictError,
+)
 from pinky_daemon.scheduler import (
     _SCHEDULE_PROMPT_WARN_INTERVAL_SEC,
     AgentScheduler,
@@ -507,6 +511,7 @@ class TestAgentSchedules:
             {
                 "agent_name": "oleg",
                 "count": 1,
+                "abandoned_count": 0,
                 "oldest_fired_at": 100.0,
                 "newest_fired_at": 100.0,
                 "oldest_age_seconds": 400.0,
@@ -652,6 +657,7 @@ class TestAgentSchedules:
             assert columns.count("accepted_at") == 1
             assert columns.count("failed_at") == 1
             assert columns.count("last_error") == 1
+            assert columns.count("abandoned_at") == 1
         finally:
             reopened.close()
             os.unlink(path)
@@ -756,6 +762,658 @@ class TestAgentSchedules:
         enabled = registry.get_schedules("oleg")
         assert len(enabled) == 1
         assert enabled[0].name == "morning"
+
+
+# ── Scheduler wake outbox reaper tests ────────────────────
+
+
+class TestOutboxReaper:
+    DAY = 24 * 60 * 60
+
+    @classmethod
+    def _reap(
+        cls,
+        registry,
+        *,
+        now: float,
+        abandon_after: float = 3_600,
+        retain_accepted: float | None = None,
+        retain_abandoned: float | None = None,
+        retain_parked: float | None = None,
+        payload_trim_after: float | None = None,
+        batch_size: int = 10_000,
+    ):
+        return registry.reap_pending_schedule_wakes(
+            now=now,
+            abandon_after=abandon_after,
+            retain_accepted=(
+                7 * cls.DAY
+                if retain_accepted is None
+                else retain_accepted
+            ),
+            retain_abandoned=(
+                14 * cls.DAY
+                if retain_abandoned is None
+                else retain_abandoned
+            ),
+            retain_parked=(
+                30 * cls.DAY if retain_parked is None else retain_parked
+            ),
+            payload_trim_after=(
+                1_000_000_000
+                if payload_trim_after is None
+                else payload_trim_after
+            ),
+            batch_size=batch_size,
+        )
+
+    def test_transition_is_strict_at_ceiling_and_separates_health(
+        self, registry, capsys
+    ):
+        registry.register("oleg")
+        schedule = registry.add_schedule(
+            "oleg", "0 8 * * *", name="boundary", prompt="run"
+        )
+        now = 2_000_000_000.0
+        stranded, _ = registry.persist_schedule_wake(
+            schedule.id,
+            agent_name="oleg",
+            schedule_name=schedule.name,
+            prompt="stranded",
+            fired_at=now - 3_601,
+        )
+        boundary, _ = registry.persist_schedule_wake(
+            schedule.id,
+            agent_name="oleg",
+            schedule_name=schedule.name,
+            prompt="boundary",
+            fired_at=now - 3_600,
+        )
+        young, _ = registry.persist_schedule_wake(
+            schedule.id,
+            agent_name="oleg",
+            schedule_name=schedule.name,
+            prompt="young",
+            fired_at=now - 3_599,
+        )
+        legacy_parked, _ = registry.persist_schedule_wake(
+            schedule.id,
+            agent_name="oleg",
+            schedule_name=schedule.name,
+            prompt="legacy abandoned",
+            fired_at=now - 3_602,
+        )
+        assert registry.park_pending_schedule_wake(
+            legacy_parked.id,
+            parked_at=now - 2,
+            reason="RECEIPT_ABANDONED: legacy ceiling marker",
+        )
+        capsys.readouterr()
+
+        metrics = self._reap(
+            registry,
+            now=now,
+            batch_size=2,
+        )
+
+        assert metrics == [
+            {
+                "agent_name": "oleg",
+                "abandoned": 2,
+                "accepted_reaped": 0,
+                "abandoned_reaped": 0,
+                "parked_reaped": 0,
+                "payloads_trimmed": 0,
+                "retained_active": 2,
+            }
+        ]
+        by_id = {
+            row.id: row for row in registry.list_schedule_wake_ledger("oleg")
+        }
+        assert by_id[stranded.id].ledger_state == "abandoned"
+        assert by_id[stranded.id].abandoned_at == now
+        assert by_id[legacy_parked.id].ledger_state == "abandoned"
+        assert by_id[legacy_parked.id].abandoned_at == now
+        assert by_id[legacy_parked.id].parked_at == 0
+        assert by_id[boundary.id].ledger_state == "pending"
+        assert by_id[young.id].ledger_state == "pending"
+        assert [
+            row.id for row in registry.list_pending_schedule_wakes("oleg")
+        ] == [boundary.id, young.id]
+        assert registry.get_pending_schedule_wake_health(
+            "oleg", now=now
+        ) == [
+            {
+                "agent_name": "oleg",
+                "count": 2,
+                "abandoned_count": 2,
+                "oldest_fired_at": now - 3_600,
+                "newest_fired_at": now - 3_599,
+                "oldest_age_seconds": 3_600.0,
+            }
+        ]
+        logs = capsys.readouterr().err
+        assert (
+            "outbox-reaper: agent=oleg abandoned=+2 accepted_reaped=0 "
+            "abandoned_reaped=0 parked_reaped=0 payloads_trimmed=0 "
+            "retained_active=2"
+        ) in logs
+        assert "outbox-reaper: summary agents=1 abandoned=+2" in logs
+
+    def test_transition_chunks_rows_above_batch_limit(self, registry):
+        registry.register("oleg")
+        schedule = registry.add_schedule(
+            "oleg", "0 8 * * *", name="batch", prompt="run"
+        )
+        now = 2_000_000_000.0
+        rows = [
+            registry.persist_schedule_wake(
+                schedule.id,
+                agent_name="oleg",
+                schedule_name=schedule.name,
+                prompt=f"old-{index}",
+                fired_at=now - 4_000 - index,
+            )[0]
+            for index in range(5)
+        ]
+
+        metrics = self._reap(
+            registry,
+            now=now,
+            batch_size=2,
+        )
+
+        assert metrics[0]["abandoned"] == 5
+        assert metrics[0]["retained_active"] == 0
+        assert {
+            registry.get_schedule_wake_by_fire(
+                schedule.id, row.fired_at
+            ).ledger_state
+            for row in rows
+        } == {"abandoned"}
+        assert registry.get_pending_schedule_wake_health(
+            "oleg", now=now
+        ) == [
+            {
+                "agent_name": "oleg",
+                "count": 0,
+                "abandoned_count": 5,
+                "oldest_fired_at": 0.0,
+                "newest_fired_at": 0.0,
+                "oldest_age_seconds": 0.0,
+            }
+        ]
+
+    def test_retention_boundaries_and_newest_parked_specimen(
+        self, registry
+    ):
+        registry.register("oleg")
+        now = 2_000_000_000.0
+        accepted_schedule = registry.add_schedule(
+            "oleg", "0 1 * * *", name="accepted", prompt="accepted"
+        )
+        abandoned_schedule = registry.add_schedule(
+            "oleg", "0 2 * * *", name="abandoned", prompt="abandoned"
+        )
+        discarded_schedule = registry.add_schedule(
+            "oleg", "0 3 * * *", name="discarded", prompt="discarded"
+        )
+        parked_schedule = registry.add_schedule(
+            "oleg", "0 4 * * *", name="parked", prompt="parked"
+        )
+        boundary_parked_schedule = registry.add_schedule(
+            "oleg", "0 5 * * *", name="parked-boundary", prompt="parked"
+        )
+
+        accepted_old, _ = registry.persist_schedule_wake(
+            accepted_schedule.id,
+            agent_name="oleg",
+            schedule_name=accepted_schedule.name,
+            prompt="accepted-old",
+            fired_at=now - 7 * self.DAY - 100,
+        )
+        accepted_boundary, _ = registry.persist_schedule_wake(
+            accepted_schedule.id,
+            agent_name="oleg",
+            schedule_name=accepted_schedule.name,
+            prompt="accepted-boundary",
+            fired_at=now - 7 * self.DAY - 99,
+        )
+        assert registry.confirm_pending_schedule_wake(
+            accepted_old.id, delivered_at=now - 7 * self.DAY - 1
+        )
+        assert registry.confirm_pending_schedule_wake(
+            accepted_boundary.id, delivered_at=now - 7 * self.DAY
+        )
+
+        abandoned_old, _ = registry.persist_schedule_wake(
+            abandoned_schedule.id,
+            agent_name="oleg",
+            schedule_name=abandoned_schedule.name,
+            prompt="abandoned-old",
+            fired_at=now - 14 * self.DAY - 100,
+        )
+        abandoned_boundary, _ = registry.persist_schedule_wake(
+            abandoned_schedule.id,
+            agent_name="oleg",
+            schedule_name=abandoned_schedule.name,
+            prompt="abandoned-boundary",
+            fired_at=now - 14 * self.DAY - 99,
+        )
+        assert registry.abandon_pending_schedule_wake(
+            abandoned_old.id,
+            abandoned_at=now - 14 * self.DAY - 1,
+        )
+        assert registry.abandon_pending_schedule_wake(
+            abandoned_boundary.id,
+            abandoned_at=now - 14 * self.DAY,
+        )
+
+        discarded_old, _ = registry.persist_schedule_wake(
+            discarded_schedule.id,
+            agent_name="oleg",
+            schedule_name=discarded_schedule.name,
+            prompt="discarded-old",
+            fired_at=now - 14 * self.DAY - 98,
+        )
+        discarded_boundary, _ = registry.persist_schedule_wake(
+            discarded_schedule.id,
+            agent_name="oleg",
+            schedule_name=discarded_schedule.name,
+            prompt="discarded-boundary",
+            fired_at=now - 14 * self.DAY - 97,
+        )
+        assert registry.discard_pending_schedule_wake(discarded_old.id)
+        assert registry.discard_pending_schedule_wake(discarded_boundary.id)
+        registry._db.execute(
+            "UPDATE pending_schedule_wakes SET parked_at=? WHERE id=?",
+            (now - 14 * self.DAY - 1, discarded_old.id),
+        )
+        registry._db.execute(
+            "UPDATE pending_schedule_wakes SET parked_at=? WHERE id=?",
+            (now - 14 * self.DAY, discarded_boundary.id),
+        )
+
+        parked_oldest, _ = registry.persist_schedule_wake(
+            parked_schedule.id,
+            agent_name="oleg",
+            schedule_name=parked_schedule.name,
+            prompt="parked-oldest",
+            fired_at=now - 30 * self.DAY - 100,
+        )
+        parked_newest, _ = registry.persist_schedule_wake(
+            parked_schedule.id,
+            agent_name="oleg",
+            schedule_name=parked_schedule.name,
+            prompt="parked-newest",
+            fired_at=now - 30 * self.DAY - 99,
+        )
+        assert registry.park_pending_schedule_wake(
+            parked_oldest.id,
+            parked_at=now - 30 * self.DAY - 2,
+            reason="old quarantine",
+        )
+        assert registry.park_pending_schedule_wake(
+            parked_newest.id,
+            parked_at=now - 30 * self.DAY - 1,
+            reason="newest open quarantine",
+        )
+        parked_boundary, _ = registry.persist_schedule_wake(
+            boundary_parked_schedule.id,
+            agent_name="oleg",
+            schedule_name=boundary_parked_schedule.name,
+            prompt="parked-boundary",
+            fired_at=now - 30 * self.DAY - 98,
+        )
+        assert registry.park_pending_schedule_wake(
+            parked_boundary.id,
+            parked_at=now - 30 * self.DAY,
+            reason="boundary quarantine",
+        )
+        registry._db.commit()
+
+        metrics = self._reap(registry, now=now)
+
+        assert metrics[0]["accepted_reaped"] == 1
+        assert metrics[0]["abandoned_reaped"] == 2
+        assert metrics[0]["parked_reaped"] == 1
+        remaining = {
+            row.id for row in registry.list_schedule_wake_ledger("oleg")
+        }
+        assert accepted_old.id not in remaining
+        assert abandoned_old.id not in remaining
+        assert discarded_old.id not in remaining
+        assert parked_oldest.id not in remaining
+        assert accepted_boundary.id in remaining
+        assert abandoned_boundary.id in remaining
+        assert discarded_boundary.id in remaining
+        assert parked_newest.id in remaining
+        assert parked_boundary.id in remaining
+
+    def test_payload_trim_is_auditable_quarantine_safe_and_idempotent(
+        self, registry
+    ):
+        registry.register("oleg")
+        now = 2_000_000_000.0
+        schedule = registry.add_schedule(
+            "oleg", "0 1 * * *", name="payloads", prompt="payload"
+        )
+        parked_schedule = registry.add_schedule(
+            "oleg", "0 2 * * *", name="parked-payloads", prompt="payload"
+        )
+
+        def persist(prompt: str, offset: float):
+            return registry.persist_schedule_wake(
+                schedule.id,
+                agent_name="oleg",
+                schedule_name=schedule.name,
+                prompt=prompt,
+                fired_at=now - offset,
+            )[0]
+
+        accepted = persist("accepted secret", 3 * self.DAY + 100)
+        abandoned = persist("abandoned secret", 3 * self.DAY + 99)
+        discarded = persist("discarded secret", 3 * self.DAY + 98)
+        trim_boundary = persist("exactly 48h", 2 * self.DAY + 97)
+        active = persist("active secret", 10)
+        terminal_at = now - 3 * self.DAY
+        assert registry.confirm_pending_schedule_wake(
+            accepted.id, delivered_at=terminal_at
+        )
+        assert registry.abandon_pending_schedule_wake(
+            abandoned.id, abandoned_at=terminal_at
+        )
+        assert registry.discard_pending_schedule_wake(discarded.id)
+        registry._db.execute(
+            "UPDATE pending_schedule_wakes SET parked_at=? WHERE id=?",
+            (terminal_at, discarded.id),
+        )
+        assert registry.confirm_pending_schedule_wake(
+            trim_boundary.id,
+            delivered_at=now - 2 * self.DAY,
+        )
+
+        parked_old, _ = registry.persist_schedule_wake(
+            parked_schedule.id,
+            agent_name="oleg",
+            schedule_name=parked_schedule.name,
+            prompt="closed quarantine secret",
+            fired_at=now - 3 * self.DAY - 96,
+        )
+        parked_latest, _ = registry.persist_schedule_wake(
+            parked_schedule.id,
+            agent_name="oleg",
+            schedule_name=parked_schedule.name,
+            prompt="open quarantine specimen",
+            fired_at=now - 3 * self.DAY - 95,
+        )
+        assert registry.park_pending_schedule_wake(
+            parked_old.id,
+            parked_at=now - 3 * self.DAY,
+            reason="older quarantine",
+        )
+        assert registry.park_pending_schedule_wake(
+            parked_latest.id,
+            parked_at=now - 3 * self.DAY + 1,
+            reason="latest quarantine",
+        )
+        registry._db.commit()
+        health_before = registry.get_pending_schedule_wake_health(
+            "oleg", now=now
+        )
+
+        first = self._reap(
+            registry,
+            now=now,
+            abandon_after=3_600,
+            retain_accepted=100 * self.DAY,
+            retain_abandoned=100 * self.DAY,
+            retain_parked=100 * self.DAY,
+            payload_trim_after=2 * self.DAY,
+        )
+
+        by_id = {
+            row.id: row for row in registry.list_schedule_wake_ledger("oleg")
+        }
+        assert first[0]["payloads_trimmed"] == 4
+        for row_id in (
+            accepted.id,
+            abandoned.id,
+            discarded.id,
+            parked_old.id,
+        ):
+            assert by_id[row_id].prompt == OUTBOX_REAPER_PAYLOAD_TRIMMED
+        assert by_id[trim_boundary.id].prompt == "exactly 48h"
+        assert by_id[parked_latest.id].prompt == "open quarantine specimen"
+        assert by_id[active.id].prompt == "active secret"
+        assert registry.get_pending_schedule_wake_health(
+            "oleg", now=now
+        ) == health_before
+
+        second = self._reap(
+            registry,
+            now=now,
+            abandon_after=3_600,
+            retain_accepted=100 * self.DAY,
+            retain_abandoned=100 * self.DAY,
+            retain_parked=100 * self.DAY,
+            payload_trim_after=2 * self.DAY,
+        )
+        assert second[0]["abandoned"] == 0
+        assert second[0]["accepted_reaped"] == 0
+        assert second[0]["abandoned_reaped"] == 0
+        assert second[0]["parked_reaped"] == 0
+        assert second[0]["payloads_trimmed"] == 0
+        assert second[0]["retained_active"] == 1
+
+    def test_zero_work_run_logs_one_summary(self, registry, capsys):
+        capsys.readouterr()
+
+        assert self._reap(registry, now=2_000_000_000.0) == []
+
+        lines = [
+            line
+            for line in capsys.readouterr().err.splitlines()
+            if line.startswith("outbox-reaper:")
+        ]
+        assert lines == [
+            "outbox-reaper: summary agents=0 abandoned=+0 "
+            "accepted_reaped=0 abandoned_reaped=0 parked_reaped=0 "
+            "payloads_trimmed=0 retained_active=0"
+        ]
+
+    @pytest.mark.asyncio
+    async def test_inflight_drain_and_reap_converge_to_one_receipt(
+        self, registry, monkeypatch
+    ):
+        registry.register("worker")
+        schedule = registry.add_schedule(
+            "worker", "0 0 * * *", name="concurrent", prompt="deliver once"
+        )
+        now = 2_000_000_000.0
+        fired_at = now - 91
+        pending, _ = registry.persist_schedule_wake(
+            schedule.id,
+            agent_name="worker",
+            schedule_name=schedule.name,
+            prompt=schedule.prompt,
+            fired_at=fired_at,
+        )
+        monkeypatch.setattr(
+            "pinky_daemon.scheduler.time.time", lambda: now
+        )
+        delivery_started = asyncio.Event()
+        release_delivery = asyncio.Event()
+        deliveries: list[str] = []
+
+        async def confirm_once(agent_name, session_id, prompt):
+            del agent_name, session_id
+            deliveries.append(prompt)
+            delivery_started.set()
+            await release_delivery.wait()
+            return True
+
+        scheduler = AgentScheduler(
+            registry,
+            wake_callback=confirm_once,
+            delivery_inflight_fn=lambda agent_name, prompt: (
+                delivery_started.is_set()
+            ),
+            schedule_delivery_timeout=10,
+            pending_wake_max_age_sec=1_000,
+            receipt_extension_max_age_sec=90,
+        )
+        scheduler.replay_pending_for_agent("worker")
+        await asyncio.wait_for(delivery_started.wait(), timeout=1)
+
+        metrics = self._reap(
+            registry,
+            now=now,
+            abandon_after=90,
+            retain_accepted=100 * self.DAY,
+            retain_abandoned=100 * self.DAY,
+            retain_parked=100 * self.DAY,
+        )
+        assert metrics[0]["abandoned"] == 1
+        release_delivery.set()
+        await scheduler._pending_replay_tasks["worker"]
+
+        row = registry.get_schedule_wake_by_fire(schedule.id, fired_at)
+        assert deliveries == ["deliver once"]
+        assert row.id == pending.id
+        assert row.ledger_state == "receipted-ran-once"
+        assert row.accepted_at == now
+        assert row.abandoned_at == 0
+        assert row.parked_at == 0
+
+    @pytest.mark.asyncio
+    async def test_reap_before_boot_drain_never_delivers_abandoned_row(
+        self, registry
+    ):
+        registry.register("worker")
+        schedule = registry.add_schedule(
+            "worker", "0 0 * * *", name="old", prompt="never replay"
+        )
+        now = 2_000_000_000.0
+        pending, _ = registry.persist_schedule_wake(
+            schedule.id,
+            agent_name="worker",
+            schedule_name=schedule.name,
+            prompt=schedule.prompt,
+            fired_at=now - 3_601,
+        )
+        deliveries: list[str] = []
+
+        async def unexpected(agent_name, session_id, prompt):
+            del agent_name, session_id
+            deliveries.append(prompt)
+            return True
+
+        scheduler = AgentScheduler(registry, wake_callback=unexpected)
+        self._reap(registry, now=now)
+
+        scheduler._drain_outbox_if_pending("worker")
+        await asyncio.sleep(0)
+
+        assert deliveries == []
+        assert "worker" not in scheduler._pending_replay_tasks
+        assert registry.get_schedule_wake_by_fire(
+            schedule.id, pending.fired_at
+        ).ledger_state == "abandoned"
+
+    @pytest.mark.asyncio
+    async def test_daemon_start_reaps_before_boot_replay(
+        self, registry, monkeypatch
+    ):
+        registry.register("worker")
+        schedule = registry.add_schedule(
+            "worker", "0 0 * * *", name="boot", prompt="deliver young"
+        )
+        now = 2_000_000_000.0
+        old, _ = registry.persist_schedule_wake(
+            schedule.id,
+            agent_name="worker",
+            schedule_name=schedule.name,
+            prompt="do not deliver old",
+            fired_at=now - 3_601,
+        )
+        young, _ = registry.persist_schedule_wake(
+            schedule.id,
+            agent_name="worker",
+            schedule_name=schedule.name,
+            prompt="deliver young",
+            fired_at=now - 60,
+        )
+        monkeypatch.setattr(
+            "pinky_daemon.scheduler.time.time", lambda: now
+        )
+        deliveries: list[str] = []
+
+        async def confirm(agent_name, session_id, prompt):
+            del agent_name, session_id
+            deliveries.append(prompt)
+            return True
+
+        scheduler = AgentScheduler(registry, wake_callback=confirm)
+
+        async def no_loop():
+            return None
+
+        monkeypatch.setattr(scheduler, "_loop", no_loop)
+        await scheduler.start()
+        await asyncio.gather(*scheduler._pending_replay_tasks.values())
+        await scheduler.stop()
+
+        assert deliveries == ["deliver young"]
+        assert registry.get_schedule_wake_by_fire(
+            schedule.id, old.fired_at
+        ).ledger_state == "abandoned"
+        assert registry.get_schedule_wake_by_fire(
+            schedule.id, young.fired_at
+        ).ledger_state == "receipted-ran-once"
+
+    def test_daemon_schedule_runs_once_per_day_with_configured_windows(
+        self, registry, monkeypatch
+    ):
+        monkeypatch.setenv(
+            "PINKY_OUTBOX_REAPER_RETAIN_ACCEPTED_SEC", "101"
+        )
+        monkeypatch.setenv(
+            "PINKY_OUTBOX_REAPER_RETAIN_ABANDONED_SEC", "202"
+        )
+        monkeypatch.setenv(
+            "PINKY_OUTBOX_REAPER_RETAIN_PARKED_SEC", "303"
+        )
+        monkeypatch.setenv(
+            "PINKY_OUTBOX_REAPER_PAYLOAD_TRIM_AFTER_SEC", "404"
+        )
+        calls: list[dict] = []
+        monkeypatch.setattr(
+            registry,
+            "reap_pending_schedule_wakes",
+            lambda **kwargs: calls.append(kwargs),
+        )
+        scheduler = AgentScheduler(
+            registry,
+            receipt_extension_max_age_sec=90,
+        )
+        now = 2_000_000_000.0
+
+        assert scheduler._run_outbox_reaper_if_due(now) is True
+        assert scheduler._run_outbox_reaper_if_due(now + 60) is False
+        assert scheduler._run_outbox_reaper_if_due(
+            now + self.DAY
+        ) is True
+
+        assert len(calls) == 2
+        assert calls[0] == {
+            "now": now,
+            "abandon_after": 90.0,
+            "retain_accepted": 101.0,
+            "retain_abandoned": 202.0,
+            "retain_parked": 303.0,
+            "payload_trim_after": 404.0,
+        }
 
 
 # ── Agent Heartbeat Tests ──────────────────────────────────
@@ -1791,7 +2449,7 @@ class TestScheduler:
         ledger = restarted_registry.get_schedule_wake_by_fire(
             schedule.id, fired_at
         )
-        assert ledger.ledger_state == "quarantined"
+        assert ledger.ledger_state == "abandoned"
         assert "RECEIPT_ABANDONED" in ledger.last_error
         assert submissions == []
         assert not restarted._schedule_delivery_locks["worker"].locked()
@@ -1928,7 +2586,7 @@ class TestScheduler:
         assert ledger is not None
         assert ledger.id == pending.id
         assert ledger.id != ledger.schedule_id
-        assert ledger.ledger_state == "quarantined"
+        assert ledger.ledger_state == "abandoned"
         assert "RECEIPT_ABANDONED" in ledger.last_error
         assert submissions == []
         assert probes and set(probes) == {("worker", "pasted")}
@@ -2152,13 +2810,13 @@ class TestScheduler:
         ledger = registry.get_schedule_wake_by_fire(schedule.id, fired_at)
         assert ledger is not None
         assert ledger.id == pending.id
-        assert ledger.ledger_state == "quarantined"
+        assert ledger.ledger_state == "abandoned"
         assert "RECEIPT_ABANDONED" in ledger.last_error
         assert durable_receipt is not None
         assert durable_receipt.schedule_id == schedule.id
         logs = capsys.readouterr().err
         assert "schedule 'late-identity' (#1)" in logs
-        assert "quarantined=True" in logs
+        assert "abandoned=True" in logs
 
         assert durable_receipt.accept() is True
         process_local_receipt.set_result(True)
@@ -2228,7 +2886,7 @@ class TestScheduler:
             row.id: row for row in registry.list_schedule_wake_ledger("worker")
         }
         assert submissions == []
-        assert by_id[older.id].ledger_state == "quarantined"
+        assert by_id[older.id].ledger_state == "abandoned"
         assert "RECEIPT_ABANDONED" in by_id[older.id].last_error
         assert by_id[newer.id].ledger_state == "pending"
         assert by_id[newer.id].attempts == 0


### PR DESCRIPTION
The scheduler's durable wake ledger (`pending_schedule_wakes`) doubles as replay outbox and forensic receipt store, and nothing ever cleans it: terminal rows retain full prompt payloads forever (#1035), and active rows past the replay ceiling accumulate indefinitely as apparent debt, hiding genuinely stuck deliveries in stale noise. Observed fleet-wide growth doubled over three days.

This adds a reaper with a strict contract — it only transitions state and deletes expired history; it never delivers, replays, or re-queues:

- **`abandoned_at` terminal state** (additive column migration): active rows past the abandonment ceiling transition to an explicit terminal state instead of counting as active debt forever. The existing `RECEIPT_ABANDONED` path now writes it directly; a one-time pass reclassifies legacy tombstones preserving their `last_error`/`failed_at` forensics. A late positive receipt atomically wins over abandonment.
- **Retention windows** per class: accepted 7d, abandoned/discarded 14d, parked quarantine 30d with the newest specimen per schedule retained indefinitely.
- **Payload trim**: terminal rows older than 48h have their prompt replaced by a constant self-describing sentinel (`[payload trimmed by outbox reaper]`) — the column is `TEXT NOT NULL`, so the sentinel avoids a table rebuild while keeping policy-trim distinguishable from data loss. Receipt fields and health counts survive; active rows and the newest parked specimen are exempt.
- **Separated health counters**: the health helper now reports `abandoned_count` alongside the active count, so real replay debt and receipt-gap history are distinct numbers.
- **Daemon-side scheduling**: runs at daemon start (before boot replay, so young rows are untouched) and once per local calendar day. Chunked (10k) for large backlogs. Every run emits per-agent and summary metrics; zero-work runs still log.

Boundary guarantees under test: exact-ceiling boundary, non-interference with the boot-boundary drain (concurrent drain+reap converges to a single accepted outcome), retention day-before/day-after per class, sentinel idempotence, legacy reclassification, migration, and API surfacing. Suites green on 3.11 and 3.13 (API, scheduler focused, broad).

🤖 Opened by barsik