### PR TITLE
chore: bump claude-agent-sdk to >=0.2.139 (#1095)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     "fastapi>=0.135",
     "uvicorn>=0.44",
     "websockets>=15.0",
-    "claude-agent-sdk>=0.2.138,<0.3",
+    "claude-agent-sdk>=0.2.139,<0.3",
     "Pillow>=10.0",
     # Federation crypto (sealed_box_v1): X25519, Ed25519, HKDF, XChaCha20-Poly1305.
     "cryptography>=41.0",

--- a/tests/test_packaging_dependencies.py
+++ b/tests/test_packaging_dependencies.py
@@ -29,4 +29,4 @@ def test_buzz_dependencies_are_in_base_install() -> None:
 
 
 def test_claude_agent_sdk_excludes_allowed_tools_injection_versions() -> None:
-    assert "claude-agent-sdk>=0.2.138,<0.3" in _project()["dependencies"]
+    assert "claude-agent-sdk>=0.2.139,<0.3" in _project()["dependencies"]


### PR DESCRIPTION
## Summary

Addresses #1095. One-line floor bump in `pyproject.toml` (`>=0.2.138` → `>=0.2.139`).

0.2.139 updates the bundled CLI from 2.1.232 → 2.1.233. Relevant fixes for this project:

- **MCP v2 reconnect fix**: connections no longer endlessly reopen the subscriptions/listen stream against servers that terminate long-held streams on a fixed timeout — directly relevant to our shared SSE/streamable MCP server setups.
- **Linux idle-CPU fix**: idle sessions with sandboxing enabled could pin one CPU core at 100%.
- **Skill alias fix**: bundled skill aliases reported "Unknown command" in `-p` mode when shadowed by user/project skills.
- **Argument-substitution fix**: skill/command argument values are no longer re-expanded as template markers.

No SDK-side API changes between 0.2.138 and 0.2.139 (message-type unions unchanged).

## Test plan

- [ ] CI green (same shape as #1085)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YPVWAnEsFfH9yURxg27SDs)_