### PR TITLE
fix: replace removed ConversationResetMessage with SystemMessage subtype check

### DIFF
--- a/src/pinky_daemon/sdk_runner.py
+++ b/src/pinky_daemon/sdk_runner.py
@@ -125,7 +125,6 @@ class SDKRunner:
         from claude_agent_sdk import (
             AssistantMessage,
             ClaudeAgentOptions,
-            ConversationResetMessage,
             RateLimitEvent,
             ResultMessage,
             StreamEvent,
@@ -233,8 +232,35 @@ class SDKRunner:
                     self._session_id_callback(result_session_id)
 
             async for message in query(prompt=prompt, options=options):
-                if isinstance(message, SystemMessage):
-                    # Extract session ID from init
+                if (
+                    isinstance(message, SystemMessage)
+                    and getattr(message, "subtype", "") == "conversation_reset"
+                ):
+                    # /clear invalidates the outgoing ID immediately. Clear
+                    # both local and durable state synchronously, before the
+                    # iterator can advance to a fresh-session frame.
+                    # ConversationResetMessage was removed from the SDK;
+                    # the CLI now sends this as a SystemMessage with
+                    # subtype="conversation_reset".
+                    reset_data = getattr(message, "data", {}) or {}
+                    old_sid = reset_data.get("session_id", "")
+                    if old_sid:
+                        invalidated_session_ids.add(old_sid)
+                    if result_session_id:
+                        invalidated_session_ids.add(result_session_id)
+                    result_session_id = ""
+                    if self._session_id_callback:
+                        self._session_id_callback("")
+
+                    _log(
+                        "sdk-runner: WARNING SDK conversation reset; transcript "
+                        "was discarded "
+                        f"new_conversation_id={reset_data.get('new_conversation_id', '')!r} "
+                        f"session_id={old_sid!r}"
+                    )
+
+                elif isinstance(message, SystemMessage):
+                    # Extract session ID from init (non-reset SystemMessages)
                     capture_session_id(getattr(message, "session_id", ""))
                     _log(f"sdk-runner: session={result_session_id}")
 
@@ -274,25 +300,6 @@ class SDKRunner:
                 elif isinstance(message, AssistantMessage):
                     # Result content already won the existing dedupe rule.
                     capture_session_id(message.session_id)
-
-                elif isinstance(message, ConversationResetMessage):
-                    # /clear invalidates the outgoing ID immediately. Clear
-                    # both local and durable state synchronously, before the
-                    # iterator can advance to a fresh-session frame.
-                    if message.session_id:
-                        invalidated_session_ids.add(message.session_id)
-                    if result_session_id:
-                        invalidated_session_ids.add(result_session_id)
-                    result_session_id = ""
-                    if self._session_id_callback:
-                        self._session_id_callback("")
-
-                    _log(
-                        "sdk-runner: WARNING SDK conversation reset; transcript "
-                        "was discarded "
-                        f"new_conversation_id={message.new_conversation_id!r} "
-                        f"session_id={message.session_id!r}"
-                    )
 
                 elif isinstance(message, RateLimitEvent):
                     _log(


### PR DESCRIPTION
## Problem

`ConversationResetMessage` was removed from `claude_agent_sdk` (>= 0.2.131). The daemon's `sdk_runner.py` imports it at query time, causing an `ImportError` that breaks all agent sessions and dream runs.

## Fix

- Remove `ConversationResetMessage` from the SDK import
- The CLI now sends conversation resets as `SystemMessage` with `subtype="conversation_reset"`
- Add the conversation_reset check **before** the generic `SystemMessage` handler in the elif chain (specific subtype first → generic fallback)
- Extract `session_id` and `new_conversation_id` from `message.data` dict instead of direct attributes (matching the new SDK wire format)

## Testing

- `from pinky_daemon.sdk_runner import SDKRunner` — imports clean
- No other file in the codebase references `ConversationResetMessage`
- elif chain ordering verified: conversation_reset → generic SystemMessage → ResultMessage → AssistantMessage → ...

🤖 Opened by Satoshi