### PR TITLE
Bump claude-agent-sdk to 0.2.138

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     "fastapi>=0.135",
     "uvicorn>=0.44",
     "websockets>=15.0",
-    "claude-agent-sdk>=0.2.129,<0.3",
+    "claude-agent-sdk>=0.2.138,<0.3",
     "Pillow>=10.0",
     # Federation crypto (sealed_box_v1): X25519, Ed25519, HKDF, XChaCha20-Poly1305.
     "cryptography>=41.0",

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -3435,6 +3435,35 @@ def create_api(
             f"(reason={decision.get('reason')})"
         )
 
+    def _persist_streaming_resume_handle(
+        agent_name: str,
+        label: str,
+        resume_handle: str,
+        *,
+        log_context_restart: bool,
+    ) -> None:
+        """Synchronously persist one streaming SDK resume-handle update."""
+        agents.set_streaming_session_id(agent_name, resume_handle, label=label)
+        short_id = resume_handle[:12] if resume_handle else ""
+        _log(f"streaming[{agent_name}/{label}]: persisted resume_handle {short_id}")
+        if not resume_handle and log_context_restart:
+            # Empty = auto context restart triggered internally by the session
+            try:
+                session_event_store.log(
+                    session_id=f"{agent_name}-{label}",
+                    agent_name=agent_name,
+                    event_type="context_restart",
+                    metadata={"label": label, "source": "auto"},
+                )
+                activity.log(
+                    agent_name=agent_name,
+                    event_type="context_restart",
+                    title=f"{agent_name} auto context restart",
+                    metadata={"label": label, "source": "auto"},
+                )
+            except Exception:
+                pass
+
     async def _make_streaming_resume_handle_callback(agent_name: str, label: str):
         """Persist a streaming session's SDK resume handle when captured.
 
@@ -3447,27 +3476,25 @@ def create_api(
         deliberate follow-up to avoid bundling a migration into this PR.
         """
         async def _on_resume_handle(_agent_name: str, resume_handle: str):
-            agents.set_streaming_session_id(agent_name, resume_handle, label=label)
-            short_id = resume_handle[:12] if resume_handle else ""
-            _log(f"streaming[{agent_name}/{label}]: persisted resume_handle {short_id}")
-            if not resume_handle:
-                # Empty = auto context restart triggered internally by the session
-                try:
-                    session_event_store.log(
-                        session_id=f"{agent_name}-{label}",
-                        agent_name=agent_name,
-                        event_type="context_restart",
-                        metadata={"label": label, "source": "auto"},
-                    )
-                    activity.log(
-                        agent_name=agent_name,
-                        event_type="context_restart",
-                        title=f"{agent_name} auto context restart",
-                        metadata={"label": label, "source": "auto"},
-                    )
-                except Exception:
-                    pass
+            _persist_streaming_resume_handle(
+                agent_name,
+                label,
+                resume_handle,
+                log_context_restart=True,
+            )
         return _on_resume_handle
+
+    def _make_streaming_resume_handle_sync_callback(agent_name: str, label: str):
+        """Build the no-await persistence path used by reset frames."""
+        def _on_resume_handle_sync(_agent_name: str, resume_handle: str) -> None:
+            _persist_streaming_resume_handle(
+                agent_name,
+                label,
+                resume_handle,
+                log_context_restart=False,
+            )
+
+        return _on_resume_handle_sync
 
     # Cache context usage per session to avoid blocking health checks
     _context_cache: dict[str, tuple[float, dict]] = {}  # session_id -> (timestamp, info)
@@ -3875,6 +3902,11 @@ def create_api(
 
         ss = SessionClass(config, **init_kwargs)
         ss._on_resume_handle = sid_callback
+        if hasattr(ss, "_on_resume_handle_sync"):
+            ss._on_resume_handle_sync = _make_streaming_resume_handle_sync_callback(
+                agent_name,
+                label,
+            )
         try:
             await _bounded_cold_start_connect(
                 ss,
@@ -9132,6 +9164,11 @@ npm run build</pre>
         # session keeps persisting turns and resume handles under the old name.
         ss._config.label = new_label
         ss._on_resume_handle = await _make_streaming_resume_handle_callback(name, new_label)
+        if hasattr(ss, "_on_resume_handle_sync"):
+            ss._on_resume_handle_sync = _make_streaming_resume_handle_sync_callback(
+                name,
+                new_label,
+            )
         # Update stored session ID mapping
         old_sid = agents.get_streaming_session_id(name, label=label)
         if old_sid:

--- a/src/pinky_daemon/sdk_runner.py
+++ b/src/pinky_daemon/sdk_runner.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import sys
 import time
+from collections.abc import Callable
 from dataclasses import dataclass, field
 
 from pinky_daemon.claude_runner import RunResult
@@ -87,10 +88,12 @@ class SDKRunner:
         *,
         hook_manager: HookManager | None = None,
         agent_name: str = "",
+        session_id_callback: Callable[[str], None] | None = None,
     ) -> None:
         self._config = config or SDKRunnerConfig()
         self._hook_manager = hook_manager
         self._agent_name = agent_name
+        self._session_id_callback = session_id_callback
         self._ensure_sdk()
 
     def _ensure_sdk(self) -> None:
@@ -210,22 +213,39 @@ class SDKRunner:
 
         try:
             got_result = False
+            invalidated_session_ids: set[str] = set()
+
+            def capture_session_id(candidate: object) -> None:
+                """Capture a non-empty ID not invalidated by a reset frame."""
+                nonlocal result_session_id
+                if not isinstance(candidate, str) or not candidate:
+                    return
+                if candidate in invalidated_session_ids:
+                    _log(
+                        "sdk-runner: WARNING refusing invalidated session_id "
+                        f"{candidate[:12]}"
+                    )
+                    return
+                if candidate == result_session_id:
+                    return
+                result_session_id = candidate
+                if self._session_id_callback:
+                    self._session_id_callback(result_session_id)
 
             async for message in query(prompt=prompt, options=options):
                 if isinstance(message, SystemMessage):
                     # Extract session ID from init
-                    result_session_id = getattr(message, "session_id", "") or ""
+                    capture_session_id(getattr(message, "session_id", ""))
                     _log(f"sdk-runner: session={result_session_id}")
 
                 elif isinstance(message, ResultMessage):
+                    capture_session_id(getattr(message, "session_id", None))
                     # Prefer ResultMessage over AssistantMessage to avoid duplicates
                     # Only suppress AssistantMessage if ResultMessage has actual content
                     if hasattr(message, "result") and message.result:
                         got_result = True
                         output_parts.clear()
                         output_parts.append(message.result)
-                    if hasattr(message, "session_id"):
-                        result_session_id = message.session_id or result_session_id
                     if hasattr(message, "total_cost_usd"):
                         cost_usd = message.total_cost_usd or 0.0
                     # Extended usage fields
@@ -236,6 +256,7 @@ class SDKRunner:
                     duration_api_ms = getattr(message, "duration_api_ms", 0) or 0
 
                 elif isinstance(message, AssistantMessage) and not got_result:
+                    capture_session_id(message.session_id)
                     # Collect text content + detect tool use
                     for block in message.content:
                         if isinstance(block, TextBlock):
@@ -252,9 +273,20 @@ class SDKRunner:
 
                 elif isinstance(message, AssistantMessage):
                     # Result content already won the existing dedupe rule.
-                    pass
+                    capture_session_id(message.session_id)
 
                 elif isinstance(message, ConversationResetMessage):
+                    # /clear invalidates the outgoing ID immediately. Clear
+                    # both local and durable state synchronously, before the
+                    # iterator can advance to a fresh-session frame.
+                    if message.session_id:
+                        invalidated_session_ids.add(message.session_id)
+                    if result_session_id:
+                        invalidated_session_ids.add(result_session_id)
+                    result_session_id = ""
+                    if self._session_id_callback:
+                        self._session_id_callback("")
+
                     _log(
                         "sdk-runner: WARNING SDK conversation reset; transcript "
                         "was discarded "

--- a/src/pinky_daemon/sdk_runner.py
+++ b/src/pinky_daemon/sdk_runner.py
@@ -122,9 +122,13 @@ class SDKRunner:
         from claude_agent_sdk import (
             AssistantMessage,
             ClaudeAgentOptions,
+            ConversationResetMessage,
+            RateLimitEvent,
             ResultMessage,
+            StreamEvent,
             SystemMessage,
             TextBlock,
+            UserMessage,
             query,
         )
 
@@ -245,6 +249,36 @@ class SDKRunner:
                                 session_id=result_session_id,
                                 data={"tool": {"tool_name": tool_name, "tool_input": tool_input}},
                             )
+
+                elif isinstance(message, AssistantMessage):
+                    # Result content already won the existing dedupe rule.
+                    pass
+
+                elif isinstance(message, ConversationResetMessage):
+                    _log(
+                        "sdk-runner: WARNING SDK conversation reset; transcript "
+                        "was discarded "
+                        f"new_conversation_id={message.new_conversation_id!r} "
+                        f"session_id={message.session_id!r}"
+                    )
+
+                elif isinstance(message, RateLimitEvent):
+                    _log(
+                        "sdk-runner: WARNING SDK rate-limit event "
+                        f"status={message.rate_limit_info.status!r}"
+                    )
+
+                elif isinstance(message, (UserMessage, StreamEvent)):
+                    # Known non-result frames are intentionally ignored.
+                    pass
+
+                else:
+                    # The SDK Message union is open across dependency bumps.
+                    # Never let a newly added frame disappear silently.
+                    _log(
+                        "sdk-runner: WARNING unhandled SDK message "
+                        f"type={type(message).__name__}; continuing"
+                    )
 
                 # Detect subagent activity
                 if isinstance(message, AssistantMessage):

--- a/src/pinky_daemon/sessions.py
+++ b/src/pinky_daemon/sessions.py
@@ -305,6 +305,7 @@ class Session:
                     sdk_config,
                     hook_manager=self._hook_manager,
                     agent_name=self.agent_name,
+                    session_id_callback=self._update_sdk_session_id,
                 )
                 self._runner_type = "sdk"
                 _log(f"session {self.id}: using SDK runner")
@@ -388,18 +389,24 @@ class Session:
                 active = self._active_history()
                 is_first = len(active) <= 1  # Only the message we just added
 
-                # Build system prompt for fresh starts
-                system_prompt = ""
-                if is_first:
-                    system_prompt = self._build_restart_prompt()
-
                 start = time.time()
 
                 can_resume = not is_first
                 resume_id = ""
-                if can_resume and self._runner_type == "sdk" and self._sdk_session_id:
-                    # SDK sessions should prefer the real Claude session ID when we have it.
-                    resume_id = self._sdk_session_id
+                if self._runner_type == "sdk":
+                    # SDK continuation is safe only with the exact persisted
+                    # handle. In particular, a /clear reset synchronously
+                    # invalidates it; falling back to continue_conversation
+                    # could resurrect the transcript the user discarded.
+                    can_resume = can_resume and bool(self._sdk_session_id)
+                    if can_resume:
+                        resume_id = self._sdk_session_id
+
+                # Build system prompt for every genuinely fresh start,
+                # including a post-reset send with non-empty local history.
+                system_prompt = ""
+                if not can_resume:
+                    system_prompt = self._build_restart_prompt()
 
                 result = await self._runner.run(
                     content,
@@ -658,6 +665,11 @@ class Session:
             provider_key=self._provider_key,
         )
         self._store.save(record)
+
+    def _update_sdk_session_id(self, sdk_session_id: str) -> None:
+        """Synchronously mirror an SDK reset/capture into durable state."""
+        self._sdk_session_id = sdk_session_id
+        self._persist()
 
     def refresh(self) -> None:
         """Refresh the session — reinitialize runner with fresh MCP config while preserving state.

--- a/src/pinky_daemon/streaming_session.py
+++ b/src/pinky_daemon/streaming_session.py
@@ -787,11 +787,16 @@ class StreamingSession(TransportReplacementMixin):
         from claude_agent_sdk.types import (
             AssistantMessage,
             AssistantMessageError,
+            ConversationResetMessage,
+            RateLimitEvent,
             ResultMessage,
+            StreamEvent,
+            SystemMessage,
             TextBlock,
             ThinkingBlock,
             ToolResultBlock,
             ToolUseBlock,
+            UserMessage,
         )
 
         # Defensive invariant: ``_is_auth_error_assistant`` does an exact
@@ -1264,6 +1269,32 @@ class StreamingSession(TransportReplacementMixin):
                         and not self._pending_chats
                     ):
                         _notify_turn_idle(self._config, self.agent_name)
+
+                elif isinstance(msg, ConversationResetMessage):
+                    _log(
+                        f"streaming[{self.agent_name}]: WARNING SDK conversation "
+                        "reset; transcript was discarded "
+                        f"new_conversation_id={msg.new_conversation_id!r} "
+                        f"session_id={msg.session_id!r}"
+                    )
+
+                elif isinstance(msg, RateLimitEvent):
+                    _log(
+                        f"streaming[{self.agent_name}]: WARNING SDK rate-limit "
+                        f"event status={msg.rate_limit_info.status!r}"
+                    )
+
+                elif isinstance(msg, (SystemMessage, UserMessage, StreamEvent)):
+                    # Known non-boundary frames are intentionally ignored.
+                    continue
+
+                else:
+                    # The SDK Message union is open across dependency bumps.
+                    # Never let a newly added frame disappear silently.
+                    _log(
+                        f"streaming[{self.agent_name}]: WARNING unhandled SDK "
+                        f"message type={type(msg).__name__}; continuing"
+                    )
 
         except Exception as e:
             _log(f"streaming[{self.agent_name}]: reader loop error: {e}")

--- a/src/pinky_daemon/streaming_session.py
+++ b/src/pinky_daemon/streaming_session.py
@@ -360,7 +360,11 @@ class StreamingSession(TransportReplacementMixin):
         self._activity_log: list[str] = []  # All tool activities this turn
         self._current_thinking = ""  # Latest thinking block (for UI streaming)
         self.account_info: dict = {}  # Populated from SDK init: email, subscriptionType, apiProvider
-        self._on_resume_handle = None  # async fn(agent_name, resume_handle) — called when SDK resume token is captured
+        self._on_resume_handle = None  # async fn(agent_name, resume_handle) — used by restart paths
+        # Reset frames invalidate the persisted handle synchronously: awaiting
+        # between observing /clear and clearing durable state leaves a window
+        # where a process death can resurrect the discarded transcript.
+        self._on_resume_handle_sync = None  # sync fn(agent_name, resume_handle)
         self._context_warned = False  # Track if we've already warned this session
         self._last_restart_block_notice_at = 0.0
         self._effort_override: str | None = None  # Session-level thinking effort override
@@ -823,6 +827,33 @@ class StreamingSession(TransportReplacementMixin):
         # threshold early and skewing the multi-agent baseline. Reset at the
         # end of ResultMessage handling (turn boundary).
         auth_reported_this_turn = False
+        invalidated_resume_handles: set[str] = set()
+
+        async def _capture_resume_handle(candidate: object) -> None:
+            """Persist a non-empty SDK handle that was not invalidated by /clear."""
+            if not isinstance(candidate, str) or not candidate:
+                return
+            if candidate in invalidated_resume_handles:
+                _log(
+                    f"streaming[{self.agent_name}]: WARNING refusing invalidated "
+                    f"resume_handle {candidate[:12]}"
+                )
+                return
+            if candidate == self.resume_handle:
+                return
+
+            self.resume_handle = candidate
+            _log(
+                f"streaming[{self.agent_name}]: captured resume_handle "
+                f"{self.resume_handle[:12]}"
+            )
+            if self._on_resume_handle_sync:
+                self._on_resume_handle_sync(self.agent_name, self.resume_handle)
+            elif self._on_resume_handle:
+                try:
+                    await self._on_resume_handle(self.agent_name, self.resume_handle)
+                except Exception:
+                    pass
 
         try:
             async for msg in self._client.receive_messages():
@@ -928,17 +959,15 @@ class StreamingSession(TransportReplacementMixin):
                         self.usage.input_tokens += msg.usage.get("input_tokens", 0)
                         self.usage.output_tokens += msg.usage.get("output_tokens", 0)
 
-                    # Capture SDK resume handle for persistence
-                    if msg.session_id and msg.session_id != self.resume_handle:
-                        self.resume_handle = msg.session_id
-                        _log(f"streaming[{self.agent_name}]: captured resume_handle {self.resume_handle[:12]}")
-                        if self._on_resume_handle:
-                            try:
-                                await self._on_resume_handle(self.agent_name, self.resume_handle)
-                            except Exception:
-                                pass
+                    # Capture SDK resume handle for persistence.
+                    await _capture_resume_handle(getattr(msg, "session_id", None))
 
                 elif isinstance(msg, ResultMessage):
+                    # A local slash command such as /clear may produce no
+                    # AssistantMessage for the fresh conversation. Result is
+                    # therefore an equally authoritative resume-handle frame.
+                    await _capture_resume_handle(getattr(msg, "session_id", None))
+
                     # Debug: log result message details
                     if msg.num_turns and msg.num_turns > 0:
                         _log(f"streaming[{self.agent_name}]: result — turns={msg.num_turns}, cost=${msg.total_cost_usd or 0:.4f}, model_usage={msg.model_usage}")
@@ -1271,6 +1300,25 @@ class StreamingSession(TransportReplacementMixin):
                         _notify_turn_idle(self._config, self.agent_name)
 
                 elif isinstance(msg, ConversationResetMessage):
+                    # The reset frame names the outgoing session. Invalidate
+                    # both it and our current handle before doing any other
+                    # work, then synchronously clear durable state. There must
+                    # be no await gap here: death before the next fresh-session
+                    # frame must produce a clean start, never resume /clear's
+                    # discarded transcript.
+                    if msg.session_id:
+                        invalidated_resume_handles.add(msg.session_id)
+                    if self.resume_handle:
+                        invalidated_resume_handles.add(self.resume_handle)
+                    self.resume_handle = ""
+                    if self._on_resume_handle_sync:
+                        self._on_resume_handle_sync(self.agent_name, "")
+                    elif self._on_resume_handle:
+                        raise RuntimeError(
+                            "conversation reset requires synchronous "
+                            "resume-handle persistence"
+                        )
+
                     _log(
                         f"streaming[{self.agent_name}]: WARNING SDK conversation "
                         "reset; transcript was discarded "

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -144,7 +144,11 @@ class TestSession:
     async def test_send_resumes_after_first(self):
         session = Session(session_id="test")
         session._runner.run = AsyncMock(
-            return_value=RunResult(output="ok", exit_code=0)
+            return_value=RunResult(
+                output="ok",
+                exit_code=0,
+                session_id="11111111-1111-4111-8111-111111111111",
+            )
         )
 
         await session.send("First message")
@@ -159,7 +163,11 @@ class TestSession:
     async def test_send_system_prompt_first_only(self):
         session = Session(session_id="test", system_prompt="Be helpful")
         session._runner.run = AsyncMock(
-            return_value=RunResult(output="ok", exit_code=0)
+            return_value=RunResult(
+                output="ok",
+                exit_code=0,
+                session_id="11111111-1111-4111-8111-111111111111",
+            )
         )
 
         await session.send("First")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -324,6 +324,14 @@ class TestStreamingSession:
         fake_types.ToolResultBlock = ToolResultBlock
         fake_types.AssistantMessage = AssistantMessage
         fake_types.ResultMessage = ResultMessage
+        for message_type in (
+            "ConversationResetMessage",
+            "RateLimitEvent",
+            "StreamEvent",
+            "SystemMessage",
+            "UserMessage",
+        ):
+            setattr(fake_types, message_type, type(message_type, (), {}))
         # Stub for the SDK Literal — reader_loop's import-time invariant
         # check (PR #404) reads __args__ to defend against SDK rename.
         from typing import Literal as _Literal

--- a/tests/test_packaging_dependencies.py
+++ b/tests/test_packaging_dependencies.py
@@ -29,4 +29,4 @@ def test_buzz_dependencies_are_in_base_install() -> None:
 
 
 def test_claude_agent_sdk_excludes_allowed_tools_injection_versions() -> None:
-    assert "claude-agent-sdk>=0.2.129,<0.3" in _project()["dependencies"]
+    assert "claude-agent-sdk>=0.2.138,<0.3" in _project()["dependencies"]

--- a/tests/test_sdk_runner.py
+++ b/tests/test_sdk_runner.py
@@ -2,11 +2,16 @@
 
 from __future__ import annotations
 
+import asyncio
+from contextlib import suppress
 from unittest.mock import MagicMock
 
 import pytest
 
 from pinky_daemon.sdk_runner import SDKRunner, SDKRunnerConfig, sdk_available
+
+OLD_SESSION_ID = "11111111-1111-4111-8111-111111111111"
+NEW_SESSION_ID = "22222222-2222-4222-8222-222222222222"
 
 
 class TestSDKAvailable:
@@ -112,6 +117,133 @@ class TestSDKRunner:
         assert "WARNING SDK conversation reset" in logs
         assert "new_conversation_id='new-conversation'" in logs
         assert "WARNING unhandled SDK message type=object; continuing" in logs
+
+    @pytest.mark.asyncio
+    async def test_session_store_reset_then_result_replaces_old_id(
+        self, monkeypatch, tmp_path
+    ):
+        """The per-run lane persists Reset(old) before capturing Result(new)."""
+        import claude_agent_sdk
+        from claude_agent_sdk import ConversationResetMessage, ResultMessage
+
+        from pinky_daemon.session_store import SessionStore
+        from pinky_daemon.sessions import Session, SessionMessage
+
+        options_seen = []
+
+        async def fake_query(*, prompt, options):
+            del prompt
+            options_seen.append(options)
+            yield ConversationResetMessage(
+                new_conversation_id="new-conversation",
+                uuid="reset-uuid",
+                session_id=OLD_SESSION_ID,
+            )
+            yield ResultMessage(
+                subtype="success",
+                duration_ms=10,
+                duration_api_ms=5,
+                is_error=False,
+                num_turns=1,
+                session_id=NEW_SESSION_ID,
+                result="cleared",
+            )
+
+        monkeypatch.setattr(claude_agent_sdk, "query", fake_query)
+        store = SessionStore(tmp_path / "sessions.db")
+        session = Session(session_id="reset-session", agent_name="test")
+        session._store = store
+        session._sdk_session_id = OLD_SESSION_ID
+        session.history.append(SessionMessage(role="assistant", content="before reset"))
+        session._persist()
+
+        response = await session.send("/clear")
+
+        record = store.get(session.id)
+        assert response.error == ""
+        assert options_seen[0].resume == OLD_SESSION_ID
+        assert record is not None
+        assert record.sdk_session_id == NEW_SESSION_ID
+        assert session._sdk_session_id == NEW_SESSION_ID
+
+    @pytest.mark.asyncio
+    async def test_session_store_reset_window_reboots_as_clean_start(
+        self, monkeypatch, tmp_path
+    ):
+        """Death after Reset clears the store; the next boot starts clean."""
+        import claude_agent_sdk
+        from claude_agent_sdk import ConversationResetMessage, ResultMessage
+
+        from pinky_daemon.session_store import SessionStore
+        from pinky_daemon.sessions import Session, SessionManager, SessionMessage
+
+        reset_consumed = asyncio.Event()
+        hold_stream_open = asyncio.Event()
+        options_seen = []
+
+        async def reset_then_block(*, prompt, options):
+            del prompt
+            options_seen.append(options)
+            yield ConversationResetMessage(
+                new_conversation_id="new-conversation",
+                uuid="reset-uuid",
+                session_id=OLD_SESSION_ID,
+            )
+            reset_consumed.set()
+            await hold_stream_open.wait()
+
+        monkeypatch.setattr(claude_agent_sdk, "query", reset_then_block)
+        store = SessionStore(tmp_path / "sessions.db")
+        session = Session(session_id="reset-window", agent_name="test")
+        session._store = store
+        session._sdk_session_id = OLD_SESSION_ID
+        session.history.append(SessionMessage(role="assistant", content="before reset"))
+        session._persist()
+
+        send_task = asyncio.create_task(session.send("/clear"))
+        await asyncio.wait_for(reset_consumed.wait(), timeout=1)
+
+        record = store.get(session.id)
+        assert options_seen[0].resume == OLD_SESSION_ID
+        assert session._sdk_session_id == ""
+        assert record is not None
+        assert record.sdk_session_id == ""
+
+        # Simulate process death before any frame can carry the fresh ID.
+        send_task.cancel()
+        with suppress(asyncio.CancelledError):
+            await send_task
+
+        manager = SessionManager(store=store)
+        restored = manager.get(session.id)
+        assert restored is not None
+        assert restored._sdk_session_id == ""
+
+        fresh_options = []
+
+        async def fresh_query(*, prompt, options):
+            del prompt
+            fresh_options.append(options)
+            yield ResultMessage(
+                subtype="success",
+                duration_ms=10,
+                duration_api_ms=5,
+                is_error=False,
+                num_turns=1,
+                session_id=NEW_SESSION_ID,
+                result="fresh",
+            )
+
+        monkeypatch.setattr(claude_agent_sdk, "query", fresh_query)
+        # Keep local history to prove the empty handle, not is_first, forces a
+        # fresh SDK start instead of continue_conversation.
+        restored.history.append(SessionMessage(role="assistant", content="local history"))
+
+        response = await restored.send("after reset")
+
+        assert response.error == ""
+        assert fresh_options[0].resume is None
+        assert fresh_options[0].continue_conversation is False
 
 
 class TestSessionSDKIntegration:

--- a/tests/test_sdk_runner.py
+++ b/tests/test_sdk_runner.py
@@ -87,6 +87,32 @@ class TestSDKRunner:
         assert hasattr(runner, "health_check")
         assert runner._config.working_dir == "."
 
+    @pytest.mark.asyncio
+    async def test_run_warns_on_conversation_reset_and_unknown_frame(
+        self, monkeypatch, capsys
+    ):
+        """A widened SDK Message union must never degrade to a silent drop."""
+        import claude_agent_sdk
+        from claude_agent_sdk import ConversationResetMessage
+
+        async def fake_query(*, prompt, options):
+            del prompt, options
+            yield ConversationResetMessage(
+                new_conversation_id="new-conversation",
+                uuid="reset-uuid",
+                session_id="session-uuid",
+            )
+            yield object()
+
+        monkeypatch.setattr(claude_agent_sdk, "query", fake_query)
+        result = await SDKRunner().run("clear")
+
+        assert result.ok
+        logs = capsys.readouterr().err
+        assert "WARNING SDK conversation reset" in logs
+        assert "new_conversation_id='new-conversation'" in logs
+        assert "WARNING unhandled SDK message type=object; continuing" in logs
+
 
 class TestSessionSDKIntegration:
     """Test that Session correctly initializes with SDK runner."""

--- a/tests/test_streaming_session.py
+++ b/tests/test_streaming_session.py
@@ -15,6 +15,9 @@ import pytest
 from pinky_daemon.streaming_session import StreamingSession, StreamingSessionConfig
 from pinky_daemon.transport_state import SessionState
 
+OLD_SESSION_ID = "11111111-1111-4111-8111-111111111111"
+NEW_SESSION_ID = "22222222-2222-4222-8222-222222222222"
+
 
 def _make_session(
     *,
@@ -231,6 +234,7 @@ def _make_result_message(
     is_error: bool = False,
     api_error_status: int | None = None,
     errors: list[str] | None = None,
+    session_id: str = "test-session",
 ):
     """Build a ResultMessage with the minimum fields the reader_loop reads."""
     from claude_agent_sdk.types import ResultMessage
@@ -241,7 +245,7 @@ def _make_result_message(
         duration_api_ms=5,
         is_error=is_error,
         num_turns=1,
-        session_id="test-session",
+        session_id=session_id,
         stop_reason="end_turn" if not is_error else "error",
         api_error_status=api_error_status,
         errors=errors,
@@ -291,6 +295,68 @@ async def test_reader_warns_on_conversation_reset_and_unknown_frame(capsys) -> N
     assert "WARNING SDK conversation reset" in logs
     assert "new_conversation_id='new-conversation'" in logs
     assert "WARNING unhandled SDK message type=object; continuing" in logs
+
+
+@pytest.mark.asyncio
+async def test_reset_replaces_old_resume_handle_from_result_message() -> None:
+    """Reset(old) + Result(new) persists empty first, then the fresh handle."""
+    from claude_agent_sdk.types import ConversationResetMessage
+
+    persisted = OLD_SESSION_ID
+    writes: list[str] = []
+    ss = _make_session()
+    ss.resume_handle = OLD_SESSION_ID
+
+    def persist(_agent_name: str, resume_handle: str) -> None:
+        nonlocal persisted
+        persisted = resume_handle
+        writes.append(resume_handle)
+
+    ss._on_resume_handle_sync = persist
+    reset = ConversationResetMessage(
+        new_conversation_id="new-conversation",
+        uuid="reset-uuid",
+        session_id=OLD_SESSION_ID,
+    )
+
+    await _run_reader_against_stream(
+        ss,
+        [reset, _make_result_message(session_id=NEW_SESSION_ID)],
+    )
+
+    assert writes == ["", NEW_SESSION_ID]
+    assert persisted == NEW_SESSION_ID
+    assert ss.resume_handle == NEW_SESSION_ID
+
+
+@pytest.mark.asyncio
+async def test_reset_without_fresh_frame_clears_resume_handle_before_death() -> None:
+    """A reset-window death leaves durable and in-memory handles empty."""
+    from claude_agent_sdk.types import ConversationResetMessage
+
+    persisted = OLD_SESSION_ID
+    ss = _make_session()
+    ss.resume_handle = OLD_SESSION_ID
+
+    def persist(_agent_name: str, resume_handle: str) -> None:
+        nonlocal persisted
+        persisted = resume_handle
+
+    ss._on_resume_handle_sync = persist
+    reset = ConversationResetMessage(
+        new_conversation_id="new-conversation",
+        uuid="reset-uuid",
+        session_id=OLD_SESSION_ID,
+    )
+
+    await _run_reader_against_stream(ss, [reset])
+
+    assert persisted == ""
+    assert ss.resume_handle == ""
+    restarted = StreamingSession(
+        StreamingSessionConfig(agent_name="test", resume_handle=persisted)
+    )
+    assert restarted.resume_handle == ""
 
 
 @pytest.mark.asyncio

--- a/tests/test_streaming_session.py
+++ b/tests/test_streaming_session.py
@@ -274,6 +274,26 @@ async def _run_reader_against_stream(ss: StreamingSession, messages: list) -> No
 
 
 @pytest.mark.asyncio
+async def test_reader_warns_on_conversation_reset_and_unknown_frame(capsys) -> None:
+    """A widened SDK Message union must never degrade to a silent drop."""
+    from claude_agent_sdk.types import ConversationResetMessage
+
+    ss = _make_session()
+    reset = ConversationResetMessage(
+        new_conversation_id="new-conversation",
+        uuid="reset-uuid",
+        session_id="session-uuid",
+    )
+
+    await _run_reader_against_stream(ss, [reset, object()])
+
+    logs = capsys.readouterr().err
+    assert "WARNING SDK conversation reset" in logs
+    assert "new_conversation_id='new-conversation'" in logs
+    assert "WARNING unhandled SDK message type=object; continuing" in logs
+
+
+@pytest.mark.asyncio
 async def test_auth_callback_fires_once_when_both_paths_signal_for_same_turn() -> None:
     """Regression for PR #404 / Murzik's review.
 

--- a/uv.lock
+++ b/uv.lock
@@ -520,20 +520,20 @@ wheels = [
 
 [[package]]
 name = "claude-agent-sdk"
-version = "0.2.129"
+version = "0.2.138"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "mcp" },
     { name = "sniffio" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3b/ab/b2144806f4210582a0135734bb5f8ce40fd3ff2e867598b0f3234cc6f865/claude_agent_sdk-0.2.129.tar.gz", hash = "sha256:bf2ac3e5f8367a3f5edfb62f74a19ccd0bcd6277c555c8359dd9aa98f7abcf4f", size = 312225, upload-time = "2026-08-04T00:30:04.663Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/8f/07da8bf64606cc06c82a8f478c16509bf332d17da7398d31e1126ec3702b/claude_agent_sdk-0.2.138.tar.gz", hash = "sha256:bb09194a877869fda84ac9980f04dcef2abbb0c7534b4cd555283f0e5dfb827a", size = 319524, upload-time = "2026-08-13T23:43:46.281Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c3/a2/ce954fa03d0f27959667b9615e17eabb2517aa462994cf6fc8cc204888e1/claude_agent_sdk-0.2.129-py3-none-macosx_11_0_arm64.whl", hash = "sha256:854d520c14f4efb543d37a1aa0a3d1e8d35b154e16a42fa947e20af732f6860e", size = 78491128, upload-time = "2026-08-04T00:30:09.664Z" },
-    { url = "https://files.pythonhosted.org/packages/54/2c/0e68e89d93c59843905d8a8fa5b3ad6a97420cd478045c8784be946f2ed8/claude_agent_sdk-0.2.129-py3-none-macosx_11_0_x86_64.whl", hash = "sha256:e07a544acd689e3c64a01f9eb337b2540d5efb7cbd9d07a2054935395adbfe55", size = 83614484, upload-time = "2026-08-04T00:30:14.515Z" },
-    { url = "https://files.pythonhosted.org/packages/66/83/d7f44a781bb8ff8b2c8551611e9ec66083d0154095b799d452713ef1ba6d/claude_agent_sdk-0.2.129-py3-none-manylinux_2_17_aarch64.whl", hash = "sha256:2c2eb485c01b264cd676b11aaeba207cbc05bff3b87f9b796bf9fef4da6df7bd", size = 88064416, upload-time = "2026-08-04T00:30:20.235Z" },
-    { url = "https://files.pythonhosted.org/packages/82/00/2e333bdf78151c2272a70f9af75ab7d6f26bea70d1eb9b70797e498acc2f/claude_agent_sdk-0.2.129-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:ce2470fb183c55f154700db63ad44b009c1dc78048e0c35b5c1536cd4c2707fa", size = 88992936, upload-time = "2026-08-04T00:30:26.119Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/72/1705ea65918b967f663da3c4704218851dd18f33db6034685f25393a0d9d/claude_agent_sdk-0.2.129-py3-none-win_amd64.whl", hash = "sha256:d6bc9691dae5df5a7d0bb1f3fbff13e325362b550c9f61f8661e83f8320c1f1c", size = 88560015, upload-time = "2026-08-04T00:30:31.905Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/e5/c869afe2c8ff4625331ce9b0a62b2602c01418a12fd4ea092515da8c1678/claude_agent_sdk-0.2.138-py3-none-macosx_11_0_arm64.whl", hash = "sha256:2b34fdcdaed8a750521dbd800590c9a411b9b13803425133f38d3afe7c2ce893", size = 87842823, upload-time = "2026-08-13T23:43:49.74Z" },
+    { url = "https://files.pythonhosted.org/packages/19/81/0fe3d111b6c1a3f7bc917fae38797389795aee74a05fa78e0001d679a764/claude_agent_sdk-0.2.138-py3-none-macosx_11_0_x86_64.whl", hash = "sha256:68b973423e20afc39ce69ffc47a8dc498bb4779d3da8d00ec1087ed6a4d748fa", size = 92734215, upload-time = "2026-08-13T23:43:53.685Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/9d/3735711bb98d278773b86ef82a153ae69549d8bef4907acced7fa2994dab/claude_agent_sdk-0.2.138-py3-none-manylinux_2_17_aarch64.whl", hash = "sha256:564a619126e1194b4c5ae9be00505173fa904f7dcf75d10bd891d634d78270ad", size = 96736541, upload-time = "2026-08-13T23:43:57.243Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/cc/3f09a6adbb1d3beab30552ce2212b55621ba8a301035796d210e43db40bc/claude_agent_sdk-0.2.138-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:ab3cdabc506b3ae8db4fc8ae15327e2c0014ad44d92969021100964fa812a627", size = 97704281, upload-time = "2026-08-13T23:44:00.917Z" },
+    { url = "https://files.pythonhosted.org/packages/db/1f/cc472296e9d4d52a1d42fc8efc8111d3320e6233b3dcef713bcda9603745/claude_agent_sdk-0.2.138-py3-none-win_amd64.whl", hash = "sha256:b144521a013b92f633d061311000263779dd6d4b364e4f747fbe1c49e5f20567", size = 99994959, upload-time = "2026-08-13T23:44:04.784Z" },
 ]
 
 [[package]]
@@ -2329,7 +2329,7 @@ requires-dist = [
     { name = "beautifulsoup4", marker = "extra == 'web'", specifier = ">=4.12" },
     { name = "caldav", marker = "extra == 'calendar'", specifier = ">=1.3" },
     { name = "camoufox", marker = "extra == 'web'", specifier = ">=0.4" },
-    { name = "claude-agent-sdk", specifier = ">=0.2.129,<0.3" },
+    { name = "claude-agent-sdk", specifier = ">=0.2.138,<0.3" },
     { name = "coincurve", specifier = ">=21.0" },
     { name = "cryptography", specifier = ">=41.0" },
     { name = "cryptography", marker = "extra == 'calendar'", specifier = ">=41.0" },


### PR DESCRIPTION
## Summary

- Raise the `claude-agent-sdk` floor and lockfile from 0.2.129 to 0.2.138.
- Handle `ConversationResetMessage` explicitly in both SDK message consumers and warn on reset, rate-limit, or unknown future frames instead of dropping them silently.
- Add regression coverage for conversation-reset and unknown-frame handling, plus keep the API test SDK stub aligned with the widened message union.

## Release audit

The [0.2.137 release](https://github.com/anthropics/claude-agent-sdk-python/releases/tag/v0.2.137) widens `Message` with `ConversationResetMessage` and adds origin/resume surfaces. Both PinkyBot consumers now account for every current union member and retain a warning fallback for future additions.

The [0.2.138 release](https://github.com/anthropics/claude-agent-sdk-python/releases/tag/v0.2.138) updates the bundled Claude CLI from 2.1.229 to 2.1.232. A source-distribution comparison found no additional Python message-union widening, changed defaults, or new frame types on top of 0.2.137.

Origin tracking, `resume_session_at`, and `resume_drops_turn` are explicitly out of scope for this PR.

## Testing

- Transport/session matrix: 811 passed, 1 skipped in 143.97s.
- Full suite: 5172 passed, 4 skipped in 2724.57s.
- Ruff, compileall, `uv lock --check`, and diff checks passed.
- [Sanitized test-run captures](https://gist.github.com/olegbrok/3b069fd96f1b0fd910dfb7bafaa0dd6d)

The full-suite evidence run used a fresh empty `HOME`, a fresh empty `CLAUDE_CONFIG_DIR`, and explicit empty values for `CLAUDE_CODE_OAUTH_TOKEN`, `ANTHROPIC_API_KEY`, and `ANTHROPIC_AUTH_TOKEN`. A bundled-CLI preflight under that exact boundary reported `loggedIn=false` and `authMethod=none`. This prevents existing integration paths from inheriting developer-machine credentials; no test-isolation behavior change is included in this PR.

Fixes #1071

🤖 Opened by Kuzya