### PR TITLE
fix: recognize canonical tmux server absence

### DIFF
--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -658,7 +658,7 @@ class _TmuxControl:
         result = await self._run("has-session", "-t", self.session_name)
         if result.ok:
             return True
-        if await self._session_absence_is_verified():
+        if await self._session_absence_is_verified(result):
             return False
         raise RuntimeError(
             f"tmux has-session failed without verified absence: "
@@ -701,8 +701,26 @@ class _TmuxControl:
             return False
         return False
 
-    async def _session_absence_is_verified(self) -> bool:
-        """Prove the owned target absent without classifying tmux stderr."""
+    @staticmethod
+    def _server_absence_is_reported(result: TmuxCommandResult) -> bool:
+        """Recognize only tmux's canonical, unambiguous no-server result."""
+        return (
+            result.returncode == 1
+            and result.stdout == ""
+            and re.fullmatch(
+                r"no server running on \S+",
+                result.stderr.strip(),
+            )
+            is not None
+        )
+
+    async def _session_absence_is_verified(
+        self,
+        failed_result: TmuxCommandResult,
+    ) -> bool:
+        """Prove the owned target absent from the failed command or server state."""
+        if self._server_absence_is_reported(failed_result):
+            return True
         if self._server_socket_is_missing():
             return True
         listing = await self._run("list-sessions", "-F", "#{session_name}")
@@ -745,14 +763,12 @@ class _TmuxControl:
         result = await self._run("kill-session", "-t", self.session_name)
         if result.ok:
             return result
-        # Do not classify absence from stderr: tmux versions and platforms use
-        # different text for a missing session versus a missing server/socket.
-        # Positive absence is either a missing local server socket, or an rc=0
-        # session enumeration which omits the owned target. Non-ok probes,
-        # ambiguous output, stat errors, and a still-listed target all preserve
-        # the original failure so strict replacement callers fail closed.
-        # Probe exceptions still propagate.
-        if await self._session_absence_is_verified():
+        # Positive absence is tmux's exact canonical no-server result, a missing
+        # local server socket, or an rc=0 session enumeration which omits the
+        # owned target. Non-ok probes, ambiguous output, stat errors, and a
+        # still-listed target all preserve the original failure so strict
+        # replacement callers fail closed. Probe exceptions still propagate.
+        if await self._session_absence_is_verified(result):
             return TmuxCommandResult(returncode=0, stdout="", stderr=result.stderr)
         return result
 

--- a/tests/test_codex_home.py
+++ b/tests/test_codex_home.py
@@ -2742,6 +2742,7 @@ async def test_tmux_repl_absent_server_cold_start_proceeds(
     tmux = _TmuxControl("pinky-test-agent")
     session = TmuxSession(config, tmux_control=tmux)
     _mark_tmux_server_socket(tmp_path, monkeypatch)
+    monkeypatch.setenv("PINKY_SESSION_SECRET", "daemon-env-marker")
     tmux_calls: list[tuple[str, ...]] = []
     has_session_calls = 0
 
@@ -2758,6 +2759,7 @@ async def test_tmux_repl_absent_server_cold_start_proceeds(
                 )
             return TmuxCommandResult(returncode=0, stdout="", stderr="")
         if args[0] == "new-session":
+            assert "PINKY_SESSION_SECRET=daemon-env-marker" in args
             return TmuxCommandResult(returncode=0, stdout="", stderr="")
         raise AssertionError(f"unexpected tmux call: {args}")
 

--- a/tests/test_codex_home.py
+++ b/tests/test_codex_home.py
@@ -2632,20 +2632,116 @@ async def test_tmux_app_server_first_start_with_absent_server_proceeds(
 
 
 @pytest.mark.asyncio
+async def test_tmux_has_session_accepts_exact_reported_server_absence(
+    tmp_path,
+    monkeypatch,
+):
+    """The canonical tmux no-server result positively proves no target exists."""
+    control = _TmuxControl("pinky-test-agent")
+    _mark_tmux_server_socket(tmp_path, monkeypatch)
+    tmux_calls: list[tuple[str, ...]] = []
+
+    async def _tmux_run(*args, timeout=5.0, stdin_data=None):
+        tmux_calls.append(args)
+        if args[0] == "has-session":
+            return TmuxCommandResult(
+                returncode=1,
+                stdout="",
+                stderr="no server running on /tmp/tmux-1000/default\n",
+            )
+        raise AssertionError(f"unexpected tmux call: {args}")
+
+    monkeypatch.setattr(control, "_run", _tmux_run)
+
+    assert await control.has_session() is False
+    assert [call[0] for call in tmux_calls] == ["has-session"]
+
+
+@pytest.mark.parametrize(
+    ("returncode", "stdout", "stderr"),
+    [
+        (2, "", "no server running on /tmp/tmux-1000/default"),
+        (1, "unexpected", "no server running on /tmp/tmux-1000/default"),
+        (1, "", ""),
+        (1, "", "no server running on "),
+        (1, "", "tmux: no server running on /tmp/tmux-1000/default"),
+        (1, "", "no server running on /tmp/tmux-1000/default (ambiguous)"),
+        (1, "", "couldn't create directory /blocked/tmux-501 (Permission denied)"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_tmux_has_session_rejects_noncanonical_server_absence(
+    tmp_path,
+    monkeypatch,
+    returncode,
+    stdout,
+    stderr,
+):
+    """Wrong, empty, and near-match probe shapes remain loudly ambiguous."""
+    control = _TmuxControl("pinky-test-agent")
+    _mark_tmux_server_socket(tmp_path, monkeypatch)
+    tmux_calls: list[tuple[str, ...]] = []
+    ambiguous = TmuxCommandResult(
+        returncode=returncode,
+        stdout=stdout,
+        stderr=stderr,
+    )
+
+    async def _tmux_run(*args, timeout=5.0, stdin_data=None):
+        tmux_calls.append(args)
+        if args[0] in {"has-session", "list-sessions"}:
+            return ambiguous
+        raise AssertionError(f"unexpected tmux call: {args}")
+
+    monkeypatch.setattr(control, "_run", _tmux_run)
+
+    with pytest.raises(RuntimeError, match="failed without verified absence"):
+        await control.has_session()
+
+    assert [call[0] for call in tmux_calls] == ["has-session", "list-sessions"]
+
+
+@pytest.mark.asyncio
+async def test_tmux_kill_session_inherits_exact_reported_server_absence(
+    tmp_path,
+    monkeypatch,
+):
+    """Idempotent cleanup shares the canonical no-server absence proof."""
+    control = _TmuxControl("pinky-test-agent")
+    _mark_tmux_server_socket(tmp_path, monkeypatch)
+    tmux_calls: list[tuple[str, ...]] = []
+
+    async def _tmux_run(*args, timeout=5.0, stdin_data=None):
+        tmux_calls.append(args)
+        if args[0] == "kill-session":
+            return TmuxCommandResult(
+                returncode=1,
+                stdout="",
+                stderr="no server running on /tmp/tmux-1000/default\n",
+            )
+        raise AssertionError(f"unexpected tmux call: {args}")
+
+    monkeypatch.setattr(control, "_run", _tmux_run)
+
+    result = await control.kill_session()
+
+    assert result.ok
+    assert [call[0] for call in tmux_calls] == ["kill-session"]
+
+
+@pytest.mark.asyncio
 async def test_tmux_repl_absent_server_cold_start_proceeds(
     tmp_path,
     monkeypatch,
 ):
-    """R8: a missing local socket remains positive cold-start absence."""
+    """R8: tmux's exact no-server result permits boot despite a stale socket."""
     config = StreamingSessionConfig(
         agent_name="test-agent",
         working_dir=str(tmp_path / "agent"),
     )
     tmux = _TmuxControl("pinky-test-agent")
     session = TmuxSession(config, tmux_control=tmux)
-    socket_dir = tmp_path / "tmux-empty"
-    monkeypatch.setenv("TMUX_TMPDIR", str(socket_dir))
-    monkeypatch.delenv("TMUX", raising=False)
+    _mark_tmux_server_socket(tmp_path, monkeypatch)
     tmux_calls: list[tuple[str, ...]] = []
     has_session_calls = 0
 
@@ -2658,7 +2754,7 @@ async def test_tmux_repl_absent_server_cold_start_proceeds(
                 return TmuxCommandResult(
                     returncode=1,
                     stdout="",
-                    stderr="no server running",
+                    stderr="no server running on /tmp/tmux-1000/default\n",
                 )
             return TmuxCommandResult(returncode=0, stdout="", stderr="")
         if args[0] == "new-session":
@@ -3243,10 +3339,19 @@ async def test_tmux_repl_permission_probe_refuses_before_publication(
     assert soul_store.calls == []
 
 
+@pytest.mark.parametrize(
+    "probe_stderr",
+    [
+        "couldn't create directory /blocked/tmux-501 (Permission denied)",
+        "",
+        "no server running on ",
+    ],
+)
 @pytest.mark.asyncio
 async def test_tmux_repl_returned_has_session_error_refuses_before_spawn_side_effects(
     tmp_path,
     monkeypatch,
+    probe_stderr,
 ):
     """R8: an ambiguous stale-session probe must fail before spawn effects."""
     shared_home = tmp_path / "shared"
@@ -3276,10 +3381,10 @@ async def test_tmux_repl_returned_has_session_error_refuses_before_spawn_side_ef
     env_build_count = 0
     publication_count = 0
     new_session_count = 0
-    permission_error = TmuxCommandResult(
+    probe_error = TmuxCommandResult(
         returncode=1,
         stdout="",
-        stderr="couldn't create directory /blocked/tmux-501 (Permission denied)",
+        stderr=probe_stderr,
     )
     real_build_env = session._build_repl_env
     real_prepare_spawn = session._prepare_tmux_spawn
@@ -3290,7 +3395,7 @@ async def test_tmux_repl_returned_has_session_error_refuses_before_spawn_side_ef
     async def _tmux_run(*args, timeout=5.0, stdin_data=None):
         tmux_calls.append(args)
         if args[0] in {"has-session", "list-sessions"}:
-            return permission_error
+            return probe_error
         raise AssertionError(f"unexpected direct tmux call: {args}")
 
     async def _tracked_new_session(**_kwargs):


### PR DESCRIPTION
Closes #1097

## Incident

When the last tmux session exits, the tmux server can disappear while its socket path remains. The next daemon cold start receives the canonical tmux result:

```text
rc=1 stdout='' stderr='no server running on /tmp/tmux-<uid>/default'
```

The existing guard then asks `list-sessions`, cannot verify absence, and fails boot closed forever. This caused the live fleet-wide bootstrap deadlock described in #1097.

## Change

- Pass the failed tmux result into the existing shared `_session_absence_is_verified` choke point.
- Treat only this canonical shape as verified server absence:
  - return code exactly `1`
  - stdout exactly empty
  - `stderr.strip()` fully matches `no server running on \S+`
- Preserve the existing missing-local-socket and successful session-listing proofs as fallbacks.
- Keep every other result fail-closed.
- Share the result across both `has_session()` and idempotent `kill_session()`, so cold start and cleanup do not grow caller-specific exceptions.

## Deliberate fail-closed boundary

Other dead-server-looking stderr families are intentionally not accepted. In particular, stale-socket variants such as `error connecting to <sock> (Connection refused)` remain ambiguous: they can overlap permission or transient transport failures, they already fail loudly, and the keepalive-class operational workaround exists if that distinct shape appears in production. This PR recognizes only tmux's exact canonical `no server running on <socket>` statement.

## Daemon parentage

Once the operator keepalive workaround is retired, the accepted no-server result lets the daemon's own `new-session` call create the first session and therefore start the tmux server as a daemon child. That restores daemon-environment parentage by construction for this bootstrap path and removes the operator-shell environment hazard documented in the [production follow-up](https://github.com/bradbrok/PinkyBot/issues/1097#issuecomment-5302785040). The lifecycle regression test also asserts a daemon-provided `PINKY_SESSION_SECRET` marker reaches the spawned session.

## Regression evidence

Exact base: `6f128e99ab508c6a2135b8b245cd0d87b32f4c83` (tree `2170df5d26bf36fb55cdbbb348f6a34bcbd953ea`)

Final head: `94805fd5896ae9fe5e9f11567eef99bfa6f8a7cf` (tree `b82f6808333853b7bc88dda9aac37d3203537c0d`)

### Pre-fix red

With only the new tests present, all three positive contracts failed on base code:

```text
FAILED test_tmux_has_session_accepts_exact_reported_server_absence
FAILED test_tmux_kill_session_inherits_exact_reported_server_absence
FAILED test_tmux_repl_absent_server_cold_start_proceeds
3 failed
```

Each failure showed the old implementation making an unexpected `list-sessions` call after the exact canonical no-server result. The lifecycle case forced a socket marker present, so the old missing-socket shortcut could not launder the test.

### Green

- Exact-shape, rejection-matrix, cleanup, and lifecycle contracts: `13 passed`
- `tests/test_codex_home.py`: `98 passed`
- `tests/test_tmux_session.py`: `410 passed in 139.45s`
- Daemon-env lifecycle assertion: `1 passed`
- `ruff check .`: green
- `git diff --check origin/main...HEAD`: green
- Final diff: one product file and one test file

The rejection matrix covers wrong rc, nonempty stdout, empty stderr, missing socket operand, prefixed/suffixed near matches, and permission/transport errors. The lifecycle fail-closed test independently covers permission failure, empty stderr, and the missing-operand near miss before env construction, state publication, or `new-session`.

## Local full-suite disclosure

The isolated Python 3.13 CI-style environment (Claude Agent SDK 0.2.139) progressed without a failure to the known macOS TestClient stall around 16–17%, then stopped responding at:

```text
tests/test_api.py::TestGoogleOAuthStateValidation::test_callback_rejects_missing_state
...
voice: WS endpoint registered at /ws/voice/{id}
```

The same standalone test reproduced on a clean detached exact-base `6f128e99` worktree: no output or completion for 73 seconds, process state `U` at ~25% CPU, then only that isolated probe was terminated. This is the same host-local baseline previously adjudicated on #1094 / task #587; the change has no causal path to `test_api.py`. Final-head Linux CI is therefore the repository-wide full-suite gate.

🤖 Opened by Kuzya