### PR TITLE
test: harden timing-sensitive regression tests

### DIFF
--- a/tests/test_buzz_inbound_poller.py
+++ b/tests/test_buzz_inbound_poller.py
@@ -168,7 +168,8 @@ async def test_real_websocket_auth_subscription_ephemeral_suppression_and_eose_h
     tmp_path,
 ):
     captured: list[list] = []
-    initial_filter = {}
+    membership_seen = asyncio.Event()
+    channel_seen = asyncio.Event()
     heartbeat_seen = asyncio.Event()
     relay_url = ""
 
@@ -179,11 +180,12 @@ async def test_real_websocket_auth_subscription_ephemeral_suppression_and_eose_h
         await _authenticate(ws, relay_url, captured)
         membership = json.loads(await ws.recv())
         captured.append(membership)
+        membership_seen.set()
         await ws.send(json.dumps(["EOSE", membership[1]]))
         main = json.loads(await ws.recv())
         captured.append(main)
         assert main[0] == "REQ"
-        initial_filter.update(main[2])
+        channel_seen.set()
         await ws.send(json.dumps(["EVENT", main[1], ephemeral]))
         await ws.send(json.dumps(["EVENT", main[1], durable]))
         await ws.send(json.dumps(["EOSE", main[1]]))
@@ -220,26 +222,41 @@ async def test_real_websocket_auth_subscription_ephemeral_suppression_and_eose_h
             reconnect_max=0.02,
         )
         task = asyncio.create_task(poller.start())
-        await asyncio.wait_for(broker.delivered.wait(), timeout=2)
-        await asyncio.wait_for(heartbeat_seen.wait(), timeout=2)
+        await asyncio.wait_for(membership_seen.wait(), timeout=5)
+        await asyncio.wait_for(channel_seen.wait(), timeout=5)
+        await asyncio.wait_for(broker.delivered.wait(), timeout=5)
+        await asyncio.wait_for(heartbeat_seen.wait(), timeout=5)
         poller.stop()
-        await asyncio.wait_for(task, timeout=2)
+        await asyncio.wait_for(task, timeout=5)
 
-        assert initial_filter["kinds"] == [9, 20002]
-        assert initial_filter["#h"] == [CHANNEL]
-        assert "since" not in initial_filter
         membership_filters = [
             frame[2]
             for frame in captured
             if frame[0] == "REQ" and frame[1].startswith("pinky-membership-")
         ]
-        assert membership_filters == [
-            {"kinds": [44100, 44101], "#p": [material.pubkey]}
+        assert {
+            json.dumps(item, sort_keys=True) for item in membership_filters
+        } == {
+            json.dumps(
+                {"kinds": [44100, 44101], "#p": [material.pubkey]},
+                sort_keys=True,
+            )
+        }
+        channel_filters = [
+            frame[2]
+            for frame in captured
+            if frame[0] == "REQ" and frame[1].startswith("pinky-barsik-")
         ]
+        assert {json.dumps(item, sort_keys=True) for item in channel_filters} == {
+            json.dumps(
+                {"kinds": [9, 20002], "#h": [CHANNEL]}, sort_keys=True
+            )
+        }
         assert len(broker.calls) == 1
+        assert broker.calls[0][1].message_id == durable["id"]
         assert broker.calls[0][1].content == "hello from Brad"
         assert poller.health["delivered"] == 1
-        assert poller.health["ephemeral_ignored"] == 1
+        assert poller.health["ephemeral_ignored"] >= 1
         assert notices == []
         assert store._db.execute(
             "SELECT event_id, kind, delivery_status FROM buzz_inbound_events"
@@ -250,10 +267,21 @@ async def test_real_websocket_auth_subscription_ephemeral_suppression_and_eose_h
             if frame[0] == "REQ" and frame[1].startswith("pinky-live-")
         ]
         assert heartbeat_filters
-        assert all(
-            isinstance(item["since"], int) and item["limit"] == 1
+        assert all(type(item["since"]) is int for item in heartbeat_filters)
+        assert {
+            json.dumps({**item, "since": "<dynamic>"}, sort_keys=True)
             for item in heartbeat_filters
-        )
+        } == {
+            json.dumps(
+                {
+                    "kinds": [9, 20002],
+                    "#h": [CHANNEL],
+                    "since": "<dynamic>",
+                    "limit": 1,
+                },
+                sort_keys=True,
+            )
+        }
         assert all(frame[0] in {"AUTH", "REQ", "CLOSE"} for frame in captured)
         assert not any(frame[0] == "EVENT" for frame in captured)
         store.close()

--- a/tests/test_codex_home.py
+++ b/tests/test_codex_home.py
@@ -3664,13 +3664,13 @@ async def test_spawn_rollback_outer_deadline_is_hard(
         "pinky_daemon.tmux_session._SPAWN_ROLLBACK_TIMEOUT_SEC", 0.07
     )
 
-    started = asyncio.get_running_loop().time()
     failure = await session._rollback_spawned_session(site="scaled deadline")
-    elapsed = asyncio.get_running_loop().time() - started
 
     assert failure is not None
     assert "within 0.07s" in failure
-    assert elapsed < 0.085
+    # The second kill begins at the outer ceiling, but its following verify is
+    # refused. This exact trace proves the logical deadline without comparing
+    # wall time, which includes arbitrary runner preemption (#1080).
     assert operations == ["kill-session", "has-session", "kill-session"]
     assert session._spawn_cleanup_debt_path().exists()
 

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1931,9 +1931,12 @@ class TestScheduler:
             "oleg", "* * * * *", name="second", prompt="second prompt"
         )
 
-        busy = False
         delivered: list[str] = []
         events: list[str] = []
+        prompts = ("first prompt", "second prompt")
+        started = {prompt: asyncio.Event() for prompt in prompts}
+        release = {prompt: asyncio.Event() for prompt in prompts}
+        confirmed = {prompt: asyncio.Event() for prompt in prompts}
 
         class Activity:
             def log(self, agent_name, event_type, summary):
@@ -1941,29 +1944,35 @@ class TestScheduler:
                 events.append(event_type)
 
         async def wake_cb(agent_name, session_id, prompt):
-            nonlocal busy
             del agent_name, session_id
-            receipt = asyncio.get_running_loop().create_future()
-            if busy:
-                receipt.set_result(False)
-                return receipt
-
-            busy = True
-
-            def confirm_delivery():
-                nonlocal busy
-                delivered.append(prompt)
-                busy = False
-                receipt.set_result(True)
-
-            asyncio.get_running_loop().call_soon(confirm_delivery)
-            return receipt
+            started[prompt].set()
+            await release[prompt].wait()
+            delivered.append(prompt)
+            confirmed[prompt].set()
+            return True
 
         scheduler = AgentScheduler(
             registry, wake_callback=wake_cb, activity=Activity()
         )
         await scheduler._check_schedules(time.time())
-        await asyncio.sleep(0.05)
+
+        delivery_tasks = tuple(scheduler._schedule_delivery_tasks)
+        assert len(delivery_tasks) == 1
+        try:
+            await asyncio.wait_for(started["first prompt"].wait(), timeout=2)
+            assert not started["second prompt"].is_set()
+
+            release["first prompt"].set()
+            await asyncio.wait_for(started["second prompt"].wait(), timeout=2)
+            assert confirmed["first prompt"].is_set()
+            assert delivered == ["first prompt"]
+
+            release["second prompt"].set()
+            await asyncio.wait_for(confirmed["second prompt"].wait(), timeout=2)
+        finally:
+            for gate in release.values():
+                gate.set()
+            await asyncio.gather(*delivery_tasks, return_exceptions=True)
 
         assert delivered == ["first prompt", "second prompt"]
         schedules = registry.get_schedules("oleg")


### PR DESCRIPTION
## In-the-wild failure on the exact base

This branch starts at `bccea7650f6ec40c306d9039d8bcad0c9f03ed50`. Main's own [CI run 31870142393](https://github.com/bradbrok/PinkyBot/actions/runs/31870142393) reproduced member 1 on Python 3.12:

```
assert 0.13515350000000126 < 0.085
FAILED tests/test_codex_home.py::test_spawn_rollback_outer_deadline_is_hard
```

That exact-base run's Python 3.11 and 3.13 full-suite jobs were green. The 3.12 job completed with 5,192 passed / 3 skipped and this single timing flake, so #1080 is not hypothetical: it broke main's own matrix.

## Local full-suite disclosure

Local full-suite attempts use isolated CI-style environments, not the shared root/prod venv. The shared root venv correctly remains on the deployed release's `claude-agent-sdk 0.2.129`, while current main requires `>=0.2.138`; isolated verification used SDK `0.2.139`.

On this macOS host, `tests/test_api.py::TestGoogleOAuthStateValidation::test_callback_rejects_missing_state` has a known `TestClient` lifecycle stall from the #1085 review, tracked separately as task #587. It is disclosed rather than skipped:

- Detached clean base worktree at exact `bccea765`, with no #1080 commits.
- Python 3.11 isolated `.[dev,acp]` environment, SDK `0.2.139`.
- Standalone test remained alive at 33 seconds in `UN` state after `create_api` setup, before any startup line or test result:

```
tests/test_api.py::TestGoogleOAuthStateValidation::test_callback_rejects_missing_state
...
voice: WS endpoint registered at /ws/voice/{id}
# still running at 00:33; terminated after capture
```

The same signature reproduces on the branch and on local Python 3.13. Reproduction without this diff plus the exact-base Linux 3.11/3.13 greens disconfirms causality. Per the #1085 precedent, the PR's final-head CI matrix is the full-suite gate.

## What changed

Test-only diff; no product code changes.

- Rollback deadline: remove the scheduler-preemption-sensitive wall-clock comparison while retaining the timeout result, cleanup debt, and exact operation trace. The trace proves the second kill begins but the following verify is refused by the outer ceiling.
- Same-tick scheduler delivery: replace `call_soon` plus sleep with explicit per-prompt started/release/confirmed gates; assert delivery 2 cannot start until delivery 1 confirms, then retain exact order, completeness, timestamps, and activity events.
- Buzz real WebSocket: await membership, channel, durable-delivery, and heartbeat observations independently. Canonical distinct membership/channel filter sets must exactly equal the singleton expected filters; only exact reconnect duplicates are tolerated. Heartbeat filters retain exact shape/content with a dynamic integer `since`.

The spec's preferred injected-clock path was unavailable for member 1 because the production boundary is task-local `asyncio.timeout` with no injectable clock seam. Adding such a product seam is out of scope for this test-only fix; the exact operation trace supplies the behavior-based proof instead.

The no-split member-3 choice is backed by the deterministic suppression test `tests/test_buzz_inbound.py::test_kind_20002_is_verified_but_never_retained_or_dispatched`, which proves repeated ephemeral events are ignored without broker dispatch, recent-ID retention, policy/DB mutation, or durable rows.

## Regression red-proofs

Each product regression was temporary and uncommitted; product files were restored before every commit.

1. Lengthen the product outer rollback timeout 10×:

```
> assert "within 0.07s" in failure
E AssertionError: assert 'within 0.07s' in '...could not prove teardown after 2 attempts...'
# stderr includes attempt 2 verify, the operation forbidden by the real ceiling
```

2. Deliver a same-agent schedule cohort concurrently:

```
> assert not started["second prompt"].is_set()
E assert not True
```

3. Regress the channel REQ from `kinds: [9, 20002]` to `kinds: [9]`:

```
Extra items in the left set:
'{"#h": ["00000000-0000-4000-8000-000000000001"], "kinds": [9]}'
Extra items in the right set:
'{"#h": ["00000000-0000-4000-8000-000000000001"], "kinds": [9, 20002]}'
```

## Green evidence

Final pushed head: `c0c9e9fdceb84c8a69794a617fedc43bea2d5bda`  
Tree: `2170df5d26bf36fb55cdbbb348f6a34bcbd953ea`

- Focused baseline before edits: 3 passed.
- Focused final tests: 3 passed on isolated Python 3.13; 3 passed on isolated Python 3.11.
- Deterministic ephemeral unit test plus hardened WebSocket test: 2 passed.
- Detached 50× loops: rollback 50/50, scheduler 50/50, Buzz 50/50 — 150/150 total.
- Induced load: 10 CPU burners saturated all 10 logical cores; lower-priority combined pytest passed 3/3 in 0.51s; all recorded burners stopped afterward.
- `ruff check` on all three changed files: green.
- `git diff --check`: green.
- Diff scope: exactly `tests/test_codex_home.py`, `tests/test_scheduler.py`, and `tests/test_buzz_inbound_poller.py`.

Closes #1080

🤖 Opened by Kuzya