### PR TITLE
Fix scheduler receipt starvation and replay wedge

### DIFF
--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -11466,6 +11466,16 @@ npm run build</pre>
             or stats.get("inflight_active") is True
         )
 
+    def _scheduler_drain_busy(agent_name: str) -> bool:
+        """Recheck current pane state for the periodic durable-outbox drain."""
+        ss = broker._get_streaming_session(agent_name)
+        if ss is None:
+            return False
+        probe = getattr(ss, "scheduler_drain_busy", None)
+        if not callable(probe):
+            return _scheduler_delivery_busy(agent_name)
+        return probe() is True
+
     def _scheduler_wake_inflight(agent_name: str, prompt: str) -> bool:
         """Per-turn execution state: is this wake pasted with an open receipt?
 
@@ -11654,6 +11664,7 @@ npm run build</pre>
         streaming_sessions_fn=lambda: broker._streaming,
         comms_cleanup_fn=comms.cleanup_expired,
         delivery_busy_fn=_scheduler_delivery_busy,
+        delivery_drain_busy_fn=_scheduler_drain_busy,
         delivery_inflight_fn=_scheduler_wake_inflight,
         delivery_queued_fn=_scheduler_wake_queued,
         delivery_cancel_queued_fn=_cancel_scheduler_wake,

--- a/src/pinky_daemon/codex_tmux_session.py
+++ b/src/pinky_daemon/codex_tmux_session.py
@@ -49,7 +49,6 @@ import os
 import re
 import shlex
 import time
-from collections import deque
 from pathlib import Path
 
 from pinky_daemon.codex_home import (
@@ -465,21 +464,12 @@ class CodexTmuxSession(TmuxSession):
         if not stale:
             return 0
         stale_ids = {id(meta) for meta in stale}
-        stale_turn_ids = {id(meta.turn) for meta in stale}
         kept = [
             meta for meta in self._inflight_metas
             if id(meta) not in stale_ids
         ]
         self._inflight_metas.clear()
         self._inflight_metas.extend(kept)
-        self._pane_queue_operations = deque(
-            turn for turn in self._pane_queue_operations
-            if turn is None or id(turn) not in stale_turn_ids
-        )
-        self._pane_dequeued_turns = deque(
-            turn for turn in self._pane_dequeued_turns
-            if turn is None or id(turn) not in stale_turn_ids
-        )
         for meta in stale:
             event = meta.completion_event
             if event is not None and not event.is_set():

--- a/src/pinky_daemon/scheduler.py
+++ b/src/pinky_daemon/scheduler.py
@@ -20,6 +20,7 @@ import math
 import os
 import sys
 import time
+from dataclasses import dataclass
 from datetime import date, datetime, timedelta
 from zoneinfo import ZoneInfo
 
@@ -60,8 +61,22 @@ _SCHEDULE_PROMPT_WARN_INTERVAL_SEC = 15 * 60
 _PERSISTED_WAKE_MAX_AGE_SEC = 60 * 60
 _RECEIPT_EXTENSION_MAX_AGE_ENV = "PINKY_SCHEDULE_RECEIPT_EXTENSION_MAX_AGE_SEC"
 _RECEIPT_EXTENSION_MAX_AGE_SEC = 60 * 60
+_RECEIPT_EXTENSION_ATTEMPT_CAP_ENV = (
+    "PINKY_SCHEDULE_RECEIPT_EXTENSION_ATTEMPT_CAP"
+)
+_RECEIPT_EXTENSION_ATTEMPT_CAP = 3
 _ABANDONED_RECEIPT_OBSERVER_INTERVAL_SEC = 1.0
 _PENDING_WAKE_LIVENESS_DRAIN_INTERVAL_SEC = 60
+_OUTBOX_DRAIN_EXTENSION_ATTEMPT_CAP_ENV = (
+    "PINKY_OUTBOX_DRAIN_EXTENSION_ATTEMPT_CAP"
+)
+_OUTBOX_DRAIN_EXTENSION_ATTEMPT_CAP = 30
+_OUTBOX_DRAIN_EXTENSION_MAX_AGE_ENV = (
+    "PINKY_OUTBOX_DRAIN_EXTENSION_MAX_AGE_SEC"
+)
+_OUTBOX_DRAIN_EXTENSION_MAX_AGE_SEC = 30 * 60
+_OUTBOX_DRAIN_PROBE_TIMEOUT_ENV = "PINKY_OUTBOX_DRAIN_PROBE_TIMEOUT_SEC"
+_OUTBOX_DRAIN_PROBE_TIMEOUT_SEC = 5.0
 _OUTBOX_REAPER_RETAIN_ACCEPTED_ENV = (
     "PINKY_OUTBOX_REAPER_RETAIN_ACCEPTED_SEC"
 )
@@ -83,7 +98,16 @@ _OUTBOX_REAPER_FAILURE_BACKOFF_SEC = 60 * 60
 
 
 class _ReceiptAbandonedError(RuntimeError):
-    """An already-pasted wake exceeded its original-fire receipt deadline."""
+    """An unconfirmed wake exhausted its receipt-extension budget."""
+
+
+@dataclass
+class _OutboxDrainExtensionState:
+    """One oldest pending fire's consecutive busy-drain evidence."""
+
+    oldest_fired_at: float
+    attempts: int = 0
+    alerted: bool = False
 
 
 def _positive_env_seconds(name: str, default: float) -> float:
@@ -99,6 +123,21 @@ def _positive_env_seconds(name: str, default: float) -> float:
             f"using {default:g}s"
         )
         return float(default)
+    return value
+
+
+def _positive_env_int(name: str, default: int) -> int:
+    """Read one positive integer, falling back loudly."""
+    raw_value = os.environ.get(name, str(default))
+    try:
+        value = int(raw_value)
+        if str(value) != raw_value.strip() or value <= 0:
+            raise ValueError("value must be a positive integer")
+    except (TypeError, ValueError):
+        _log(
+            f"scheduler: invalid {name} value {raw_value!r}; using {default}"
+        )
+        return default
     return value
 
 
@@ -263,6 +302,7 @@ class AgentScheduler:
         is_resurrectable_fn=None,
         comms_cleanup_fn=None,
         delivery_busy_fn=None,
+        delivery_drain_busy_fn=None,
         delivery_inflight_fn=None,
         delivery_queued_fn=None,
         delivery_cancel_queued_fn=None,
@@ -272,7 +312,11 @@ class AgentScheduler:
         tick_interval: int = 30,
         schedule_delivery_timeout: float = 600.0,
         pending_wake_max_age_sec: float = _PERSISTED_WAKE_MAX_AGE_SEC,
+        receipt_extension_attempt_cap: int | None = None,
         receipt_extension_max_age_sec: float | None = None,
+        outbox_drain_extension_attempt_cap: int | None = None,
+        outbox_drain_extension_max_age_sec: float | None = None,
+        outbox_drain_probe_timeout_sec: float | None = None,
     ) -> None:
         self._registry = registry
         # async fn(agent_name, session_id, prompt, *, schedule_receipt=None)
@@ -315,6 +359,13 @@ class AgentScheduler:
         # At the ceiling the waiter detaches, the exact row is explicitly
         # abandoned, and a later positive receipt can still win.
         self._delivery_inflight_fn = delivery_inflight_fn
+        # fn(agent_name) -> bool. A fresh, drain-specific pane-state probe
+        # evaluated under the scheduler's per-agent replay lock. This is
+        # deliberately narrower than the wide watchdog signal above: a stale
+        # inflight meta plus periodic monitor output may keep the watchdog
+        # positive after the REPL has reported a newer idle boundary (#1098).
+        # Missing implementations fall back to delivery_busy_fn.
+        self._delivery_drain_busy_fn = delivery_drain_busy_fn
         # fn(agent_name, prompt) -> bool. True means THIS wake remains queued
         # and recallable before its first pane paste on a live transport. This
         # is positive in-progress evidence just like ``delivery_inflight_fn``:
@@ -327,10 +378,10 @@ class AgentScheduler:
         # which case the unrecallable inflight abandonment path owns it.
         self._delivery_cancel_queued_fn = delivery_cancel_queued_fn
         # async fn(agent_name, text) -> bool. Delivers operator-facing owner
-        # alerts for terminal dead-letter events (PERSISTED_WAKE_PARKED, stale
-        # one-shot drop) through an out-of-band transport. Routine
-        # FIRED-BUT-UNDELIVERED receipt failures are logged only, NOT
-        # owner-notified (#1043).
+        # alerts for terminal dead-letter events (bounded receipt/drain expiry,
+        # PERSISTED_WAKE_PARKED, stale one-shot drop) through an out-of-band
+        # transport. Routine FIRED-BUT-UNDELIVERED receipt failures are logged
+        # only, NOT owner-notified (#1043).
         self._owner_notify_callback = owner_notify_callback
         self._trigger_store = trigger_store  # TriggerStore | None
         self._activity = activity  # ActivityStore | None
@@ -339,6 +390,20 @@ class AgentScheduler:
         if pending_wake_max_age_sec <= 0:
             raise ValueError("pending_wake_max_age_sec must be positive")
         self._pending_wake_max_age_sec = float(pending_wake_max_age_sec)
+        if receipt_extension_attempt_cap is None:
+            receipt_extension_attempt_cap = _positive_env_int(
+                _RECEIPT_EXTENSION_ATTEMPT_CAP_ENV,
+                _RECEIPT_EXTENSION_ATTEMPT_CAP,
+            )
+        if (
+            isinstance(receipt_extension_attempt_cap, bool)
+            or not isinstance(receipt_extension_attempt_cap, int)
+            or receipt_extension_attempt_cap <= 0
+        ):
+            raise ValueError(
+                "receipt_extension_attempt_cap must be a positive integer"
+            )
+        self._receipt_extension_attempt_cap = receipt_extension_attempt_cap
         if receipt_extension_max_age_sec is None:
             raw_extension_max_age = os.environ.get(
                 _RECEIPT_EXTENSION_MAX_AGE_ENV,
@@ -367,6 +432,52 @@ class AgentScheduler:
             )
         self._receipt_extension_max_age_sec = float(
             receipt_extension_max_age_sec
+        )
+        if outbox_drain_extension_attempt_cap is None:
+            outbox_drain_extension_attempt_cap = _positive_env_int(
+                _OUTBOX_DRAIN_EXTENSION_ATTEMPT_CAP_ENV,
+                _OUTBOX_DRAIN_EXTENSION_ATTEMPT_CAP,
+            )
+        if (
+            isinstance(outbox_drain_extension_attempt_cap, bool)
+            or not isinstance(outbox_drain_extension_attempt_cap, int)
+            or outbox_drain_extension_attempt_cap <= 0
+        ):
+            raise ValueError(
+                "outbox_drain_extension_attempt_cap must be a positive integer"
+            )
+        self._outbox_drain_extension_attempt_cap = (
+            outbox_drain_extension_attempt_cap
+        )
+        if outbox_drain_extension_max_age_sec is None:
+            outbox_drain_extension_max_age_sec = _positive_env_seconds(
+                _OUTBOX_DRAIN_EXTENSION_MAX_AGE_ENV,
+                _OUTBOX_DRAIN_EXTENSION_MAX_AGE_SEC,
+            )
+        if (
+            not math.isfinite(outbox_drain_extension_max_age_sec)
+            or outbox_drain_extension_max_age_sec <= 0
+        ):
+            raise ValueError(
+                "outbox_drain_extension_max_age_sec must be finite and positive"
+            )
+        self._outbox_drain_extension_max_age_sec = float(
+            outbox_drain_extension_max_age_sec
+        )
+        if outbox_drain_probe_timeout_sec is None:
+            outbox_drain_probe_timeout_sec = _positive_env_seconds(
+                _OUTBOX_DRAIN_PROBE_TIMEOUT_ENV,
+                _OUTBOX_DRAIN_PROBE_TIMEOUT_SEC,
+            )
+        if (
+            not math.isfinite(outbox_drain_probe_timeout_sec)
+            or outbox_drain_probe_timeout_sec <= 0
+        ):
+            raise ValueError(
+                "outbox_drain_probe_timeout_sec must be finite and positive"
+            )
+        self._outbox_drain_probe_timeout_sec = float(
+            outbox_drain_probe_timeout_sec
         )
         self._outbox_reaper_retain_accepted_sec = _positive_env_seconds(
             _OUTBOX_REAPER_RETAIN_ACCEPTED_ENV,
@@ -415,6 +526,11 @@ class AgentScheduler:
         self._detached_receipt_tasks: set[asyncio.Task] = set()
         self._pending_replay_tasks: dict[str, asyncio.Task] = {}
         self._pending_replay_again: set[str] = set()
+        self._pending_replay_drain_recheck: set[str] = set()
+        self._outbox_drain_extensions: dict[
+            str, _OutboxDrainExtensionState
+        ] = {}
+        self._receipt_extension_alerted: set[tuple[int, float]] = set()
         self._owner_alert_tasks: set[asyncio.Task] = set()
         self._last_schedule_prompt_warn_at: float | None = None
         self._last_pending_wake_liveness_drain_at: float | None = None
@@ -477,6 +593,7 @@ class AgentScheduler:
             await asyncio.gather(*detached_receipts, return_exceptions=True)
         self._detached_receipt_tasks.clear()
         self._pending_replay_again.clear()
+        self._pending_replay_drain_recheck.clear()
         replay_tasks = list(self._pending_replay_tasks.values())
         for task in replay_tasks:
             if not task.done():
@@ -484,6 +601,7 @@ class AgentScheduler:
         if replay_tasks:
             await asyncio.gather(*replay_tasks, return_exceptions=True)
         self._pending_replay_tasks.clear()
+        self._outbox_drain_extensions.clear()
         alert_tasks = list(self._owner_alert_tasks)
         if alert_tasks:
             await asyncio.gather(*alert_tasks, return_exceptions=True)
@@ -1129,6 +1247,7 @@ class AgentScheduler:
                 attempt_started=attempt_started,
             )
         )
+        receipt_wait_attempts = 0
         try:
             while True:
                 try:
@@ -1146,6 +1265,7 @@ class AgentScheduler:
                             remaining, self._schedule_delivery_timeout
                         )
                         fresh_receipt_budget = False
+                    receipt_wait_attempts += 1
                     confirmed = await asyncio.wait_for(
                         asyncio.shield(delivery),
                         timeout=min(
@@ -1159,7 +1279,19 @@ class AgentScheduler:
                     return confirmed
                 except asyncio.TimeoutError:
                     age = self._receipt_age(schedule)
-                    if age >= self._receipt_extension_max_age_sec:
+                    wall_clock_expired = (
+                        age >= self._receipt_extension_max_age_sec
+                    )
+                    attempts_expired = (
+                        receipt_wait_attempts
+                        >= self._receipt_extension_attempt_cap
+                    )
+                    if wall_clock_expired or attempts_expired:
+                        bound_reason = (
+                            "wall-clock cap"
+                            if wall_clock_expired
+                            else "attempt cap"
+                        )
                         queued = self._wake_prompt_queued(
                             schedule, prompt=delivery_prompt
                         )
@@ -1184,7 +1316,10 @@ class AgentScheduler:
                                     "receipt abandonment"
                                 )
                                 self._mark_abandoned_receipt(
-                                    schedule, age=age
+                                    schedule,
+                                    age=age,
+                                    bound_reason=bound_reason,
+                                    wait_attempts=receipt_wait_attempts,
                                 )
                                 raise _ReceiptAbandonedError
 
@@ -1215,6 +1350,8 @@ class AgentScheduler:
                                     schedule,
                                     delivery,
                                     age=age,
+                                    bound_reason=bound_reason,
+                                    wait_attempts=receipt_wait_attempts,
                                     stale_drop_notices=stale_drop_notices,
                                 )
                                 raise _ReceiptAbandonedError
@@ -1244,7 +1381,10 @@ class AgentScheduler:
                                         "(receipt-fence fallback)"
                                     )
                                     self._mark_abandoned_receipt(
-                                        schedule, age=age
+                                        schedule,
+                                        age=age,
+                                        bound_reason=bound_reason,
+                                        wait_attempts=receipt_wait_attempts,
                                     )
                                     raise _ReceiptAbandonedError
 
@@ -1256,6 +1396,8 @@ class AgentScheduler:
                                 schedule,
                                 delivery,
                                 age=age,
+                                bound_reason=bound_reason,
+                                wait_attempts=receipt_wait_attempts,
                                 stale_drop_notices=stale_drop_notices,
                             )
                             raise _ReceiptAbandonedError
@@ -1278,7 +1420,21 @@ class AgentScheduler:
                         if self._wake_prompt_queued(
                             schedule, prompt=delivery_prompt
                         ):
-                            continue
+                            # Positive recallability never owns a late-receipt
+                            # observer. Cancel the delivery task so the
+                            # transport's in-lock receipt fence prevents a
+                            # later paste, then terminalize the exact fire.
+                            delivery.cancel()
+                            await asyncio.gather(
+                                delivery, return_exceptions=True
+                            )
+                            self._mark_abandoned_receipt(
+                                schedule,
+                                age=age,
+                                bound_reason=bound_reason,
+                                wait_attempts=receipt_wait_attempts,
+                            )
+                            raise _ReceiptAbandonedError
                         if self._wake_prompt_inflight(
                             schedule, prompt=delivery_prompt
                         ):
@@ -1286,6 +1442,8 @@ class AgentScheduler:
                                 schedule,
                                 delivery,
                                 age=age,
+                                bound_reason=bound_reason,
+                                wait_attempts=receipt_wait_attempts,
                                 stale_drop_notices=stale_drop_notices,
                             )
                             raise _ReceiptAbandonedError
@@ -1293,17 +1451,22 @@ class AgentScheduler:
                         await asyncio.gather(
                             delivery, return_exceptions=True
                         )
-                        raise asyncio.TimeoutError(
-                            "delivery receipt ceiling reached from original "
-                            f"fired_at after {age:.1f}s"
+                        self._mark_abandoned_receipt(
+                            schedule,
+                            age=age,
+                            bound_reason=bound_reason,
+                            wait_attempts=receipt_wait_attempts,
                         )
+                        raise _ReceiptAbandonedError
                     if self._agent_busy_not_wedged(schedule.agent_name):
                         _log(
                             f"scheduler: receipt still pending for schedule "
                             f"'{schedule.name}' "
                             f"(#{self._schedule_id(schedule)}) for agent "
                             f"'{schedule.agent_name}', but inflight watchdog "
-                            "reports busy-not-wedged; extending delivery timeout"
+                            "reports busy-not-wedged; extending delivery timeout "
+                            f"(wait {receipt_wait_attempts}/"
+                            f"{self._receipt_extension_attempt_cap})"
                         )
                         continue
                     if self._wake_prompt_inflight(
@@ -1317,7 +1480,9 @@ class AgentScheduler:
                             "already pasted to the transport — a cancel "
                             "cannot recall it, and declaring undelivered "
                             "would re-persist a wake that is about to "
-                            "execute (duplicate execution); extending"
+                            "execute (duplicate execution); extending "
+                            f"(wait {receipt_wait_attempts}/"
+                            f"{self._receipt_extension_attempt_cap})"
                         )
                         continue
                     if self._wake_prompt_queued(
@@ -1329,7 +1494,9 @@ class AgentScheduler:
                             f"(#{self._schedule_id(schedule)}) for agent "
                             f"'{schedule.agent_name}', but its prompt is "
                             "queued-unpasted on a connected transport; "
-                            "extending delivery timeout"
+                            "extending delivery timeout "
+                            f"(wait {receipt_wait_attempts}/"
+                            f"{self._receipt_extension_attempt_cap})"
                         )
                         continue
                     await asyncio.sleep(0)
@@ -1362,11 +1529,16 @@ class AgentScheduler:
         delivery: asyncio.Task,
         *,
         age: float,
+        bound_reason: str,
+        wait_attempts: int,
         stale_drop_notices: list[RecurringScheduleStaleDrop],
     ) -> None:
         """Release the delivery lock while retaining late-receipt authority."""
         schedule_id, fired_at, _ = self._mark_abandoned_receipt(
-            schedule, age=age
+            schedule,
+            age=age,
+            bound_reason=bound_reason,
+            wait_attempts=wait_attempts,
         )
 
         async def _observe_late_receipt() -> None:
@@ -1398,12 +1570,24 @@ class AgentScheduler:
         self._track_detached_receipt_task(_observe_late_receipt())
 
     def _mark_abandoned_receipt(
-        self, schedule, *, age: float
+        self,
+        schedule,
+        *,
+        age: float,
+        bound_reason: str = "wall-clock cap",
+        wait_attempts: int | None = None,
     ) -> tuple[int, float, bool]:
-        """Abandon one unrecallable fire without submitting new work."""
+        """Move one budget-expired unconfirmed fire to explicit abandonment."""
+        attempt_detail = (
+            f", wait_attempts={wait_attempts}"
+            if wait_attempts is not None
+            else ""
+        )
         reason = (
-            "RECEIPT_ABANDONED: original fired_at exceeded receipt-extension "
-            f"ceiling ({age:.1f}s >= {self._receipt_extension_max_age_sec:.1f}s)"
+            "RECEIPT_ABANDONED: receipt-extension budget expired "
+            f"by {bound_reason} (age={age:.1f}s, "
+            f"max_age={self._receipt_extension_max_age_sec:.1f}s"
+            f"{attempt_detail})"
         )
         schedule_id = self._schedule_id(schedule)
         fired_at = self._schedule_fired_at(schedule)
@@ -1423,7 +1607,14 @@ class AgentScheduler:
             f"(#{schedule_id}) for agent '{schedule.agent_name}' "
             f"fired_at={fired_at} age_s={age:.1f} "
             f"ceiling_s={self._receipt_extension_max_age_sec:.1f} "
+            f"bound={bound_reason!r} wait_attempts={wait_attempts} "
             f"abandoned={abandoned}"
+        )
+        self._alert_receipt_extension_expired(
+            schedule,
+            age=age,
+            bound_reason=bound_reason,
+            wait_attempts=wait_attempts,
         )
         if self._activity:
             try:
@@ -1431,11 +1622,53 @@ class AgentScheduler:
                     schedule.agent_name,
                     "schedule_receipt_abandoned",
                     f"Schedule '{schedule.name}' receipt wait exceeded its "
-                    "original-fire ceiling",
+                    f"{bound_reason}",
                 )
             except Exception:
                 pass
         return schedule_id, fired_at, abandoned
+
+    def _alert_receipt_extension_expired(
+        self,
+        schedule,
+        *,
+        age: float,
+        bound_reason: str,
+        wait_attempts: int | None,
+    ) -> None:
+        """Emit one durable-fire alert after its generous wait budget expires."""
+        schedule_id = self._schedule_id(schedule)
+        fired_at = self._schedule_fired_at(schedule)
+        alert_key = (schedule_id, fired_at)
+        if alert_key in self._receipt_extension_alerted:
+            _log(
+                "scheduler: RECEIPT_EXTENSION_EXPIRED owner already alerted "
+                f"for schedule '{schedule.name}' (#{schedule_id}) on agent "
+                f"'{schedule.agent_name}' fired_at={fired_at}"
+            )
+            return
+        self._receipt_extension_alerted.add(alert_key)
+        attempts = (
+            str(wait_attempts) if wait_attempts is not None else "persisted replay"
+        )
+        _log(
+            f"scheduler: RECEIPT_EXTENSION_EXPIRED schedule "
+            f"'{schedule.name}' (#{schedule_id}) for agent "
+            f"'{schedule.agent_name}' fired_at={fired_at} age_s={age:.1f} "
+            f"bound={bound_reason!r} wait_attempts={attempts}; owner alert queued"
+        )
+        self._queue_owner_alert(
+            schedule.agent_name,
+            (
+                "🚨 RECEIPT EXTENSION EXPIRED: schedule "
+                f"'{schedule.name}' (#{schedule_id}) on agent "
+                f"'{schedule.agent_name}' exhausted its {bound_reason} after "
+                f"{age:.1f}s and {attempts} confirmation wait(s). The exact "
+                "fire was moved to explicit abandonment to prevent replay; "
+                "an already-pasted delivery retains one late-receipt authority. "
+                "Inspect the transport and wake ledger before intervening."
+            ),
+        )
 
     def _abandon_inflight_replay(
         self,
@@ -1570,6 +1803,32 @@ class AgentScheduler:
             )
             return False
 
+    async def _agent_busy_for_drain(self, agent_name: str) -> bool:
+        """Re-read pane state without letting a hung probe hold the lane lock."""
+        probe = self._delivery_drain_busy_fn or self._delivery_busy_fn
+        if probe is None:
+            return False
+        try:
+            result = await asyncio.wait_for(
+                asyncio.to_thread(probe, agent_name),
+                timeout=self._outbox_drain_probe_timeout_sec,
+            )
+            return result is True
+        except asyncio.TimeoutError:
+            _log(
+                f"scheduler: drain-time transport recheck timed out for "
+                f"'{agent_name}' after "
+                f"{self._outbox_drain_probe_timeout_sec:.1f}s; "
+                "counting as busy and releasing the replay lock"
+            )
+            return True
+        except Exception as exc:
+            _log(
+                f"scheduler: drain-time transport recheck failed for "
+                f"'{agent_name}': {type(exc).__name__}: {exc}; deferring safely"
+            )
+            return True
+
     def _queue_owner_alert(self, agent_name: str, message: str) -> None:
         """Start one owner alert with a strong task reference and loud failure."""
         if self._owner_notify_callback is None:
@@ -1605,8 +1864,12 @@ class AgentScheduler:
         self._owner_alert_tasks.add(task)
         task.add_done_callback(self._owner_alert_tasks.discard)
 
-    def replay_pending_for_agent(self, agent_name: str) -> None:
+    def replay_pending_for_agent(
+        self, agent_name: str, *, drain_recheck: bool = False
+    ) -> None:
         """Coalesce triggers while guaranteeing one replay after the active pass."""
+        if drain_recheck:
+            self._pending_replay_drain_recheck.add(agent_name)
         existing = self._pending_replay_tasks.get(agent_name)
         if existing is not None and not existing.done():
             self._pending_replay_again.add(agent_name)
@@ -1642,7 +1905,14 @@ class AgentScheduler:
         """Deliver one agent's current owed wakes with exact receipts."""
         lock = self._schedule_delivery_locks.setdefault(agent_name, asyncio.Lock())
         async with lock:
-            await self._replay_pending_locked(agent_name)
+            drain_recheck = agent_name in self._pending_replay_drain_recheck
+            self._pending_replay_drain_recheck.discard(agent_name)
+            if drain_recheck:
+                await self._replay_pending_locked(
+                    agent_name, drain_recheck=True
+                )
+            else:
+                await self._replay_pending_locked(agent_name)
 
     def _park_pending_wake_if_capped(self, pending, attempts: int) -> bool:
         """Park one capped wake once and emit its single owner alert."""
@@ -1679,7 +1949,122 @@ class AgentScheduler:
         )
         return True
 
-    async def _replay_pending_locked(self, agent_name: str) -> None:
+    def _record_outbox_drain_extension(
+        self, agent_name: str, *, summary: dict, now: float
+    ) -> bool:
+        """Bound consecutive drain deferrals by count and oldest-fire age."""
+        oldest_fired_at = float(summary["oldest_fired_at"])
+        state = self._outbox_drain_extensions.get(agent_name)
+        if state is None or state.oldest_fired_at != oldest_fired_at:
+            state = _OutboxDrainExtensionState(oldest_fired_at)
+            self._outbox_drain_extensions[agent_name] = state
+        state.attempts += 1
+        oldest_age = max(0.0, now - oldest_fired_at)
+        wall_clock_expired = (
+            oldest_age >= self._outbox_drain_extension_max_age_sec
+        )
+        attempts_expired = (
+            state.attempts >= self._outbox_drain_extension_attempt_cap
+        )
+        if not (wall_clock_expired or attempts_expired):
+            _log(
+                f"scheduler: periodic outbox drain deferred for "
+                f"'{agent_name}': fresh transport recheck remains busy "
+                f"(attempt {state.attempts}/"
+                f"{self._outbox_drain_extension_attempt_cap}, "
+                f"oldest_age_s={oldest_age:.1f}/"
+                f"{self._outbox_drain_extension_max_age_sec:.1f})"
+            )
+            return False
+
+        bound_reason = (
+            "wall-clock cap" if wall_clock_expired else "attempt cap"
+        )
+        targeted, abandoned = self._abandon_outbox_drain_rows(
+            agent_name,
+            now=now,
+            bound_reason=bound_reason,
+            state=state,
+            oldest_age=oldest_age,
+        )
+        if state.alerted:
+            _log(
+                "scheduler: OUTBOX_DRAIN_EXTENSION_EXPIRED owner already "
+                f"alerted for '{agent_name}' oldest_fired_at={oldest_fired_at} "
+                f"bound={bound_reason!r}; transport recheck remains busy, "
+                f"terminalized={abandoned}/{targeted}"
+            )
+            return True
+        state.alerted = True
+        _log(
+            f"scheduler: OUTBOX_DRAIN_EXTENSION_EXPIRED agent='{agent_name}' "
+            f"oldest_fired_at={oldest_fired_at} oldest_age_s={oldest_age:.1f} "
+            f"attempts={state.attempts} bound={bound_reason!r} "
+            f"terminalized={abandoned}/{targeted}; owner alert queued"
+        )
+        self._queue_owner_alert(
+            agent_name,
+            (
+                "🚨 OUTBOX DRAIN EXTENSION EXPIRED: agent "
+                f"'{agent_name}' still reports busy at the fresh drain-time "
+                f"transport check after hitting its {bound_reason} "
+                f"({state.attempts} checks, oldest wake age "
+                f"{oldest_age:.1f}s). {abandoned}/{targeted} active wake row(s) "
+                "were moved to explicit OUTBOX_DRAIN_ABANDONED terminal state; "
+                "a late positive receipt can still supersede abandonment. "
+                "Inspect the transport and wake ledger before intervening."
+            ),
+        )
+        return True
+
+    def _abandon_outbox_drain_rows(
+        self,
+        agent_name: str,
+        *,
+        now: float,
+        bound_reason: str,
+        state: _OutboxDrainExtensionState,
+        oldest_age: float,
+    ) -> tuple[int, int]:
+        """Move every active row behind an expired drain to honest terminal state."""
+        try:
+            pending_wakes = self._registry.list_pending_schedule_wakes(
+                agent_name
+            )
+        except Exception as exc:
+            _log(
+                "scheduler: OUTBOX_DRAIN_ABANDON_FAILURE listing active rows "
+                f"for '{agent_name}': {type(exc).__name__}: {exc}"
+            )
+            return 0, 0
+
+        reason = (
+            "OUTBOX_DRAIN_ABANDONED: drain-extension budget expired "
+            f"by {bound_reason} (oldest_fired_at={state.oldest_fired_at}, "
+            f"oldest_age={oldest_age:.1f}s, checks={state.attempts}, "
+            f"attempt_cap={self._outbox_drain_extension_attempt_cap}, "
+            f"max_age={self._outbox_drain_extension_max_age_sec:.1f}s)"
+        )
+        abandoned = 0
+        for pending in pending_wakes:
+            try:
+                if self._registry.abandon_pending_schedule_wake(
+                    pending.id,
+                    abandoned_at=now,
+                    reason=reason,
+                ):
+                    abandoned += 1
+            except Exception as exc:
+                _log(
+                    "scheduler: OUTBOX_DRAIN_ABANDON_FAILURE pending "
+                    f"#{pending.id} for '{agent_name}': "
+                    f"{type(exc).__name__}: {exc}"
+                )
+        return len(pending_wakes), abandoned
+
+    async def _replay_pending_locked(
+        self, agent_name: str, *, drain_recheck: bool = False
+    ) -> None:
         """Reap zombies, collapse recurrences, then replay under the agent lock."""
         replay_now = time.time()
         health = self._registry.get_pending_schedule_wake_health(
@@ -1694,12 +2079,31 @@ class AgentScheduler:
                 f"oldest_age_s={summary['oldest_age_seconds']:.1f} "
                 f"oldest_fired_at={summary['oldest_fired_at']}"
             )
-            if self._agent_busy_not_wedged(agent_name):
-                _log(
-                    f"scheduler: persisted wake replay deferred for "
-                    f"'{agent_name}' until the next turn-idle boundary"
-                )
+            busy = (
+                await self._agent_busy_for_drain(agent_name)
+                if drain_recheck
+                else self._agent_busy_not_wedged(agent_name)
+            )
+            if busy:
+                drain_expired = False
+                if drain_recheck:
+                    drain_expired = self._record_outbox_drain_extension(
+                        agent_name, summary=summary, now=replay_now
+                    )
+                if drain_expired:
+                    _log(
+                        "scheduler: persisted wake replay stopped for "
+                        f"'{agent_name}': drain-extension budget terminalized "
+                        "the active rows"
+                    )
+                else:
+                    _log(
+                        f"scheduler: persisted wake replay deferred for "
+                        f"'{agent_name}' until the next turn-idle boundary"
+                    )
                 return
+            if drain_recheck:
+                self._outbox_drain_extensions.pop(agent_name, None)
         all_pending_wakes = self._registry.list_pending_schedule_wakes(
             agent_name, include_parked=True
         )
@@ -2270,8 +2674,10 @@ class AgentScheduler:
         """Periodically drain live-daemon outboxes without heartbeat opt-in.
 
         Turn-idle remains the primary path.  This once-per-minute scan is the
-        bounded fallback for a lost idle callback; the positive busy gate is
-        checked both here and again under the per-agent replay lock.
+        bounded fallback for a lost idle callback. Each replay rechecks the
+        transport's current pane state under the per-agent delivery lock; it
+        does not trust the watchdog-wide liveness verdict sampled by a receipt
+        waiter. Busy rechecks have their own attempt and wall-clock budget.
         """
         last_drain = self._last_pending_wake_liveness_drain_at
         if last_drain is None:
@@ -2291,18 +2697,14 @@ class AgentScheduler:
                 f"{type(exc).__name__}: {exc}"
             )
             return
+        for settled_agent in self._outbox_drain_extensions.keys() - agent_names:
+            self._outbox_drain_extensions.pop(settled_agent, None)
         for agent_name in sorted(agent_names):
-            if self._agent_busy_not_wedged(agent_name):
-                _log(
-                    f"scheduler: periodic outbox drain deferred for "
-                    f"'{agent_name}': transport remains busy-not-wedged"
-                )
-                continue
             _log(
                 f"scheduler: periodic liveness drain found pending wakes "
-                f"for '{agent_name}'"
+                f"for '{agent_name}'; scheduling fresh transport recheck"
             )
-            self.replay_pending_for_agent(agent_name)
+            self.replay_pending_for_agent(agent_name, drain_recheck=True)
 
     # Resurrection cap: at most this many attempts per RESURRECTION_WINDOW_SECONDS
     # per agent. Prevents thrashing on a persistently-broken session while still

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -1382,10 +1382,16 @@ class _QueuedTurn:
 
 @dataclass(frozen=True)
 class _QueuedPromptEvidence:
-    """One native queue occurrence plus optional cleanup ownership."""
+    """One native queue occurrence plus optional cleanup ownership.
+
+    ``retired`` is a tombstone, not permission to delete the occurrence. A
+    contentless dequeue must consume the same FIFO slot Claude recorded at
+    enqueue time even if a racing Stop has already retired that turn's meta.
+    """
 
     content: str | None
     turn: _QueuedTurn | None
+    retired: bool = False
 
 
 @dataclass(frozen=True)
@@ -1395,6 +1401,7 @@ class _DequeuedPromptEvidence:
     content: str | None
     accepted_at_dequeue: bool
     turn: _QueuedTurn | None
+    retired: bool = False
 
 
 @dataclass
@@ -5816,13 +5823,14 @@ class TmuxSession(TransportReplacementMixin):
             return
 
         entry = self._inflight_metas.popleft()
-        # A racing prompt can make this Stop retire the scheduler turn's local
-        # FIFO meta before Claude emits that prompt's dequeue row. Preserve
-        # only an exact turn whose acceptance receipt is still unresolved;
-        # every ordinary/accepted turn retires one content ticket here so a
-        # missing transcript row cannot grow the evidence deques forever.
+        # A racing prompt can make this Stop retire a turn's local FIFO meta
+        # before Claude emits that prompt's contentless dequeue row. Preserve
+        # every native occurrence until dequeue: unresolved receipt owners stay
+        # live, while ordinary/already-accepted owners become tombstones. Deleting
+        # either kind here shifts every later occurrence and can make an equal
+        # scheduler prompt consume the wrong ticket.
         if not self._turn_has_unresolved_acceptance(entry.turn):
-            self._discard_acceptance_evidence(entry.turn)
+            self._retire_acceptance_evidence(entry.turn)
         if (
             self._fresh_context_respawn_grace_until
             and self._fresh_context_respawn_epoch
@@ -8001,6 +8009,13 @@ class TmuxSession(TransportReplacementMixin):
             )
         ):
             return True
+        # An observed physical paste with an unresolved exact receipt is live
+        # state. It outranks a newer idle row: idle may clear stale accepted
+        # metas, but it cannot make an unreceipted paste safe to overlap or
+        # replay. Include occurrence tickets because a racing Stop can retire
+        # the turn from the ordinary inflight collections before dequeue.
+        if self._has_unresolved_pasted_acceptance():
+            return True
         live_status_fn = getattr(self._config, "live_status_fn", None)
         if live_status_fn is None:
             return True
@@ -8115,27 +8130,79 @@ class TmuxSession(TransportReplacementMixin):
             for receipt in (turn.scheduler_delivery, turn.submission_receipt)
         )
 
-    def _discard_acceptance_evidence(self, turn: _QueuedTurn) -> None:
-        """Retire this turn's queue occurrence without consuming an equal peer."""
+    def _has_unresolved_pasted_acceptance(self) -> bool:
+        """Whether any live pane occurrence owns an unresolved exact receipt."""
+        candidates = self._acceptance_candidates()
+        candidates.extend(
+            evidence.turn
+            for evidence in self._pane_queue_operations
+            if not evidence.retired and evidence.turn is not None
+        )
+        candidates.extend(
+            evidence.turn
+            for evidence in self._pane_dequeued_turns
+            if not evidence.retired and evidence.turn is not None
+        )
+        seen: set[int] = set()
+        for turn in candidates:
+            identity = id(turn)
+            if identity in seen:
+                continue
+            seen.add(identity)
+            if (
+                turn.pane_delivery_started
+                and self._turn_has_unresolved_acceptance(turn)
+            ):
+                return True
+        return False
+
+    def _retire_acceptance_evidence(self, turn: _QueuedTurn) -> None:
+        """Tombstone this occurrence without shifting the native FIFO ledger."""
         for index, evidence in enumerate(self._pane_queue_operations):
             if evidence.turn is turn:
-                del self._pane_queue_operations[index]
+                self._pane_queue_operations[index] = _QueuedPromptEvidence(
+                    evidence.content,
+                    evidence.turn,
+                    retired=True,
+                )
                 return
         for index, evidence in enumerate(self._pane_dequeued_turns):
             if evidence.turn is turn:
-                del self._pane_dequeued_turns[index]
+                self._pane_dequeued_turns[index] = _DequeuedPromptEvidence(
+                    evidence.content,
+                    evidence.accepted_at_dequeue,
+                    evidence.turn,
+                    retired=True,
+                )
                 return
         if turn.pane_queue_enqueued:
             # A matched ticket no longer present was already consumed. Never
-            # delete a later equal-content occurrence owned by another turn.
+            # tombstone a later equal-content occurrence owned by another turn.
             return
         for index, evidence in enumerate(self._pane_queue_operations):
-            if evidence.turn is None and evidence.content == turn.prompt:
-                del self._pane_queue_operations[index]
+            if (
+                not evidence.retired
+                and evidence.turn is None
+                and evidence.content == turn.prompt
+            ):
+                self._pane_queue_operations[index] = _QueuedPromptEvidence(
+                    evidence.content,
+                    evidence.turn,
+                    retired=True,
+                )
                 return
         for index, evidence in enumerate(self._pane_dequeued_turns):
-            if evidence.turn is None and evidence.content == turn.prompt:
-                del self._pane_dequeued_turns[index]
+            if (
+                not evidence.retired
+                and evidence.turn is None
+                and evidence.content == turn.prompt
+            ):
+                self._pane_dequeued_turns[index] = _DequeuedPromptEvidence(
+                    evidence.content,
+                    evidence.accepted_at_dequeue,
+                    evidence.turn,
+                    retired=True,
+                )
                 return
 
     def _mark_transport_accepted(self, turn: _QueuedTurn | None) -> bool:
@@ -8215,17 +8282,19 @@ class TmuxSession(TransportReplacementMixin):
             elif operation == "dequeue" and self._pane_queue_operations:
                 queued_evidence = self._pane_queue_operations.popleft()
                 content = queued_evidence.content
+                # Dequeue rows are contentless. Their identity is the exact FIFO
+                # occurrence captured at enqueue, never a fresh content match:
+                # rematching after Stop can jump to a later equal scheduler row.
                 turn = (
-                    self._match_acceptance_content(content)
-                    if content is not None
-                    else None
+                    None if queued_evidence.retired else queued_evidence.turn
                 )
                 accepted = self._mark_transport_accepted(turn)
                 self._pane_dequeued_turns.append(
                     _DequeuedPromptEvidence(
                         content,
                         accepted,
-                        turn or queued_evidence.turn,
+                        queued_evidence.turn,
+                        queued_evidence.retired,
                     )
                 )
             return
@@ -8259,10 +8328,8 @@ class TmuxSession(TransportReplacementMixin):
                 if matching_dequeue is not None:
                     evidence = self._pane_dequeued_turns[matching_dequeue]
                     del self._pane_dequeued_turns[matching_dequeue]
-                    if not evidence.accepted_at_dequeue:
-                        self._mark_transport_accepted(
-                            self._match_acceptance_content(prompt)
-                        )
+                    if not evidence.accepted_at_dequeue and not evidence.retired:
+                        self._mark_transport_accepted(evidence.turn)
                     return
                 self._mark_transport_accepted(
                     self._match_acceptance_content(prompt)
@@ -8300,7 +8367,10 @@ class TmuxSession(TransportReplacementMixin):
             if removed_index == 0:
                 self._inflight_pane_ext_anchor = None
                 self._head_started_at = time.time() if entries else None
-        self._discard_acceptance_evidence(turn)
+        # Receipt exhaustion retires ownership but cannot delete the physical
+        # occurrence: a late dequeue still has to consume this FIFO slot before
+        # any later equal-content turn can become eligible.
+        self._retire_acceptance_evidence(turn)
         turn.pane_delivery_recorded = False
 
     @staticmethod

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -1380,6 +1380,23 @@ class _QueuedTurn:
     submission_receipt: asyncio.Future[bool] | None = None
 
 
+@dataclass(frozen=True)
+class _QueuedPromptEvidence:
+    """One native queue occurrence plus optional cleanup ownership."""
+
+    content: str | None
+    turn: _QueuedTurn | None
+
+
+@dataclass(frozen=True)
+class _DequeuedPromptEvidence:
+    """Content proof carried from a native queue dequeue to its user row."""
+
+    content: str | None
+    accepted_at_dequeue: bool
+    turn: _QueuedTurn | None
+
+
 @dataclass
 class _WakeContextReloadGuard:
     """Short-lived fence joining one failed wake to its broker fallback."""
@@ -1807,10 +1824,12 @@ class TmuxSession(TransportReplacementMixin):
         self._scheduler_delivery_lock = asyncio.Lock()
         # Turns remain here after paste until their exact transcript receipt
         # resolves. Raw queue-operation dequeue rows carry no content, so the
-        # companion deque preserves enqueue ordering across all pane turns.
+        # companion deques preserve enqueue content ordering across all pane
+        # turns. Exact-content tickets survive a racing Stop that retires the local
+        # turn object before Claude emits its dequeue row (#1098).
         self._scheduler_pending_turns: list[_QueuedTurn] = []
-        self._pane_queue_operations: deque[_QueuedTurn | None] = deque()
-        self._pane_dequeued_turns: deque[_QueuedTurn | None] = deque()
+        self._pane_queue_operations: deque[_QueuedPromptEvidence] = deque()
+        self._pane_dequeued_turns: deque[_DequeuedPromptEvidence] = deque()
         # Dashboard terminal requests start immediately and may arrive out of
         # order. Serialize pane input and remember each client's acknowledged
         # sequence so cumulative retries never duplicate text or Enter.
@@ -5797,16 +5816,13 @@ class TmuxSession(TransportReplacementMixin):
             return
 
         entry = self._inflight_metas.popleft()
-        self._pane_queue_operations = deque(
-            queued
-            for queued in self._pane_queue_operations
-            if queued is not entry.turn
-        )
-        self._pane_dequeued_turns = deque(
-            dequeued
-            for dequeued in self._pane_dequeued_turns
-            if dequeued is not entry.turn
-        )
+        # A racing prompt can make this Stop retire the scheduler turn's local
+        # FIFO meta before Claude emits that prompt's dequeue row. Preserve
+        # only an exact turn whose acceptance receipt is still unresolved;
+        # every ordinary/accepted turn retires one content ticket here so a
+        # missing transcript row cannot grow the evidence deques forever.
+        if not self._turn_has_unresolved_acceptance(entry.turn):
+            self._discard_acceptance_evidence(entry.turn)
         if (
             self._fresh_context_respawn_grace_until
             and self._fresh_context_respawn_epoch
@@ -8018,6 +8034,19 @@ class TmuxSession(TransportReplacementMixin):
                 return True
         return False
 
+    def scheduler_drain_busy(self) -> bool:
+        """Fresh conservative pane verdict for the periodic wake drain.
+
+        Receipt waits deliberately use the wider watchdog liveness window.
+        The drain instead asks whether pane FIFO/tool state or a live status
+        newer than every paste still blocks a scheduler turn right now. This
+        lets an explicit idle boundary override monitor writes attached to a
+        stale inflight meta without weakening teardown protection (#1098).
+        """
+        if self.state != SessionState.CONNECTED:
+            return False
+        return self._scheduler_pane_busy()
+
     @staticmethod
     def _transcript_user_text(entry: dict) -> str | None:
         """Extract a plain user prompt from either known transcript shape."""
@@ -8053,11 +8082,17 @@ class TmuxSession(TransportReplacementMixin):
         self, prompt: str, *, for_enqueue: bool = False
     ) -> _QueuedTurn | None:
         """Match an exact transcript prompt to its oldest pending pane turn."""
+        return self._match_acceptance_content(prompt, for_enqueue=for_enqueue)
+
+    def _match_acceptance_content(
+        self, content: str, *, for_enqueue: bool = False
+    ) -> _QueuedTurn | None:
+        """Match exact content even when its original turn meta was retired."""
         for turn in self._acceptance_candidates():
             if (
                 not turn.pane_delivery_started
                 or turn.transport_accepted
-                or turn.prompt != prompt
+                or turn.prompt != content
                 or (
                     turn.submission_receipt is not None
                     and turn.submission_receipt.done()
@@ -8070,10 +8105,45 @@ class TmuxSession(TransportReplacementMixin):
             return turn
         return None
 
-    def _mark_transport_accepted(self, turn: _QueuedTurn | None) -> None:
-        """Resolve exact receipts only on observed pane acceptance."""
-        if turn is None or turn.transport_accepted:
+    @staticmethod
+    def _turn_has_unresolved_acceptance(turn: _QueuedTurn) -> bool:
+        """Whether a consumed-content ticket must survive a racing Stop."""
+        if turn.transport_accepted:
+            return False
+        return any(
+            receipt is not None and not receipt.done()
+            for receipt in (turn.scheduler_delivery, turn.submission_receipt)
+        )
+
+    def _discard_acceptance_evidence(self, turn: _QueuedTurn) -> None:
+        """Retire this turn's queue occurrence without consuming an equal peer."""
+        for index, evidence in enumerate(self._pane_queue_operations):
+            if evidence.turn is turn:
+                del self._pane_queue_operations[index]
+                return
+        for index, evidence in enumerate(self._pane_dequeued_turns):
+            if evidence.turn is turn:
+                del self._pane_dequeued_turns[index]
+                return
+        if turn.pane_queue_enqueued:
+            # A matched ticket no longer present was already consumed. Never
+            # delete a later equal-content occurrence owned by another turn.
             return
+        for index, evidence in enumerate(self._pane_queue_operations):
+            if evidence.turn is None and evidence.content == turn.prompt:
+                del self._pane_queue_operations[index]
+                return
+        for index, evidence in enumerate(self._pane_dequeued_turns):
+            if evidence.turn is None and evidence.content == turn.prompt:
+                del self._pane_dequeued_turns[index]
+                return
+
+    def _mark_transport_accepted(self, turn: _QueuedTurn | None) -> bool:
+        """Resolve exact receipts only on observed pane acceptance."""
+        if turn is None:
+            return False
+        if turn.transport_accepted:
+            return True
         # A fast wake can write user+assistant+Stop rows before paste_text's
         # final tmux subprocess coroutine resumes. Reserve its FIFO metadata
         # synchronously on the exact user/dequeue row so the same-read Stop
@@ -8104,6 +8174,7 @@ class TmuxSession(TransportReplacementMixin):
         for receipt in (turn.scheduler_delivery, turn.submission_receipt):
             if receipt is not None and not receipt.done():
                 receipt.set_result(True)
+        return True
 
     def _wake_context_reload_guard_for(
         self, turn: _QueuedTurn
@@ -8129,17 +8200,34 @@ class TmuxSession(TransportReplacementMixin):
             if operation == "enqueue":
                 content = entry.get("content")
                 turn = (
-                    self._match_acceptance_turn(content, for_enqueue=True)
+                    self._match_acceptance_content(content, for_enqueue=True)
                     if isinstance(content, str)
                     else None
                 )
                 if turn is not None:
                     turn.pane_queue_enqueued = True
-                self._pane_queue_operations.append(turn)
+                self._pane_queue_operations.append(
+                    _QueuedPromptEvidence(
+                        content if isinstance(content, str) else None,
+                        turn,
+                    )
+                )
             elif operation == "dequeue" and self._pane_queue_operations:
-                turn = self._pane_queue_operations.popleft()
-                self._pane_dequeued_turns.append(turn)
-                self._mark_transport_accepted(turn)
+                queued_evidence = self._pane_queue_operations.popleft()
+                content = queued_evidence.content
+                turn = (
+                    self._match_acceptance_content(content)
+                    if content is not None
+                    else None
+                )
+                accepted = self._mark_transport_accepted(turn)
+                self._pane_dequeued_turns.append(
+                    _DequeuedPromptEvidence(
+                        content,
+                        accepted,
+                        turn or queued_evidence.turn,
+                    )
+                )
             return
 
         if entry_type == "user":
@@ -8157,14 +8245,27 @@ class TmuxSession(TransportReplacementMixin):
                         "for original orientation wake; remaining broker "
                         "escalation will be fenced"
                     )
-                if self._pane_dequeued_turns:
-                    dequeued = self._pane_dequeued_turns[0]
-                    if dequeued is None or dequeued.prompt == prompt:
-                        self._pane_dequeued_turns.popleft()
-                        self._mark_transport_accepted(dequeued)
-                        return
+                matching_dequeue = next(
+                    (
+                        index
+                        for index, evidence in enumerate(
+                            self._pane_dequeued_turns
+                        )
+                        if evidence.content is None
+                        or evidence.content == prompt
+                    ),
+                    None,
+                )
+                if matching_dequeue is not None:
+                    evidence = self._pane_dequeued_turns[matching_dequeue]
+                    del self._pane_dequeued_turns[matching_dequeue]
+                    if not evidence.accepted_at_dequeue:
+                        self._mark_transport_accepted(
+                            self._match_acceptance_content(prompt)
+                        )
+                    return
                 self._mark_transport_accepted(
-                    self._match_acceptance_turn(prompt)
+                    self._match_acceptance_content(prompt)
                 )
 
     @staticmethod
@@ -8199,16 +8300,7 @@ class TmuxSession(TransportReplacementMixin):
             if removed_index == 0:
                 self._inflight_pane_ext_anchor = None
                 self._head_started_at = time.time() if entries else None
-        self._pane_queue_operations = deque(
-            queued
-            for queued in self._pane_queue_operations
-            if queued is not turn
-        )
-        self._pane_dequeued_turns = deque(
-            dequeued
-            for dequeued in self._pane_dequeued_turns
-            if dequeued is not turn
-        )
+        self._discard_acceptance_evidence(turn)
         turn.pane_delivery_recorded = False
 
     @staticmethod

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -8970,6 +8970,28 @@ class TestBuildStreamingWakeContextReasonGating:
 
             cancel.assert_awaited_once_with("exact wake")
 
+    def test_scheduler_drain_probe_is_distinct_from_wide_busy_signal(self):
+        """#1098: periodic drains re-read pane state through the transport."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            app = self._make_app(os.path.join(tmpdir, "test.db"))
+            session = SimpleNamespace(
+                stats={
+                    "inflight_active": True,
+                    "inflight_busy_not_wedged": True,
+                },
+                scheduler_drain_busy=lambda: False,
+            )
+            with patch.object(
+                app.state.broker,
+                "_get_streaming_session",
+                return_value=session,
+            ):
+                assert app.state.scheduler._delivery_busy_fn("dymok") is True
+                assert (
+                    app.state.scheduler._delivery_drain_busy_fn("dymok")
+                    is False
+                )
+
     @pytest.mark.asyncio
     async def test_scheduler_owner_alert_uses_owner_destination(self):
         """The owner-notify callback (dead-letter alerts: PARKED / stale

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1835,6 +1835,41 @@ class TestScheduler:
         assert repr(raw_value) in error_log
         assert "using 3600s" in error_log
 
+    @pytest.mark.parametrize(
+        ("env_name", "attribute", "expected"),
+        [
+            (
+                "PINKY_SCHEDULE_RECEIPT_EXTENSION_ATTEMPT_CAP",
+                "_receipt_extension_attempt_cap",
+                3,
+            ),
+            (
+                "PINKY_OUTBOX_DRAIN_EXTENSION_ATTEMPT_CAP",
+                "_outbox_drain_extension_attempt_cap",
+                30,
+            ),
+            (
+                "PINKY_OUTBOX_DRAIN_EXTENSION_MAX_AGE_SEC",
+                "_outbox_drain_extension_max_age_sec",
+                1_800.0,
+            ),
+            (
+                "PINKY_OUTBOX_DRAIN_PROBE_TIMEOUT_SEC",
+                "_outbox_drain_probe_timeout_sec",
+                5.0,
+            ),
+        ],
+    )
+    def test_invalid_new_bound_env_uses_safe_default(
+        self, registry, monkeypatch, capsys, env_name, attribute, expected
+    ):
+        monkeypatch.setenv(env_name, "0")
+
+        scheduler = AgentScheduler(registry)
+
+        assert getattr(scheduler, attribute) == expected
+        assert env_name in capsys.readouterr().err
+
     def test_init(self, registry):
         scheduler = AgentScheduler(registry)
         assert scheduler.running is False
@@ -2546,6 +2581,107 @@ class TestScheduler:
         assert registry.list_pending_schedule_wakes("oleg") == []
         assert "busy-not-wedged; extending" in capsys.readouterr().err
 
+    @pytest.mark.parametrize(
+        ("attempt_cap", "max_age", "expected_bound"),
+        [
+            (2, 10.0, "attempt cap"),
+            (100, 0.025, "wall-clock cap"),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_receipt_extension_bounds_abandon_and_alert_once(
+        self,
+        registry,
+        capsys,
+        attempt_cap,
+        max_age,
+        expected_bound,
+    ):
+        """#1098: positive busy evidence extends generously but never forever."""
+        registry.register("oleg")
+        schedule = registry.add_schedule(
+            "oleg", "* * * * *", name="bounded busy", prompt="run once"
+        )
+        fired_at = time.time()
+        registry.update_schedule_last_run(schedule.id, fired_at)
+        schedule.last_run = fired_at
+        receipt = asyncio.get_running_loop().create_future()
+        alerts: list[tuple[str, str]] = []
+
+        async def wake_cb(agent_name, session_id, prompt):
+            del agent_name, session_id, prompt
+            return receipt
+
+        async def owner_notify(agent_name, message):
+            alerts.append((agent_name, message))
+            return True
+
+        scheduler = AgentScheduler(
+            registry,
+            wake_callback=wake_cb,
+            delivery_busy_fn=lambda agent_name: True,
+            delivery_inflight_fn=lambda agent_name, prompt: True,
+            owner_notify_callback=owner_notify,
+            schedule_delivery_timeout=0.01,
+            receipt_extension_attempt_cap=attempt_cap,
+            receipt_extension_max_age_sec=max_age,
+        )
+
+        await scheduler._deliver_schedule(schedule)
+        await asyncio.gather(*list(scheduler._owner_alert_tasks))
+
+        ledger = registry.get_schedule_wake_by_fire(schedule.id, fired_at)
+        assert ledger is not None
+        assert ledger.ledger_state == "abandoned"
+        assert not receipt.cancelled()
+        assert len(alerts) == 1
+        assert alerts[0][0] == "oleg"
+        assert "RECEIPT EXTENSION EXPIRED" in alerts[0][1]
+        assert expected_bound in alerts[0][1]
+        assert "RECEIPT_EXTENSION_EXPIRED" in capsys.readouterr().err
+
+        await scheduler.stop()
+
+    @pytest.mark.asyncio
+    async def test_receipt_extension_expiry_alert_dedupes_exact_fire(
+        self, registry, capsys
+    ):
+        registry.register("oleg")
+        schedule = registry.add_schedule(
+            "oleg", "* * * * *", name="deduped alert", prompt="run once"
+        )
+        fired_at = time.time()
+        schedule.last_run = fired_at
+        registry.persist_schedule_wake(
+            schedule.id,
+            agent_name="oleg",
+            schedule_name=schedule.name,
+            prompt=schedule.prompt,
+            fired_at=fired_at,
+        )
+        alerts: list[str] = []
+
+        async def owner_notify(agent_name, message):
+            del agent_name
+            alerts.append(message)
+            return True
+
+        scheduler = AgentScheduler(
+            registry,
+            owner_notify_callback=owner_notify,
+        )
+        for _ in range(2):
+            scheduler._alert_receipt_extension_expired(
+                schedule,
+                age=1_800.0,
+                bound_reason="attempt cap",
+                wait_attempts=3,
+            )
+        await asyncio.gather(*list(scheduler._owner_alert_tasks))
+
+        assert len(alerts) == 1
+        assert "owner already alerted" in capsys.readouterr().err
+
     @pytest.mark.asyncio
     async def test_pasted_wake_extends_timeout_instead_of_cancelling(
         self, registry, capsys
@@ -2584,6 +2720,7 @@ class TestScheduler:
             delivery_busy_fn=lambda agent_name: False,  # liveness blip
             delivery_inflight_fn=inflight_fn,
             schedule_delivery_timeout=0.01,
+            receipt_extension_attempt_cap=10,
         )
         await scheduler._deliver_schedule(schedule)
 
@@ -2591,6 +2728,65 @@ class TestScheduler:
         assert registry.get_schedules("oleg")[0].last_delivered > 0
         assert registry.list_pending_schedule_wakes("oleg") == []
         assert "already pasted to the transport" in capsys.readouterr().err
+
+    @pytest.mark.asyncio
+    async def test_pasted_wake_expiry_abandons_without_replay_then_late_accepts(
+        self, registry
+    ):
+        """A physical paste has one authority after expiry, never a replay."""
+        registry.register("oleg")
+        schedule = registry.add_schedule(
+            "oleg", "* * * * *", name="single authority", prompt="run once"
+        )
+        fired_at = time.time()
+        registry.update_schedule_last_run(schedule.id, fired_at)
+        schedule.last_run = fired_at
+        receipt = asyncio.get_running_loop().create_future()
+        submissions = 0
+        alerts: list[str] = []
+
+        async def wake_cb(agent_name, session_id, prompt):
+            nonlocal submissions
+            del agent_name, session_id, prompt
+            submissions += 1
+            return receipt
+
+        async def owner_notify(agent_name, message):
+            del agent_name
+            alerts.append(message)
+            return True
+
+        scheduler = AgentScheduler(
+            registry,
+            wake_callback=wake_cb,
+            delivery_busy_fn=lambda agent_name: False,
+            delivery_inflight_fn=lambda agent_name, prompt: True,
+            owner_notify_callback=owner_notify,
+            schedule_delivery_timeout=0.01,
+            receipt_extension_attempt_cap=2,
+            receipt_extension_max_age_sec=1.0,
+        )
+
+        await scheduler._deliver_schedule(schedule)
+        await asyncio.gather(*list(scheduler._owner_alert_tasks))
+        ledger = registry.get_schedule_wake_by_fire(schedule.id, fired_at)
+        assert ledger is not None
+        assert ledger.ledger_state == "abandoned"
+        assert not receipt.cancelled()
+        assert len(scheduler._detached_receipt_tasks) == 1
+        assert submissions == 1
+        assert len(alerts) == 1
+
+        await scheduler._replay_pending_locked("oleg")
+        assert submissions == 1
+
+        receipt.set_result(True)
+        await asyncio.gather(*list(scheduler._detached_receipt_tasks))
+        assert registry.get_schedule_wake_by_fire(
+            schedule.id, fired_at
+        ).ledger_state == "receipted-ran-once"
+        await scheduler._replay_pending_locked("oleg")
+        assert submissions == 1
 
     @pytest.mark.asyncio
     async def test_queued_wake_extends_until_consumed_without_replay(
@@ -2628,6 +2824,7 @@ class TestScheduler:
             delivery_inflight_fn=lambda agent_name, prompt: False,
             delivery_queued_fn=lambda agent_name, prompt: queued,
             schedule_delivery_timeout=0.01,
+            receipt_extension_attempt_cap=10,
             receipt_extension_max_age_sec=1.0,
         )
 
@@ -2696,6 +2893,7 @@ class TestScheduler:
         assert ledger is not None
         assert ledger.ledger_state == "abandoned"
         assert registry.list_pending_schedule_wakes("oleg") == []
+        assert scheduler._detached_receipt_tasks == set()
         logs = capsys.readouterr().err
         assert logs.index("cancelled-queued") < logs.index("RECEIPT_ABANDONED")
 
@@ -3565,6 +3763,242 @@ class TestScheduler:
         assert len(ledger) == 3
         assert all(row.ledger_state == "receipted-ran-once" for row in ledger)
         assert registry.get("worker").heartbeat_interval == 0
+
+    @pytest.mark.asyncio
+    async def test_periodic_drain_rechecks_transport_instead_of_wide_watchdog(
+        self, registry, monkeypatch
+    ):
+        """#1098: a live idle recheck can drain despite stale wide evidence."""
+        registry.register("worker")
+        schedule = registry.add_schedule(
+            "worker", "0 * * * *", name="recheck", prompt="deliver now"
+        )
+        base = 1_800_000_000.0
+        clock = [base]
+        monkeypatch.setattr(
+            "pinky_daemon.scheduler.time.time", lambda: clock[0]
+        )
+        registry.persist_schedule_wake(
+            schedule.id,
+            agent_name="worker",
+            schedule_name=schedule.name,
+            prompt=schedule.prompt,
+            fired_at=base,
+        )
+        delivered: list[str] = []
+        drain_checks: list[str] = []
+
+        async def confirmed(agent_name, session_id, prompt):
+            del agent_name, session_id
+            delivered.append(prompt)
+            return True
+
+        def drain_busy(agent_name):
+            drain_checks.append(agent_name)
+            return False
+
+        scheduler = AgentScheduler(
+            registry,
+            wake_callback=confirmed,
+            delivery_busy_fn=lambda agent_name: True,
+            delivery_drain_busy_fn=drain_busy,
+            pending_wake_max_age_sec=1_000,
+        )
+        scheduler._check_pending_wake_liveness(base)
+        clock[0] = base + 60
+        scheduler._check_pending_wake_liveness(clock[0])
+        await scheduler._pending_replay_tasks["worker"]
+
+        assert drain_checks == ["worker"]
+        assert delivered == ["deliver now"]
+        assert registry.list_pending_schedule_wakes("worker") == []
+
+    @pytest.mark.parametrize(
+        ("attempt_cap", "max_age", "cycles", "expected_bound"),
+        [
+            (2, 1_000.0, 2, "attempt cap"),
+            (99, 30.0, 1, "wall-clock cap"),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_periodic_drain_deferral_bounds_alert_once(
+        self,
+        registry,
+        monkeypatch,
+        capsys,
+        attempt_cap,
+        max_age,
+        cycles,
+        expected_bound,
+    ):
+        """A genuinely busy transport is protected, but starvation is loud."""
+        registry.register("worker")
+        schedule = registry.add_schedule(
+            "worker", "0 * * * *", name="busy drain", prompt="owed work"
+        )
+        base = 1_800_000_000.0
+        clock = [base]
+        monkeypatch.setattr(
+            "pinky_daemon.scheduler.time.time", lambda: clock[0]
+        )
+        pending, _ = registry.persist_schedule_wake(
+            schedule.id,
+            agent_name="worker",
+            schedule_name=schedule.name,
+            prompt=schedule.prompt,
+            fired_at=base,
+        )
+        alerts: list[tuple[str, str]] = []
+        deliveries: list[str] = []
+
+        async def unexpected(agent_name, session_id, prompt):
+            del agent_name, session_id
+            deliveries.append(prompt)
+            return True
+
+        async def owner_notify(agent_name, message):
+            alerts.append((agent_name, message))
+            return True
+
+        scheduler = AgentScheduler(
+            registry,
+            wake_callback=unexpected,
+            delivery_busy_fn=lambda agent_name: True,
+            delivery_drain_busy_fn=lambda agent_name: True,
+            owner_notify_callback=owner_notify,
+            pending_wake_max_age_sec=1_000,
+            outbox_drain_extension_attempt_cap=attempt_cap,
+            outbox_drain_extension_max_age_sec=max_age,
+        )
+        scheduler._check_pending_wake_liveness(base)
+        for cycle in range(1, cycles + 1):
+            clock[0] = base + (cycle * 60)
+            scheduler._check_pending_wake_liveness(clock[0])
+            await scheduler._pending_replay_tasks["worker"]
+        await asyncio.gather(*list(scheduler._owner_alert_tasks))
+
+        assert deliveries == []
+        ledger = registry.get_schedule_wake_by_fire(
+            schedule.id, pending.fired_at
+        )
+        assert ledger is not None
+        assert ledger.attempts == 0
+        assert ledger.ledger_state == "abandoned"
+        assert ledger.last_error.startswith("OUTBOX_DRAIN_ABANDONED:")
+        assert len(alerts) == 1
+        assert alerts[0][0] == "worker"
+        assert "OUTBOX DRAIN EXTENSION EXPIRED" in alerts[0][1]
+        assert expected_bound in alerts[0][1]
+
+        clock[0] += 60
+        scheduler._check_pending_wake_liveness(clock[0])
+        await asyncio.sleep(0)
+        assert "worker" not in scheduler._pending_replay_tasks
+        assert "worker" not in scheduler._outbox_drain_extensions
+        assert len(alerts) == 1
+        logs = capsys.readouterr().err
+        assert "OUTBOX_DRAIN_EXTENSION_EXPIRED" in logs
+        assert "terminalized=1/1" in logs
+
+    @pytest.mark.asyncio
+    async def test_drain_probe_timeout_counts_busy_and_releases_replay_lock(
+        self, registry, capsys
+    ):
+        """A hung transport probe cannot wedge the per-agent scheduler lane."""
+        registry.register("worker")
+        schedule = registry.add_schedule(
+            "worker", "0 * * * *", name="probe timeout", prompt="owed work"
+        )
+        registry.persist_schedule_wake(
+            schedule.id,
+            agent_name="worker",
+            schedule_name=schedule.name,
+            prompt=schedule.prompt,
+            fired_at=time.time(),
+        )
+        probe_started = threading.Event()
+        release_probe = threading.Event()
+        deliveries: list[str] = []
+
+        def hung_probe(agent_name):
+            del agent_name
+            probe_started.set()
+            release_probe.wait(timeout=0.2)
+            return False
+
+        async def unexpected(agent_name, session_id, prompt):
+            del agent_name, session_id
+            deliveries.append(prompt)
+            return True
+
+        scheduler = AgentScheduler(
+            registry,
+            wake_callback=unexpected,
+            delivery_drain_busy_fn=hung_probe,
+            outbox_drain_probe_timeout_sec=0.01,
+            outbox_drain_extension_attempt_cap=2,
+        )
+        scheduler.replay_pending_for_agent("worker", drain_recheck=True)
+        task = scheduler._pending_replay_tasks["worker"]
+        await asyncio.wait_for(asyncio.shield(task), timeout=0.1)
+        release_probe.set()
+
+        assert probe_started.is_set()
+        assert deliveries == []
+        assert len(registry.list_pending_schedule_wakes("worker")) == 1
+        assert scheduler._outbox_drain_extensions["worker"].attempts == 1
+        assert "counting as busy and releasing" in capsys.readouterr().err
+
+    @pytest.mark.asyncio
+    async def test_drain_wall_cap_uses_oldest_active_not_abandoned_history(
+        self, registry, monkeypatch
+    ):
+        """A terminal old row cannot age a newer active wake into abandonment."""
+        registry.register("worker")
+        schedule = registry.add_schedule(
+            "worker", "0 * * * *", name="active age", prompt="owed work"
+        )
+        now = 1_800_000_000.0
+        old, _ = registry.persist_schedule_wake(
+            schedule.id,
+            agent_name="worker",
+            schedule_name=schedule.name,
+            prompt=schedule.prompt,
+            fired_at=now - 3_600,
+        )
+        assert registry.abandon_pending_schedule_wake(old.id, abandoned_at=now - 3_500)
+        active, _ = registry.persist_schedule_wake(
+            schedule.id,
+            agent_name="worker",
+            schedule_name=schedule.name,
+            prompt=schedule.prompt,
+            fired_at=now - 10,
+        )
+        monkeypatch.setattr("pinky_daemon.scheduler.time.time", lambda: now)
+        alerts: list[str] = []
+
+        async def owner_notify(agent_name, message):
+            del agent_name
+            alerts.append(message)
+            return True
+
+        scheduler = AgentScheduler(
+            registry,
+            delivery_drain_busy_fn=lambda agent_name: True,
+            owner_notify_callback=owner_notify,
+            outbox_drain_extension_attempt_cap=2,
+            outbox_drain_extension_max_age_sec=30.0,
+        )
+        scheduler.replay_pending_for_agent("worker", drain_recheck=True)
+        await scheduler._pending_replay_tasks["worker"]
+
+        ledger = registry.get_schedule_wake_by_fire(schedule.id, active.fired_at)
+        assert ledger is not None
+        assert ledger.ledger_state == "pending"
+        assert alerts == []
+        assert scheduler._outbox_drain_extensions["worker"].oldest_fired_at == (
+            active.fired_at
+        )
 
     @pytest.mark.asyncio
     async def test_idle_trigger_during_replay_guarantees_follow_up_pass(

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -28,6 +28,8 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from pinky_daemon import tmux_session
+from pinky_daemon.agent_registry import AgentRegistry
+from pinky_daemon.scheduler import AgentScheduler, ScheduleWakeReceipt
 from pinky_daemon.streaming_session import StreamingSessionConfig
 from pinky_daemon.tmux_session import (
     TmuxCommandResult,
@@ -3828,6 +3830,199 @@ async def test_scheduler_prompt_receipt_waits_for_idle_pane() -> None:
         "transport acceptance must not wait for turn completion"
     )
     await ss.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_scheduler_prompt_dequeue_matches_content_after_racing_turn_pop() -> None:
+    """#1098: an interleaved Stop must not erase queued acceptance evidence.
+
+    A near-simultaneous prompt can make the next Stop pop the scheduler wake's
+    local FIFO meta before Claude emits the queued prompt's dequeue row.  The
+    dequeue proves that exact content was consumed even though the turn object
+    was already retired under another turn boundary.
+    """
+    ss, _ = _make_session(state=SessionState.CONNECTED)
+    receipt = asyncio.get_running_loop().create_future()
+    persisted: list[str] = []
+    turn = _QueuedTurn(
+        prompt="scheduled under a racing turn",
+        scheduler_delivery=receipt,
+        scheduler_accept=lambda: persisted.append("accepted") or True,
+        scheduler_serialized=True,
+    )
+    turn.pane_delivery_started = True
+    ss._scheduler_pending_turns.append(turn)
+    ss._finish_turn_delivery(turn)
+
+    ss._on_transcript_entry(
+        {
+            "type": "queue-operation",
+            "operation": "enqueue",
+            "content": turn.prompt,
+        }
+    )
+    assert not receipt.done()
+
+    await ss._handle_turn_complete(
+        TurnResponse(text="racing turn completed", stop_reason="end_turn")
+    )
+    assert not receipt.done()
+    assert not ss._inflight_metas
+
+    ss._on_transcript_entry(
+        {"type": "queue-operation", "operation": "dequeue"}
+    )
+
+    assert receipt.done(), "content dequeue must settle the racing wake receipt"
+    assert receipt.result() is True
+    assert persisted == ["accepted"]
+    ss._on_transcript_entry(
+        {
+            "type": "user",
+            "message": {"role": "user", "content": turn.prompt},
+        }
+    )
+    assert not ss._pane_queue_operations
+    assert not ss._pane_dequeued_turns
+
+
+@pytest.mark.asyncio
+async def test_scheduler_acceptance_equal_prompts_consumes_one_fifo_ticket() -> None:
+    """Equal text is occurrence-counted; one dequeue cannot accept two wakes."""
+    ss, _ = _make_session(state=SessionState.CONNECTED)
+    prompt = "same scheduled work"
+    receipts = [
+        asyncio.get_running_loop().create_future(),
+        asyncio.get_running_loop().create_future(),
+    ]
+    accepted: list[int] = []
+    turns = [
+        _QueuedTurn(
+            prompt=prompt,
+            scheduler_delivery=receipt,
+            scheduler_accept=lambda index=index: accepted.append(index) or True,
+            scheduler_serialized=True,
+        )
+        for index, receipt in enumerate(receipts)
+    ]
+    for turn in turns:
+        turn.pane_delivery_started = True
+        ss._scheduler_pending_turns.append(turn)
+        ss._finish_turn_delivery(turn)
+        ss._on_transcript_entry(
+            {
+                "type": "queue-operation",
+                "operation": "enqueue",
+                "content": prompt,
+            }
+        )
+
+    ss._on_transcript_entry({"type": "queue-operation", "operation": "dequeue"})
+    assert receipts[0].result() is True
+    assert not receipts[1].done()
+    assert accepted == [0]
+
+    ss._on_transcript_entry(
+        {"type": "user", "message": {"role": "user", "content": prompt}}
+    )
+    assert not receipts[1].done(), "the first user row must not accept occurrence 2"
+
+    await ss._handle_turn_complete(
+        TurnResponse(text="first duplicate done", stop_reason="end_turn")
+    )
+    assert not receipts[1].done()
+
+    ss._on_transcript_entry({"type": "queue-operation", "operation": "dequeue"})
+    assert receipts[1].result() is True
+    assert accepted == [0, 1]
+
+
+@pytest.mark.asyncio
+async def test_racing_content_acceptance_persists_row_and_prevents_replay(
+    tmp_path,
+) -> None:
+    """#1098 specimen 3: consumed racing wake becomes durably un-replayable."""
+    registry = AgentRegistry(db_path=str(tmp_path / "agents.db"))
+    try:
+        registry.register("dymok")
+        schedule = registry.add_schedule(
+            "dymok", "0 * * * *", name="weekly probe", prompt="probe once"
+        )
+        fired_at = _time.time()
+        pending, _ = registry.persist_schedule_wake(
+            schedule.id,
+            agent_name="dymok",
+            schedule_name=schedule.name,
+            prompt=schedule.prompt,
+            fired_at=fired_at,
+        )
+        durable_receipt = ScheduleWakeReceipt(registry, schedule.id, fired_at)
+        local_receipt = asyncio.get_running_loop().create_future()
+        turn = _QueuedTurn(
+            prompt=schedule.prompt,
+            scheduler_delivery=local_receipt,
+            scheduler_accept=durable_receipt.accept,
+            scheduler_serialized=True,
+        )
+        turn.pane_delivery_started = True
+        ss, _ = _make_session(agent_name="dymok", state=SessionState.CONNECTED)
+        ss._scheduler_pending_turns.append(turn)
+        ss._finish_turn_delivery(turn)
+        ss._on_transcript_entry(
+            {
+                "type": "queue-operation",
+                "operation": "enqueue",
+                "content": schedule.prompt,
+            }
+        )
+        await ss._handle_turn_complete(
+            TurnResponse(text="racing turn", stop_reason="end_turn")
+        )
+        ss._on_transcript_entry(
+            {"type": "queue-operation", "operation": "dequeue"}
+        )
+
+        assert local_receipt.result() is True
+        ledger = registry.get_schedule_wake_by_fire(schedule.id, fired_at)
+        assert ledger is not None
+        assert ledger.id == pending.id
+        assert ledger.ledger_state == "receipted-ran-once"
+
+        replays: list[str] = []
+
+        async def replay(agent_name, session_id, prompt):
+            del agent_name, session_id
+            replays.append(prompt)
+            return True
+
+        scheduler = AgentScheduler(registry, wake_callback=replay)
+        await scheduler._replay_pending_locked("dymok")
+        assert replays == []
+    finally:
+        registry.close()
+
+
+@pytest.mark.asyncio
+async def test_turn_stop_discards_ordinary_queue_content_evidence() -> None:
+    """Content tickets stay bounded when no unresolved receipt owns them."""
+    ss, _ = _make_session(state=SessionState.CONNECTED)
+    turn = _QueuedTurn(prompt="ordinary prompt")
+    turn.pane_delivery_started = True
+    ss._finish_turn_delivery(turn)
+    ss._on_transcript_entry(
+        {
+            "type": "queue-operation",
+            "operation": "enqueue",
+            "content": turn.prompt,
+        }
+    )
+
+    await ss._handle_turn_complete(
+        TurnResponse(text="done", stop_reason="end_turn")
+    )
+
+    assert not ss._pane_queue_operations
+    assert not ss._pane_dequeued_turns
 
 
 @pytest.mark.asyncio
@@ -11569,3 +11764,56 @@ def test_stats_inflight_inactive_when_idle(tmp_path) -> None:
     assert stats["inflight_active"] is False
     assert stats["inflight_busy_not_wedged"] is False
     assert stats["inflight_liveness_reason"] == "no_inflight_turn"
+
+
+def test_stats_monitor_writes_need_an_inflight_turn_to_report_busy(tmp_path) -> None:
+    """#1098 controlled hypothesis: monitors alone cannot pin idle as busy."""
+    ss, _ = _make_session()
+    main = tmp_path / "session.jsonl"
+    main.write_text("{}")
+    _age_file(main, 1000)
+    workflows = tmp_path / "session" / "workflows"
+    workflows.mkdir(parents=True)
+    (workflows / "monitor.jsonl").write_text("{}")
+    _point_transcript(ss, main)
+
+    idle_stats = ss.stats
+    assert idle_stats["inflight_active"] is False
+    assert idle_stats["inflight_busy_not_wedged"] is False
+    assert idle_stats["inflight_liveness_reason"] == "no_inflight_turn"
+
+    _seed_inflight(ss)
+    phantom_stats = ss.stats
+    assert phantom_stats["inflight_active"] is True
+    assert phantom_stats["inflight_busy_not_wedged"] is True
+    assert phantom_stats["inflight_liveness_reason"] == (
+        "background_transcript_recent"
+    )
+
+
+def test_scheduler_drain_busy_trusts_newer_explicit_idle_over_monitor(
+    tmp_path,
+) -> None:
+    """#1098: drain state is revalidated separately from watchdog liveness."""
+    ss, _ = _make_session(state=SessionState.CONNECTED)
+    _seed_inflight(ss)
+    main = tmp_path / "session.jsonl"
+    main.write_text("{}")
+    _age_file(main, 1000)
+    workflows = tmp_path / "session" / "workflows"
+    workflows.mkdir(parents=True)
+    (workflows / "monitor.jsonl").write_text("{}")
+    _point_transcript(ss, main)
+    ss._config.live_status_fn = lambda: {
+        "status": "idle",
+        "last_updated": _time.time() + 1,
+    }
+
+    assert ss.stats["inflight_busy_not_wedged"] is True
+    assert ss.scheduler_drain_busy() is False
+
+    ss._config.live_status_fn = lambda: {
+        "status": "working",
+        "last_updated": _time.time() + 2,
+    }
+    assert ss.scheduler_drain_busy() is True

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -3938,6 +3938,61 @@ async def test_scheduler_acceptance_equal_prompts_consumes_one_fifo_ticket() -> 
 
 
 @pytest.mark.asyncio
+async def test_stop_tombstone_absorbs_dequeue_before_equal_scheduler_turn() -> None:
+    """A racing Stop cannot shift an old native occurrence onto a later wake."""
+    ss, _ = _make_session(state=SessionState.CONNECTED)
+    prompt = "same ordinary and scheduled work"
+    ordinary = _QueuedTurn(prompt=prompt)
+    ordinary.pane_delivery_started = True
+    ss._finish_turn_delivery(ordinary)
+    ss._on_transcript_entry(
+        {
+            "type": "queue-operation",
+            "operation": "enqueue",
+            "content": prompt,
+        }
+    )
+
+    # The Stop races ahead of the ordinary prompt's contentless dequeue.
+    await ss._handle_turn_complete(
+        TurnResponse(text="prior turn stopped", stop_reason="end_turn")
+    )
+
+    receipt = asyncio.get_running_loop().create_future()
+    accepted: list[str] = []
+    scheduled = _QueuedTurn(
+        prompt=prompt,
+        scheduler_delivery=receipt,
+        scheduler_accept=lambda: accepted.append("scheduled") or True,
+        scheduler_serialized=True,
+    )
+    scheduled.pane_delivery_started = True
+    ss._scheduler_pending_turns.append(scheduled)
+    ss._finish_turn_delivery(scheduled)
+    ss._on_transcript_entry(
+        {
+            "type": "queue-operation",
+            "operation": "enqueue",
+            "content": prompt,
+        }
+    )
+
+    # This dequeue belongs to the retired ordinary occurrence. It must consume
+    # that tombstone, never rematch the equal-content scheduler occurrence.
+    ss._on_transcript_entry({"type": "queue-operation", "operation": "dequeue"})
+    assert not receipt.done()
+    assert accepted == []
+
+    ss._on_transcript_entry(
+        {"type": "user", "message": {"role": "user", "content": prompt}}
+    )
+    assert not receipt.done()
+    ss._on_transcript_entry({"type": "queue-operation", "operation": "dequeue"})
+    assert receipt.result() is True
+    assert accepted == ["scheduled"]
+
+
+@pytest.mark.asyncio
 async def test_racing_content_acceptance_persists_row_and_prevents_replay(
     tmp_path,
 ) -> None:
@@ -4003,8 +4058,8 @@ async def test_racing_content_acceptance_persists_row_and_prevents_replay(
 
 
 @pytest.mark.asyncio
-async def test_turn_stop_discards_ordinary_queue_content_evidence() -> None:
-    """Content tickets stay bounded when no unresolved receipt owns them."""
+async def test_turn_stop_tombstones_ordinary_queue_content_evidence() -> None:
+    """Stop retires an occurrence in place until dequeue and user consume it."""
     ss, _ = _make_session(state=SessionState.CONNECTED)
     turn = _QueuedTurn(prompt="ordinary prompt")
     turn.pane_delivery_started = True
@@ -4021,8 +4076,86 @@ async def test_turn_stop_discards_ordinary_queue_content_evidence() -> None:
         TurnResponse(text="done", stop_reason="end_turn")
     )
 
+    assert len(ss._pane_queue_operations) == 1
+    assert ss._pane_queue_operations[0].retired is True
+    ss._on_transcript_entry({"type": "queue-operation", "operation": "dequeue"})
     assert not ss._pane_queue_operations
+    assert len(ss._pane_dequeued_turns) == 1
+    assert ss._pane_dequeued_turns[0].retired is True
+    ss._on_transcript_entry(
+        {
+            "type": "user",
+            "message": {"role": "user", "content": turn.prompt},
+        }
+    )
     assert not ss._pane_dequeued_turns
+
+
+@pytest.mark.asyncio
+async def test_recorded_dequeue_persists_before_disconnect_and_prevents_replay(
+    tmp_path,
+) -> None:
+    """A #943 replay ticket is durable at dequeue, before its user row lands."""
+    registry = AgentRegistry(db_path=str(tmp_path / "agents.db"))
+    try:
+        registry.register("dymok")
+        schedule = registry.add_schedule(
+            "dymok", "0 * * * *", name="disconnect probe", prompt="run once"
+        )
+        fired_at = _time.time()
+        registry.persist_schedule_wake(
+            schedule.id,
+            agent_name="dymok",
+            schedule_name=schedule.name,
+            prompt=schedule.prompt,
+            fired_at=fired_at,
+        )
+        receipt = asyncio.get_running_loop().create_future()
+        turn = _QueuedTurn(
+            prompt=schedule.prompt,
+            scheduler_delivery=receipt,
+            scheduler_accept=ScheduleWakeReceipt(
+                registry, schedule.id, fired_at
+            ).accept,
+            scheduler_serialized=True,
+        )
+        turn.pane_delivery_started = True
+        ss, _ = _make_session(agent_name="dymok", state=SessionState.CONNECTED)
+
+        # A #943 replay is delivered by the ordinary worker and is no longer in
+        # _scheduler_pending_turns. A racing Stop can therefore retire its sole
+        # inflight meta before the contentless dequeue appears.
+        ss._finish_turn_delivery(turn)
+        ss._on_transcript_entry(
+            {
+                "type": "queue-operation",
+                "operation": "enqueue",
+                "content": schedule.prompt,
+            }
+        )
+        await ss._handle_turn_complete(
+            TurnResponse(text="racing turn", stop_reason="end_turn")
+        )
+        assert not ss._acceptance_candidates()
+
+        ss._on_transcript_entry(
+            {"type": "queue-operation", "operation": "dequeue"}
+        )
+        assert receipt.result() is True
+        await ss.disconnect()  # before the matching transcript user row
+
+        replays: list[str] = []
+
+        async def replay(agent_name, session_id, prompt):
+            del agent_name, session_id
+            replays.append(prompt)
+            return True
+
+        scheduler = AgentScheduler(registry, wake_callback=replay)
+        await scheduler._replay_pending_locked("dymok")
+        assert replays == []
+    finally:
+        registry.close()
 
 
 @pytest.mark.asyncio
@@ -11816,4 +11949,45 @@ def test_scheduler_drain_busy_trusts_newer_explicit_idle_over_monitor(
         "status": "working",
         "last_updated": _time.time() + 2,
     }
+    assert ss.scheduler_drain_busy() is True
+
+
+@pytest.mark.asyncio
+async def test_scheduler_drain_busy_pasted_unaccepted_outranks_newer_idle(
+    tmp_path,
+) -> None:
+    """An unresolved physical paste is busy even after a newer idle row."""
+    ss, _ = _make_session(state=SessionState.CONNECTED)
+    entry = _seed_inflight(
+        ss,
+        prompt="unresolved scheduled paste",
+        transport_accepted=False,
+    )
+    turn = entry.turn
+    turn.scheduler_serialized = True
+    turn.scheduler_delivery = asyncio.get_running_loop().create_future()
+    turn.pane_delivery_started = True
+    ss._scheduler_pending_turns.append(turn)
+    ss._on_transcript_entry(
+        {
+            "type": "queue-operation",
+            "operation": "enqueue",
+            "content": turn.prompt,
+        }
+    )
+
+    main = tmp_path / "session.jsonl"
+    main.write_text("{}")
+    _age_file(main, 1000)
+    workflows = tmp_path / "session" / "workflows"
+    workflows.mkdir(parents=True)
+    (workflows / "monitor.jsonl").write_text("{}")
+    _point_transcript(ss, main)
+    ss._config.live_status_fn = lambda: {
+        "status": "idle",
+        "last_updated": entry.dispatched_at + 1,
+    }
+
+    assert turn.transport_accepted is False
+    assert ss.scheduler_wake_inflight(turn.prompt) is True
     assert ss.scheduler_drain_busy() is True


### PR DESCRIPTION
Fixes #1098.

## What changed

- Preserve native tmux queue acceptance as an occurrence ledger. Every enqueue keeps its FIFO slot; a racing Stop tombstones its own ordinary/already-accepted occurrence instead of deleting it, and a contentless dequeue consumes only the recorded occurrence rather than rematching a later equal prompt.
- Make the correctly matched native dequeue the durable scheduler-acceptance boundary. The exact fire is persisted synchronously before the process-local receipt resolves; the later transcript user row is confirmation only, so disconnect cleanup cannot erase the sole positive evidence and reopen replay.
- Give unresolved physical paste evidence unconditional precedence over newer idle status. Pending scheduler/submission receipts—including turns retained only by queue tickets—remain drain-busy while transport_accepted=False; newer idle may override only stale accepted meta/monitor state.
- Bound receipt confirmation by both 3 wait windows and 1 hour from the original fire (configurable). Expiry has deterministic terminal handling:
  - a positively accepted wake wins;
  - a recallable/unknown unconfirmed wake is cancelled and explicitly abandoned;
  - only a physically pasted wake retains one late-receipt observer, and it is never replayed.
- Give the periodic outbox drain a fresh, narrow tmux pane/FIFO/live-status probe under the per-agent replay lock. The probe has its own 5-second timeout; timeout/error counts as busy and releases the lock.
- Bound busy drain deferrals by both 30 checks and 30 minutes from the oldest active fire (configurable). Expiry moves every active row to explicit `OUTBOX_DRAIN_ABANDONED` state and emits one owner alert; it does not use parked state.
- Emit one loud owner alert through the existing owner-notify path when either receipt or drain extension budget expires.

## Review findings resolved in r2

Murzik reproduced the Stop-interleave shape as a real operational window, not a synthetic unit-test artifact: **2,598 enqueue → Stop → dequeue windows across 288 local agent transcripts**, often with intervening enqueues. r2 preserves every occurrence/tombstone through its dequeue, so that arithmetic cannot shift onto a later scheduler fire.

The drain false-idle regression explicitly seeds the discriminating half that r1's monitor test did not: `pane_delivery_started=True`, receipt unresolved, `transport_accepted=False`, with live idle newer than dispatch. The unresolved physical paste now remains busy.

The disconnect regression models a #943 ordinary-worker replay whose inflight meta is retired before its contentless dequeue. The recorded occurrence durably accepts its exact fire at dequeue; disconnect before the matching user row leaves no replayable row.

## Controlled findings

The monitor hypothesis remains resolved:

- monitor transcript writes alone do **not** make an actually empty tmux session report busy;
- a stale inflight meta plus recurring monitor writes **can** keep the wide watchdog signal busy between turns;
- a newer explicit idle status safely clears only the drain-time predicate for stale accepted state;
- an unresolved physical paste always remains drain-busy, regardless of that newer idle row.

That accounts for the observed idle-window starvation without weakening the wide #1083 receipt protection or the unaccepted-paste half.

## Safety invariants

- #943 requeued-head discovery and recall remain intact.
- #983's queued/pasted cancellation layering remains intact.
- #1083's no-premature-abandon behavior remains intact: delayed positive receipts inside the configured budget are accepted without replay.
- Bounds are terminal only after their generous attempt/wall budgets.
- A correctly matched dequeue durably records `accepted_at` before its local Future resolves; a later disconnect/replay pass makes zero second deliveries.
- Equal-content wakes are occurrence-counted and consumed one at a time.
- Stop retires occurrence ownership in place; only dequeue consumes a ticket, and definitive session reset purges residual tombstones.

## Validation

- Exact r1 base-revert proof at `0333df6`: all four r2 occurrence/drain/disconnect witnesses fail; all pass on r2.
- `tests/test_scheduler.py`: 199 passed.
- `tests/test_tmux_session.py`: 419 passed.
- Codex/tmux/session/transcript/transport parity: 152 passed, 1 expected skip.
- Focused scheduler drain/receipt API wiring: 2 passed.
- r1 changed API wiring plus post-OAuth tail: 28 passed; unchanged by r2.
- Full `tests/test_api.py` on r1 advanced through 399 tests, then reproduced the known macOS TestClient stall at `TestGoogleOAuthStateValidation::test_callback_rejects_missing_state`; the exact standalone test also remained at entry until a 15-second external timeout.
- `ruff check .`, `compileall`, and `git diff --check`: passed.

Review head: `2b883abdcce41e458569c4bb878d5d4ef58d7d2b`
Tree: `b3bb1e47234f6ac6d03fa4b0c62693aee705ee15`

🤖 Opened by Kuzya
