### PR TITLE
Fix scheduler queued receipt gap (#1068)

### DIFF
--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -11441,6 +11441,25 @@ npm run build</pre>
             return False
         return probe(prompt) is True
 
+    def _scheduler_wake_queued(agent_name: str, prompt: str) -> bool:
+        """Per-turn queue state: is this wake live and still recallable?"""
+        ss = broker._get_streaming_session(agent_name)
+        probe = getattr(ss, "scheduler_wake_queued", None) if ss else None
+        if not callable(probe):
+            return False
+        return probe(prompt) is True
+
+    async def _cancel_scheduler_wake(agent_name: str, prompt: str) -> bool:
+        """Recall an exact queued wake and preserve the transport outcome."""
+        ss = broker._get_streaming_session(agent_name)
+        cancel = getattr(ss, "cancel_scheduler_wake", None) if ss else None
+        if not callable(cancel):
+            return False
+        result = cancel(prompt)
+        if inspect.isawaitable(result):
+            result = await result
+        return result is True
+
     async def _notify_owner_alert(
         agent_name: str, message: str
     ) -> bool:
@@ -11599,6 +11618,8 @@ npm run build</pre>
         comms_cleanup_fn=comms.cleanup_expired,
         delivery_busy_fn=_scheduler_delivery_busy,
         delivery_inflight_fn=_scheduler_wake_inflight,
+        delivery_queued_fn=_scheduler_wake_queued,
+        delivery_cancel_queued_fn=_cancel_scheduler_wake,
         owner_notify_callback=_notify_owner_alert,
         trigger_store=trigger_store,
         activity=activity,

--- a/src/pinky_daemon/scheduler.py
+++ b/src/pinky_daemon/scheduler.py
@@ -264,6 +264,8 @@ class AgentScheduler:
         comms_cleanup_fn=None,
         delivery_busy_fn=None,
         delivery_inflight_fn=None,
+        delivery_queued_fn=None,
+        delivery_cancel_queued_fn=None,
         owner_notify_callback=None,
         trigger_store=None,
         activity=None,
@@ -313,6 +315,17 @@ class AgentScheduler:
         # At the ceiling the waiter detaches, the exact row is explicitly
         # abandoned, and a later positive receipt can still win.
         self._delivery_inflight_fn = delivery_inflight_fn
+        # fn(agent_name, prompt) -> bool. True means THIS wake remains queued
+        # and recallable before its first pane paste on a live transport. This
+        # is positive in-progress evidence just like ``delivery_inflight_fn``:
+        # timing it out would persist a replay row while the original remains
+        # deliverable. The companion cancel callback owns the ceiling edge.
+        self._delivery_queued_fn = delivery_queued_fn
+        # fn(agent_name, prompt) -> bool | Awaitable[bool]. True proves the
+        # exact queued-unpasted turn was recalled. False means the scheduler
+        # must re-read transport state: the turn may have raced to paste, in
+        # which case the unrecallable inflight abandonment path owns it.
+        self._delivery_cancel_queued_fn = delivery_cancel_queued_fn
         # async fn(agent_name, text) -> bool. Delivers operator-facing owner
         # alerts for terminal dead-letter events (PERSISTED_WAKE_PARKED, stale
         # one-shot drop) through an out-of-band transport. Routine
@@ -1147,10 +1160,128 @@ class AgentScheduler:
                 except asyncio.TimeoutError:
                     age = self._receipt_age(schedule)
                     if age >= self._receipt_extension_max_age_sec:
+                        queued = self._wake_prompt_queued(
+                            schedule, prompt=delivery_prompt
+                        )
+                        if queued:
+                            cancelled = await self._cancel_queued_wake(
+                                schedule, prompt=delivery_prompt
+                            )
+                            if cancelled:
+                                # Transport recall is the load-bearing first
+                                # transition. Retire the process-local waiter
+                                # only after the pane turn is no longer
+                                # deliverable, then abandon its durable row.
+                                delivery.cancel()
+                                await asyncio.gather(
+                                    delivery, return_exceptions=True
+                                )
+                                _log(
+                                    "scheduler: cancelled-queued schedule "
+                                    f"'{schedule.name}' "
+                                    f"(#{self._schedule_id(schedule)}) for "
+                                    f"agent '{schedule.agent_name}' before "
+                                    "receipt abandonment"
+                                )
+                                self._mark_abandoned_receipt(
+                                    schedule, age=age
+                                )
+                                raise _ReceiptAbandonedError
+
+                            # Acceptance can land while the transport recall
+                            # waits for its pane lock. Positive consumption is
+                            # terminal and outranks both queued and pasted
+                            # timeout handling.
+                            await asyncio.sleep(0)
+                            settled, confirmed = (
+                                self._delivery_result_if_done(delivery)
+                            )
+                            if settled:
+                                if confirmed and stale_drop_notices:
+                                    self._acknowledge_recurring_stale_drops(
+                                        schedule.agent_name,
+                                        stale_drop_notices,
+                                    )
+                                return confirmed
+
+                            # The queued probe and recall are separate edges.
+                            # If pane delivery won between them, cancellation
+                            # is no longer safe; retain late-receipt authority
+                            # exactly like every other pasted turn.
+                            if self._wake_prompt_inflight(
+                                schedule, prompt=delivery_prompt
+                            ):
+                                self._abandon_receipt_wait(
+                                    schedule,
+                                    delivery,
+                                    age=age,
+                                    stale_drop_notices=stale_drop_notices,
+                                )
+                                raise _ReceiptAbandonedError
+
+                            # A transport without an explicit recall hook (or
+                            # one that failed while the exact turn remains
+                            # queued) still gets the established receipt-
+                            # cancellation fence. There is no await between
+                            # the positive recheck and Task.cancel(), so the
+                            # pane path cannot advance in this event-loop turn;
+                            # its in-lock cancelled-receipt guard completes
+                            # the recall before any later paste.
+                            if self._wake_prompt_queued(
+                                schedule, prompt=delivery_prompt
+                            ):
+                                task_cancelled = delivery.cancel()
+                                await asyncio.gather(
+                                    delivery, return_exceptions=True
+                                )
+                                if task_cancelled:
+                                    _log(
+                                        "scheduler: cancelled-queued schedule "
+                                        f"'{schedule.name}' "
+                                        f"(#{self._schedule_id(schedule)}) "
+                                        f"for agent '{schedule.agent_name}' "
+                                        "before receipt abandonment "
+                                        "(receipt-fence fallback)"
+                                    )
+                                    self._mark_abandoned_receipt(
+                                        schedule, age=age
+                                    )
+                                    raise _ReceiptAbandonedError
+
                         inflight = self._wake_prompt_inflight(
                             schedule, prompt=delivery_prompt
                         )
                         if inflight:
+                            self._abandon_receipt_wait(
+                                schedule,
+                                delivery,
+                                age=age,
+                                stale_drop_notices=stale_drop_notices,
+                            )
+                            raise _ReceiptAbandonedError
+
+                        # A transcript acceptance can resolve the transport
+                        # Future in the same event-loop turn as this timeout.
+                        # Give the delivery task one scheduling edge before a
+                        # stale negative cancel, then re-read exact state.
+                        await asyncio.sleep(0)
+                        settled, confirmed = self._delivery_result_if_done(
+                            delivery
+                        )
+                        if settled:
+                            if confirmed and stale_drop_notices:
+                                self._acknowledge_recurring_stale_drops(
+                                    schedule.agent_name,
+                                    stale_drop_notices,
+                                )
+                            return confirmed
+                        if self._wake_prompt_queued(
+                            schedule, prompt=delivery_prompt
+                        ):
+                            continue
+                        if self._wake_prompt_inflight(
+                            schedule, prompt=delivery_prompt
+                        ):
                             self._abandon_receipt_wait(
                                 schedule,
                                 delivery,
@@ -1188,6 +1319,34 @@ class AgentScheduler:
                             "would re-persist a wake that is about to "
                             "execute (duplicate execution); extending"
                         )
+                        continue
+                    if self._wake_prompt_queued(
+                        schedule, prompt=delivery_prompt
+                    ):
+                        _log(
+                            f"scheduler: receipt still pending for schedule "
+                            f"'{schedule.name}' "
+                            f"(#{self._schedule_id(schedule)}) for agent "
+                            f"'{schedule.agent_name}', but its prompt is "
+                            "queued-unpasted on a connected transport; "
+                            "extending delivery timeout"
+                        )
+                        continue
+                    await asyncio.sleep(0)
+                    settled, confirmed = self._delivery_result_if_done(
+                        delivery
+                    )
+                    if settled:
+                        if confirmed and stale_drop_notices:
+                            self._acknowledge_recurring_stale_drops(
+                                schedule.agent_name, stale_drop_notices
+                            )
+                        return confirmed
+                    if self._wake_prompt_inflight(
+                        schedule, prompt=delivery_prompt
+                    ) or self._wake_prompt_queued(
+                        schedule, prompt=delivery_prompt
+                    ):
                         continue
                     delivery.cancel()
                     await asyncio.gather(delivery, return_exceptions=True)
@@ -1907,6 +2066,55 @@ class AgentScheduler:
                 f"'{schedule.agent_name}': {type(exc).__name__}: {exc}"
             )
             return False
+
+    def _wake_prompt_queued(self, schedule, *, prompt: str | None = None) -> bool:
+        """True when this wake is queued-unpasted and safely recallable."""
+        if self._delivery_queued_fn is None:
+            return False
+        try:
+            return (
+                self._delivery_queued_fn(
+                    schedule.agent_name,
+                    self._wake_prompt(schedule) if prompt is None else prompt,
+                )
+                is True
+            )
+        except Exception as exc:
+            _log(
+                f"scheduler: wake-queued check failed for "
+                f"'{schedule.agent_name}': {type(exc).__name__}: {exc}"
+            )
+            return False
+
+    async def _cancel_queued_wake(
+        self, schedule, *, prompt: str | None = None
+    ) -> bool:
+        """Recall one exact queued wake, returning only positive evidence."""
+        if self._delivery_cancel_queued_fn is None:
+            return False
+        try:
+            cancelled = self._delivery_cancel_queued_fn(
+                schedule.agent_name,
+                self._wake_prompt(schedule) if prompt is None else prompt,
+            )
+            if inspect.isawaitable(cancelled):
+                cancelled = await cancelled
+            return cancelled is True
+        except Exception as exc:
+            _log(
+                f"scheduler: queued-wake cancel failed for "
+                f"'{schedule.agent_name}': {type(exc).__name__}: {exc}"
+            )
+            return False
+
+    @staticmethod
+    def _delivery_result_if_done(
+        delivery: asyncio.Task,
+    ) -> tuple[bool, bool]:
+        """Return ``(settled, confirmed)`` without consuming cancellation."""
+        if not delivery.done() or delivery.cancelled():
+            return False, False
+        return True, delivery.result()
 
     async def _wake_and_confirm(
         self,

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -4410,6 +4410,66 @@ class TmuxSession(TransportReplacementMixin):
                 return True
         return False
 
+    def _scheduler_wake_candidates(self) -> list[_QueuedTurn]:
+        """Return every known scheduler turn, including #943 queue replay."""
+        candidates = self._acceptance_candidates()
+        # The #943 unaccepted-head recovery deliberately removes its turn from
+        # ``_scheduler_pending_turns`` before disconnect, then preserves it in
+        # the ordinary worker queue across the replacement pane. There is a
+        # real queued-unpasted window before the new worker pulls that head.
+        # asyncio.Queue has no public snapshot API; this event-loop-local read
+        # is non-mutating and the only way to include that load-bearing shape.
+        candidates.extend(
+            turn
+            for turn in self._message_queue._queue  # type: ignore[attr-defined]
+            if turn.scheduler_serialized
+        )
+        unique: dict[int, _QueuedTurn] = {}
+        for turn in candidates:
+            unique.setdefault(id(turn), turn)
+        return sorted(unique.values(), key=lambda turn: turn.queued_at)
+
+    def scheduler_wake_queued(self, prompt: str) -> bool:
+        """True when this exact wake is live, queued-unpasted, and recallable."""
+        if self.state != SessionState.CONNECTED:
+            return False
+        for turn in self._scheduler_wake_candidates():
+            receipt = turn.scheduler_delivery
+            if (
+                turn.scheduler_serialized
+                and receipt is not None
+                and not receipt.done()
+                and not turn.pane_delivery_started
+                and turn.prompt == prompt
+            ):
+                return True
+        return False
+
+    async def cancel_scheduler_wake(self, prompt: str) -> bool:
+        """Recall one exact queued-unpasted wake before its pane paste.
+
+        The shared REPL-control lock makes the outcome authoritative. If this
+        coroutine wins the lock, cancelling the receipt fences both scheduler
+        and #943 ordinary-worker paste paths. If pane delivery won first,
+        ``pane_delivery_started`` is already true and False tells the
+        scheduler to fall back to its unrecallable pasted-state handling.
+        """
+        if self.state != SessionState.CONNECTED:
+            return False
+        async with self._repl_control_lock:
+            for turn in self._scheduler_wake_candidates():
+                receipt = turn.scheduler_delivery
+                if (
+                    turn.scheduler_serialized
+                    and receipt is not None
+                    and not receipt.done()
+                    and turn.prompt == prompt
+                ):
+                    if turn.pane_delivery_started:
+                        return False
+                    return receipt.cancel()
+        return False
+
     async def _queue_external_turn(
         self,
         prompt: str,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -8929,6 +8929,32 @@ class TestBuildStreamingWakeContextReasonGating:
             assert idle_agents == ["test-agent"]
 
     @pytest.mark.asyncio
+    async def test_scheduler_queued_probe_and_recall_are_wired_to_transport(
+        self,
+    ):
+        """The production scheduler preserves exact tmux queue outcomes."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            app = self._make_app(os.path.join(tmpdir, "test.db"))
+            cancel = AsyncMock(return_value=True)
+            session = SimpleNamespace(
+                scheduler_wake_queued=lambda prompt: prompt == "exact wake",
+                cancel_scheduler_wake=cancel,
+            )
+            with patch.object(
+                app.state.broker,
+                "_get_streaming_session",
+                return_value=session,
+            ):
+                assert app.state.scheduler._delivery_queued_fn(
+                    "dymok", "exact wake"
+                ) is True
+                assert await app.state.scheduler._delivery_cancel_queued_fn(
+                    "dymok", "exact wake"
+                ) is True
+
+            cancel.assert_awaited_once_with("exact wake")
+
+    @pytest.mark.asyncio
     async def test_scheduler_owner_alert_uses_owner_destination(self):
         """The owner-notify callback (dead-letter alerts: PARKED / stale
         one-shot drop) routes to the durable #863 owner destination."""

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -2584,6 +2584,333 @@ class TestScheduler:
         assert "already pasted to the transport" in capsys.readouterr().err
 
     @pytest.mark.asyncio
+    async def test_queued_wake_extends_until_consumed_without_replay(
+        self, registry, capsys
+    ):
+        """#1068: queued-unpasted is positive evidence, not a replay trigger."""
+        registry.register("oleg")
+        schedule = registry.add_schedule(
+            "oleg", "* * * * *", name="busy-morning", prompt="run once"
+        )
+        fired_at = time.time()
+        registry.update_schedule_last_run(schedule.id, fired_at)
+        schedule.last_run = fired_at
+        receipt = asyncio.get_running_loop().create_future()
+        queued = True
+        submissions = 0
+
+        async def consume_after_busy_turn() -> None:
+            nonlocal queued
+            await asyncio.sleep(0.035)
+            queued = False
+            receipt.set_result(True)
+
+        async def wake_cb(agent_name, session_id, prompt):
+            nonlocal submissions
+            del agent_name, session_id, prompt
+            submissions += 1
+            asyncio.create_task(consume_after_busy_turn())
+            return receipt
+
+        scheduler = AgentScheduler(
+            registry,
+            wake_callback=wake_cb,
+            delivery_busy_fn=lambda agent_name: False,
+            delivery_inflight_fn=lambda agent_name, prompt: False,
+            delivery_queued_fn=lambda agent_name, prompt: queued,
+            schedule_delivery_timeout=0.01,
+            receipt_extension_max_age_sec=1.0,
+        )
+
+        await scheduler._deliver_schedule(schedule)
+
+        ledger = registry.get_schedule_wake_by_fire(schedule.id, fired_at)
+        assert submissions == 1
+        assert ledger is not None
+        assert ledger.attempts == 0
+        assert ledger.accepted_at > 0
+        assert registry.list_pending_schedule_wakes("oleg") == []
+        assert "queued-unpasted on a connected transport" in capsys.readouterr().err
+
+    @pytest.mark.asyncio
+    async def test_queued_wake_ceiling_cancels_before_abandoning(
+        self, registry, monkeypatch, capsys
+    ):
+        """A ceiling cannot abandon while the original turn is deliverable."""
+        registry.register("oleg")
+        schedule = registry.add_schedule(
+            "oleg", "* * * * *", name="bounded", prompt="recall me"
+        )
+        fired_at = time.time()
+        registry.update_schedule_last_run(schedule.id, fired_at)
+        schedule.last_run = fired_at
+        receipt = asyncio.get_running_loop().create_future()
+        queued = True
+        transitions: list[str] = []
+        original_abandon = registry.abandon_pending_schedule_wake
+
+        def abandon(*args, **kwargs):
+            transitions.append("abandon")
+            return original_abandon(*args, **kwargs)
+
+        monkeypatch.setattr(
+            registry, "abandon_pending_schedule_wake", abandon
+        )
+
+        async def wake_cb(agent_name, session_id, prompt):
+            del agent_name, session_id, prompt
+            return receipt
+
+        async def cancel_queued(agent_name, prompt):
+            nonlocal queued
+            del agent_name, prompt
+            transitions.append("cancel")
+            queued = False
+            assert receipt.cancel() is True
+            return True
+
+        scheduler = AgentScheduler(
+            registry,
+            wake_callback=wake_cb,
+            delivery_busy_fn=lambda agent_name: False,
+            delivery_inflight_fn=lambda agent_name, prompt: False,
+            delivery_queued_fn=lambda agent_name, prompt: queued,
+            delivery_cancel_queued_fn=cancel_queued,
+            schedule_delivery_timeout=0.01,
+            receipt_extension_max_age_sec=0.03,
+        )
+
+        await scheduler._deliver_schedule(schedule)
+
+        ledger = registry.get_schedule_wake_by_fire(schedule.id, fired_at)
+        assert transitions == ["cancel", "abandon"]
+        assert ledger is not None
+        assert ledger.ledger_state == "abandoned"
+        assert registry.list_pending_schedule_wakes("oleg") == []
+        logs = capsys.readouterr().err
+        assert logs.index("cancelled-queued") < logs.index("RECEIPT_ABANDONED")
+
+    @pytest.mark.asyncio
+    async def test_queued_cancel_paste_race_uses_inflight_abandonment(
+        self, registry
+    ):
+        """A paste winning the recall race retains late-receipt authority."""
+        registry.register("oleg")
+        schedule = registry.add_schedule(
+            "oleg", "* * * * *", name="race", prompt="paste wins"
+        )
+        fired_at = time.time()
+        registry.update_schedule_last_run(schedule.id, fired_at)
+        schedule.last_run = fired_at
+        receipt = asyncio.get_running_loop().create_future()
+        state = {"queued": True, "inflight": False}
+
+        async def wake_cb(agent_name, session_id, prompt):
+            del agent_name, session_id, prompt
+            return receipt
+
+        async def lose_cancel_race(agent_name, prompt):
+            del agent_name, prompt
+            state.update(queued=False, inflight=True)
+            return False
+
+        scheduler = AgentScheduler(
+            registry,
+            wake_callback=wake_cb,
+            delivery_busy_fn=lambda agent_name: False,
+            delivery_inflight_fn=(
+                lambda agent_name, prompt: state["inflight"]
+            ),
+            delivery_queued_fn=lambda agent_name, prompt: state["queued"],
+            delivery_cancel_queued_fn=lose_cancel_race,
+            schedule_delivery_timeout=0.01,
+            receipt_extension_max_age_sec=0.03,
+        )
+
+        await scheduler._deliver_schedule(schedule)
+
+        ledger = registry.get_schedule_wake_by_fire(schedule.id, fired_at)
+        assert ledger is not None
+        assert ledger.ledger_state == "abandoned"
+        assert not receipt.cancelled()
+        receipt.set_result(True)
+        await asyncio.gather(*list(scheduler._detached_receipt_tasks))
+        assert registry.get_schedule_wake_by_fire(
+            schedule.id, fired_at
+        ).ledger_state == "receipted-ran-once"
+
+    @pytest.mark.asyncio
+    async def test_acceptance_during_queued_cancel_wins_over_abandonment(
+        self, registry
+    ):
+        """A fast consumption while recall awaits its lock is terminal True."""
+        registry.register("oleg")
+        schedule = registry.add_schedule(
+            "oleg", "* * * * *", name="fast-race", prompt="accepted"
+        )
+        fired_at = time.time()
+        registry.update_schedule_last_run(schedule.id, fired_at)
+        schedule.last_run = fired_at
+        receipt = asyncio.get_running_loop().create_future()
+        state = {"queued": True, "inflight": False}
+
+        async def wake_cb(agent_name, session_id, prompt):
+            del agent_name, session_id, prompt
+            return receipt
+
+        async def acceptance_wins(agent_name, prompt):
+            del agent_name, prompt
+            state["queued"] = False
+            receipt.set_result(True)
+            await asyncio.sleep(0)
+            return False
+
+        scheduler = AgentScheduler(
+            registry,
+            wake_callback=wake_cb,
+            delivery_busy_fn=lambda agent_name: False,
+            delivery_inflight_fn=(
+                lambda agent_name, prompt: state["inflight"]
+            ),
+            delivery_queued_fn=lambda agent_name, prompt: state["queued"],
+            delivery_cancel_queued_fn=acceptance_wins,
+            schedule_delivery_timeout=0.01,
+            receipt_extension_max_age_sec=0.03,
+        )
+
+        await scheduler._deliver_schedule(schedule)
+
+        ledger = registry.get_schedule_wake_by_fire(schedule.id, fired_at)
+        assert ledger is not None
+        assert ledger.ledger_state == "receipted-ran-once"
+        assert ledger.abandoned_at == 0
+        assert registry.list_pending_schedule_wakes("oleg") == []
+
+    @pytest.mark.asyncio
+    async def test_settled_receipt_beats_transient_double_negative(
+        self, registry, capsys
+    ):
+        """Both probes can read False before the positive waiter resumes."""
+        registry.register("oleg")
+        schedule = registry.add_schedule(
+            "oleg", "* * * * *", name="settle-edge", prompt="accepted once"
+        )
+        fired_at = time.time()
+        registry.update_schedule_last_run(schedule.id, fired_at)
+        schedule.last_run = fired_at
+        receipt = asyncio.get_running_loop().create_future()
+        submissions = 0
+
+        async def wake_cb(agent_name, session_id, prompt):
+            nonlocal submissions
+            del agent_name, session_id, prompt
+            submissions += 1
+            return receipt
+
+        def double_negative_at_acceptance(agent_name, prompt):
+            del agent_name, prompt
+            # The transport persisted/observed acceptance and resolved its
+            # Future, but _wake_and_confirm has not had a scheduling edge to
+            # turn that into a completed delivery Task yet. Both exact state
+            # probes therefore read False in this transient window.
+            if not receipt.done():
+                receipt.set_result(True)
+            return False
+
+        scheduler = AgentScheduler(
+            registry,
+            wake_callback=wake_cb,
+            delivery_busy_fn=lambda agent_name: False,
+            delivery_inflight_fn=lambda agent_name, prompt: False,
+            delivery_queued_fn=double_negative_at_acceptance,
+            schedule_delivery_timeout=0.01,
+            receipt_extension_max_age_sec=1.0,
+        )
+
+        await scheduler._deliver_schedule(schedule)
+
+        ledger = registry.get_schedule_wake_by_fire(schedule.id, fired_at)
+        assert submissions == 1
+        assert receipt.result() is True
+        assert ledger is not None
+        assert ledger.ledger_state == "receipted-ran-once"
+        assert ledger.attempts == 0
+        assert registry.list_pending_schedule_wakes("oleg") == []
+        assert "FIRED BUT UNDELIVERED" not in capsys.readouterr().err
+
+    @pytest.mark.asyncio
+    async def test_busy_replay_accepts_at_consumption_before_turn_completion(
+        self, registry, capsys
+    ):
+        """#966/#1068: the 08-14 replay shape receipts during the turn."""
+        registry.register("worker")
+        schedule = registry.add_schedule(
+            "worker", "0 7 * * *", name="morning", prompt="daily work"
+        )
+        fired_at = time.time()
+        pending, _ = registry.persist_schedule_wake(
+            schedule.id,
+            agent_name="worker",
+            schedule_name=schedule.name,
+            prompt=schedule.prompt,
+            fired_at=fired_at,
+        )
+        receipt = asyncio.get_running_loop().create_future()
+        state = {"queued": True, "inflight": False, "turn_done": False}
+        durable_receipt = None
+        submissions = 0
+
+        async def wake_cb(
+            agent_name,
+            session_id,
+            prompt,
+            *,
+            schedule_receipt,
+        ):
+            nonlocal durable_receipt, submissions
+            del agent_name, session_id, prompt
+            submissions += 1
+            durable_receipt = schedule_receipt
+            return receipt
+
+        scheduler = AgentScheduler(
+            registry,
+            wake_callback=wake_cb,
+            delivery_busy_fn=lambda agent_name: False,
+            delivery_inflight_fn=(
+                lambda agent_name, prompt: state["inflight"]
+            ),
+            delivery_queued_fn=lambda agent_name, prompt: state["queued"],
+            schedule_delivery_timeout=0.01,
+            receipt_extension_max_age_sec=1.0,
+        )
+
+        replay = asyncio.create_task(
+            scheduler._replay_pending_locked("worker")
+        )
+        for _ in range(100):
+            if durable_receipt is not None:
+                break
+            await asyncio.sleep(0.001)
+        await asyncio.sleep(0.02)
+        state.update(queued=False, inflight=True)
+        assert state["turn_done"] is False
+        assert durable_receipt is not None
+        assert durable_receipt.accept() is True
+        receipt.set_result(True)
+        await replay
+
+        ledger = registry.get_schedule_wake_by_fire(schedule.id, fired_at)
+        assert submissions == 1
+        assert ledger is not None
+        assert ledger.id == pending.id
+        assert ledger.attempts == 1
+        assert ledger.accepted_at > 0
+        assert state["turn_done"] is False
+        assert registry.list_pending_schedule_wakes("worker") == []
+        assert "queued-unpasted on a connected transport" in capsys.readouterr().err
+
+    @pytest.mark.asyncio
     async def test_receipt_ceiling_uses_persisted_fired_at_across_restart(
         self, registry, monkeypatch, capsys
     ):

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -3795,7 +3795,7 @@ async def test_disconnect_clears_inflight_meta() -> None:
 
 @pytest.mark.asyncio
 async def test_scheduler_prompt_receipt_waits_for_idle_pane() -> None:
-    """Successful pane keystrokes are not a scheduler delivery receipt."""
+    """#966: consumption receipts before the accepted turn completes."""
     ss, tmux = _make_session(state=SessionState.CONNECTED)
     ss._config.live_status_fn = lambda: {
         "status": "idle",
@@ -3823,6 +3823,10 @@ async def test_scheduler_prompt_receipt_waits_for_idle_pane() -> None:
         "operation": "dequeue",
     })
     assert await receipt is True
+    assert len(ss._inflight_metas) == 1
+    assert not ss._turn_done.is_set(), (
+        "transport acceptance must not wait for turn completion"
+    )
     await ss.disconnect()
 
 
@@ -3906,12 +3910,83 @@ async def test_scheduler_cancel_before_paste_never_pastes() -> None:
     await asyncio.sleep(0.02)
     assert tmux.paste_text.await_count == 0
     assert ss.scheduler_wake_inflight("scheduled") is False
+    assert ss.scheduler_wake_queued("scheduled") is True
+    assert ss.scheduler_wake_queued("some other prompt") is False
 
-    receipt.cancel()
+    assert await ss.cancel_scheduler_wake("scheduled") is True
+    assert receipt.cancelled()
+    assert ss.scheduler_wake_queued("scheduled") is False
     live["status"] = "idle"
     live["last_updated"] = _time.time()
     await asyncio.sleep(0.35)  # > slot-wait poll interval
     assert tmux.paste_text.await_count == 0
+    await ss.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_scheduler_wake_queued_tracks_943_requeued_head() -> None:
+    """#943's ordinary-worker replay queue remains visible and recallable."""
+    ss, tmux = _make_session(state=SessionState.CONNECTED)
+    ss._config.live_status_fn = lambda: {
+        "status": "idle",
+        "last_updated": _time.time(),
+    }
+    receipt = asyncio.get_running_loop().create_future()
+    replayed_head = _QueuedTurn(
+        prompt="requeued scheduler head",
+        scheduler_delivery=receipt,
+        scheduler_serialized=True,
+    )
+    ss._message_queue.put_nowait(replayed_head)
+
+    assert replayed_head not in ss._scheduler_pending_turns
+    assert ss.scheduler_wake_queued("requeued scheduler head") is True
+    assert await ss.cancel_scheduler_wake("requeued scheduler head") is True
+    assert receipt.cancelled()
+
+    ss._worker_task = asyncio.create_task(ss._message_worker())
+    for _ in range(100):
+        if ss._message_queue.empty():
+            break
+        await asyncio.sleep(0.001)
+    await asyncio.sleep(0)
+    assert tmux.paste_text.await_count == 0
+    await ss.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_scheduler_cancel_paste_race_reports_pasted() -> None:
+    """The REPL lock adjudicates a paste that starts during queued recall."""
+    ss, tmux = _make_session(state=SessionState.CONNECTED)
+    ss._config.live_status_fn = lambda: {
+        "status": "idle",
+        "last_updated": _time.time(),
+    }
+
+    await ss._repl_control_lock.acquire()
+    try:
+        receipt = await ss.send_scheduler_prompt("paste race")
+        # The delivery waiter enters the lock queue first; the cancellation
+        # waiter starts from a positive queued probe immediately behind it.
+        await asyncio.sleep(0.02)
+        assert ss.scheduler_wake_queued("paste race") is True
+        cancel = asyncio.create_task(
+            ss.cancel_scheduler_wake("paste race")
+        )
+        await asyncio.sleep(0)
+    finally:
+        ss._repl_control_lock.release()
+
+    assert await cancel is False
+    assert tmux.paste_text.await_count == 1
+    assert ss.scheduler_wake_inflight("paste race") is True
+    assert not receipt.cancelled()
+
+    ss._on_transcript_entry({
+        "type": "user",
+        "message": {"role": "user", "content": "paste race"},
+    })
+    assert await receipt is True
     await ss.disconnect()
 
 


### PR DESCRIPTION
## Summary

- Add exact scheduler_wake_queued evidence for connected, unresolved, queued-unpasted tmux turns, including the #943 ordinary-worker requeued-head window.
- Extend receipt waits on queued evidence; at the ceiling, recall the queued turn under the shared REPL lock before abandoning the durable row.
- Make paste and acceptance races fail closed: pasted work keeps late-receipt authority, settled positive receipts beat transient double-negative probes, and every negative cancel re-reads transport state.
- Pin #966 acceptance to transcript consumption rather than turn completion, with the 08-14 replay shape committed as a regression.

## SDK transport audit

StreamingSession does not have the queued-unpasted gap. It declares injection_confirms_consumption=True and send awaits client.query directly; there is no internal deliver-later turn between handoff and consumption. Report-only, no SDK code change.

## Verification

- Python 3.13 scheduler: 186 passed
- Python 3.11 scheduler: 186 passed
- Python 3.13 API, excluding real_auth: 421 passed, 15 deselected
- Python 3.11 API, excluding real_auth: 421 passed, 15 deselected
- Python 3.13 broad non-API: 4753 passed, 1 skipped; the later settle-edge regression separately passed
- Python 3.11 broad non-API: 4733 passed, 4 skipped; the later settle-edge regression separately passed
- tmux session suite: 410 passed
- Codex tmux/session/streaming combination: 202 passed, 1 skipped
- Explicit #983/#943 race guards: 4 passed
- ruff, compileall, and git diff --check: clean

Fixes #1068
Refs #966

🤖 Opened by Kuzya