### PR TITLE
feat(#619): StoreCatalog + boot-time store-identity validation (#889 hardening)

### DIFF
--- a/src/pinky_daemon/activity_store.py
+++ b/src/pinky_daemon/activity_store.py
@@ -13,13 +13,21 @@ import threading
 import time
 from pathlib import Path
 
+from pinky_daemon.store_catalog import StoreCatalog
+
 
 class ActivityStore:
     """SQLite-backed activity log."""
 
-    def __init__(self, db_path: str = "data/activity.db") -> None:
+    def __init__(
+        self,
+        db_path: str = "data/activity.db",
+        *,
+        catalog: StoreCatalog | None = None,
+    ) -> None:
         Path(db_path).parent.mkdir(parents=True, exist_ok=True)
         self._db_path = db_path
+        self._catalog = catalog
         self._thread_local = threading.local()
         self._init_tables()
 
@@ -29,8 +37,17 @@ class ActivityStore:
         connection = getattr(self._thread_local, "connection", None)
         if connection is None:
             connection = sqlite3.connect(self._db_path)
-            connection.execute("PRAGMA journal_mode=WAL")
+            journal_mode = str(
+                connection.execute("PRAGMA journal_mode=WAL").fetchone()[0]
+            ).lower()
             connection.execute("PRAGMA busy_timeout=30000")
+            if self._catalog is not None:
+                self._catalog.register(
+                    "activity",
+                    self._db_path,
+                    journal_mode=journal_mode,
+                    owner=type(self).__name__,
+                )
             self._thread_local.connection = connection
         return connection
 

--- a/src/pinky_daemon/agent_comms.py
+++ b/src/pinky_daemon/agent_comms.py
@@ -23,6 +23,8 @@ import time
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from pinky_daemon.store_catalog import StoreCatalog
+
 
 @dataclass
 class AgentMessage:
@@ -66,8 +68,14 @@ class AgentComms:
     and broadcast to all sessions.
     """
 
-    def __init__(self, db_path: str = "data/agent_comms.db") -> None:
+    def __init__(
+        self,
+        db_path: str = "data/agent_comms.db",
+        *,
+        catalog: StoreCatalog | None = None,
+    ) -> None:
         self._db_path = db_path
+        self._catalog = catalog
         # Anchor file transfers next to the DB so the destination does not
         # depend on the caller's cwd at send time.
         self._transfers_root = Path(db_path).resolve().parent / "transfers"
@@ -83,8 +91,17 @@ class AgentComms:
         if connection is None:
             connection = sqlite3.connect(self._db_path)
             connection.row_factory = sqlite3.Row
-            connection.execute("PRAGMA journal_mode=WAL")
+            journal_mode = str(
+                connection.execute("PRAGMA journal_mode=WAL").fetchone()[0]
+            ).lower()
             connection.execute("PRAGMA busy_timeout=30000")
+            if self._catalog is not None:
+                self._catalog.register(
+                    "agent_comms",
+                    self._db_path,
+                    journal_mode=journal_mode,
+                    owner="AgentComms",
+                )
             self._thread_local.connection = connection
         return connection
 

--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -39,6 +39,7 @@ from uuid import UUID
 
 from pinky_daemon.cron_utils import _field_matches
 from pinky_daemon.effort import is_ultracode
+from pinky_daemon.store_catalog import StoreCatalog
 
 # Agent names appear in filesystem paths (data/agents/{name}/, hook scripts
 # under .claude/, settings.json, .mcp.json) and database queries. Restrict
@@ -1387,6 +1388,7 @@ class AgentRegistry:
         db_path: str = "data/agents.db",
         *,
         buzz_device_key_path: str | None = None,
+        catalog: StoreCatalog | None = None,
     ) -> None:
         Path(db_path).parent.mkdir(parents=True, exist_ok=True)
         # Absolute path retained so callers (e.g. _write_mcp_json) can hand
@@ -1406,8 +1408,15 @@ class AgentRegistry:
         # (si_addr confirmed inside conversations_agents.db-shm). Rollback mode
         # has no -shm, so the daemon never maps it. Runs before _init_tables and
         # before any MCP/session resume spawns stdio children. Agents DB only.
-        _configure_agents_db_connection(self._db)
+        journal_mode = _configure_agents_db_connection(self._db)
         self._db.execute("PRAGMA foreign_keys=ON")
+        if catalog is not None:
+            catalog.register(
+                "agents",
+                self._db_path,
+                journal_mode=journal_mode,
+                owner=type(self).__name__,
+            )
         # Guard read-modify-write sequences (e.g. peer_fleet_acl mutation)
         # from concurrent admin-API requests. SQLite connection is shared
         # across threads (check_same_thread=False) and Python's default

--- a/src/pinky_daemon/analytics_store.py
+++ b/src/pinky_daemon/analytics_store.py
@@ -6,6 +6,8 @@ import sqlite3
 from contextlib import contextmanager
 from datetime import UTC, datetime, timedelta
 
+from pinky_daemon.store_catalog import StoreCatalog
+
 # Providers to include in analytics dashboards.
 # Only Anthropic/Claude usage — excludes Codex CLI (OpenAI) and other non-Anthropic providers.
 _ANTHROPIC_PROVIDERS = {"firstParty", "default", "anthropic", "bedrock", "vertex"}
@@ -60,8 +62,14 @@ def _prev_range_bounds(range_name: str) -> tuple[str, str]:
 
 
 class AnalyticsStore:
-    def __init__(self, db_path: str) -> None:
+    def __init__(
+        self,
+        db_path: str,
+        *,
+        catalog: StoreCatalog | None = None,
+    ) -> None:
         self.db_path = db_path
+        self._catalog = catalog
         self._pricing_cache: dict[tuple[str, str], list[dict]] | None = None
         self._init_db()
 
@@ -251,6 +259,16 @@ class AnalyticsStore:
                 "CREATE INDEX IF NOT EXISTS idx_atc_status_started "
                 "ON analytics_tool_calls(status, started_at)"
             )
+            if self._catalog is not None:
+                journal_mode = str(
+                    conn.execute("PRAGMA journal_mode").fetchone()[0]
+                ).lower()
+                self._catalog.register(
+                    "analytics",
+                    self.db_path,
+                    journal_mode=journal_mode,
+                    owner=type(self).__name__,
+                )
 
     # Pricing rows added AFTER the original seed batch. _seed_default_pricing
     # only fires on an empty table, so these reach already-seeded production

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -193,6 +193,7 @@ from pinky_daemon.shared_mcp import (
 )
 from pinky_daemon.skill_loader import discover_all_skills, register_discovered_skills
 from pinky_daemon.skill_store import SkillStore
+from pinky_daemon.store_catalog import StoreCatalog, StoreCatalogError
 from pinky_daemon.streaming_session import _1M_MODELS, is_1m_model
 from pinky_daemon.task_store import TaskStore
 
@@ -1692,6 +1693,10 @@ def create_api(
 ) -> FastAPI:
     """Create the FastAPI application."""
 
+    db_path = os.path.realpath(db_path)
+    _data_dir = Path(db_path).parent
+    store_catalog = StoreCatalog(expected_root=_data_dir)
+
     app = FastAPI(
         title="Pinky",
         description="Stateful Claude Code session API",
@@ -1755,14 +1760,24 @@ def create_api(
             response.headers["Strict-Transport-Security"] = "max-age=31536000; includeSubDomains"
         return response
 
-    session_store = SessionStore(db_path=db_path.replace(".db", "_sessions.db"))
-    session_event_store = SessionEventStore(db_path=db_path.replace(".db", "_sessions.db"))
-    store = ConversationStore(db_path=db_path)
-    analytics = AnalyticsStore(db_path=db_path.replace(".db", "_analytics.db"))
-    agents = AgentRegistry(db_path=db_path.replace(".db", "_agents.db"))
+    session_store = SessionStore(
+        db_path=db_path.replace(".db", "_sessions.db"), catalog=store_catalog
+    )
+    session_event_store = SessionEventStore(
+        db_path=db_path.replace(".db", "_sessions.db"), catalog=store_catalog
+    )
+    store = ConversationStore(db_path=db_path, catalog=store_catalog)
+    analytics = AnalyticsStore(
+        db_path=db_path.replace(".db", "_analytics.db"), catalog=store_catalog
+    )
+    agents = AgentRegistry(
+        db_path=db_path.replace(".db", "_agents.db"), catalog=store_catalog
+    )
     _run_grandfather_approved_users_migration(store, agents)
     _refresh_1m_models(agents)
-    audit = AuditStore(db_path=db_path.replace(".db", "_audit.db"))
+    audit = AuditStore(
+        db_path=db_path.replace(".db", "_audit.db"), catalog=store_catalog
+    )
     hooks = HookManager(audit_store=audit)
 
     # In-memory live status for agents (updated by POST /agents/{name}/status).
@@ -2551,9 +2566,12 @@ def create_api(
         )
         return result
 
-    activity = ActivityStore(db_path=db_path.replace(".db", "_activity.db"))
+    activity = ActivityStore(
+        db_path=db_path.replace(".db", "_activity.db"), catalog=store_catalog
+    )
     message_context_store = MessageContextStore(
-        db_path=db_path.replace(".db", "_message_context.db")
+        db_path=db_path.replace(".db", "_message_context.db"),
+        catalog=store_catalog,
     )
     app.state.activity = activity
     app.state.message_context_store = message_context_store
@@ -2711,6 +2729,7 @@ def create_api(
         owner_provider=lambda: agents.get_owner_profile(),
         setting_provider=lambda key: agents.get_setting(key, ""),
         signing_key_provider=agents.get_signing_key,
+        catalog=store_catalog,
     )
     app.state.dream_runner = dream_runner
     app.state.agent_history_resolver = _resolve_agent_history
@@ -4126,7 +4145,9 @@ def create_api(
 
         return closed
 
-    skills = SkillStore(db_path=db_path.replace(".db", "_skills.db"))
+    skills = SkillStore(
+        db_path=db_path.replace(".db", "_skills.db"), catalog=store_catalog
+    )
     _seed_core_skills(skills)
 
     # Discover SKILL.md files from filesystem and register them
@@ -4149,13 +4170,27 @@ def create_api(
             plugins.enable(pname)
             plugins.register_in_skill_store(skills, pname)
 
-    outreach_config = OutreachConfigStore(db_path=db_path.replace(".db", "_outreach.db"))
-    tasks = TaskStore(db_path=db_path.replace(".db", "_tasks.db"))
-    research = ResearchStore(db_path=db_path.replace(".db", "_research.db"))
-    presentations = PresentationStore(db_path=db_path.replace(".db", "_presentations.db"))
-    app_store = AppStore(db_path=db_path.replace(".db", "_apps.db"))
-    trigger_store = TriggerStore(db_path=db_path.replace(".db", "_triggers.db"))
-    mesh_store = MeshStore(db_path=db_path.replace(".db", "_mesh.db"))
+    outreach_config = OutreachConfigStore(
+        db_path=db_path.replace(".db", "_outreach.db"), catalog=store_catalog
+    )
+    tasks = TaskStore(
+        db_path=db_path.replace(".db", "_tasks.db"), catalog=store_catalog
+    )
+    research = ResearchStore(
+        db_path=db_path.replace(".db", "_research.db"), catalog=store_catalog
+    )
+    presentations = PresentationStore(
+        db_path=db_path.replace(".db", "_presentations.db"), catalog=store_catalog
+    )
+    app_store = AppStore(
+        db_path=db_path.replace(".db", "_apps.db"), catalog=store_catalog
+    )
+    trigger_store = TriggerStore(
+        db_path=db_path.replace(".db", "_triggers.db"), catalog=store_catalog
+    )
+    mesh_store = MeshStore(
+        db_path=db_path.replace(".db", "_mesh.db"), catalog=store_catalog
+    )
 
     # Ferry host-callback (cross-fleet inbound). Constructed here so it shares
     # the live registry + broker + mesh_store; stashed on app.state for the
@@ -4173,8 +4208,7 @@ def create_api(
     )
 
     # Knowledge Base — project-level, all agents share
-    _data_dir = Path(db_path).parent
-    kb = KBStore(data_dir=_data_dir)
+    kb = KBStore(data_dir=_data_dir, catalog=store_catalog)
 
     # KB Librarian runner — curates wiki pages from raw sources
     librarian_runner = LibrarianRunner(
@@ -4452,7 +4486,9 @@ def create_api(
         from pinky_daemon.voice_routes import set_dependencies as _voice_set_deps
         from pinky_daemon.voice_store import VoiceStore
 
-        _voice_store = VoiceStore(db_path="data/voice_calls.db")
+        _voice_store = VoiceStore(
+            db_path=str(_data_dir / "voice_calls.db"), catalog=store_catalog
+        )
         _voice_base_url = (
             agents.get_setting("PINKY_BASE_URL")
             or os.environ.get("PINKY_BASE_URL", "")
@@ -13318,7 +13354,9 @@ npm run build</pre>
 
     from pinky_daemon.user_profile_store import UserProfileStore
 
-    user_profiles = UserProfileStore()
+    user_profiles = UserProfileStore(
+        db_path=str(_data_dir / "user_profiles.db"), catalog=store_catalog
+    )
 
     from pinky_daemon.routes.user_profiles import router as _user_profiles_router
     from pinky_daemon.routes.user_profiles import set_dependencies as _user_profiles_set_deps
@@ -13867,5 +13905,14 @@ npm run build</pre>
     # registered above.  Its final-body ``send`` return is the deterministic
     # response-delivery barrier used by context_restart.
     app.add_middleware(_ResponseSentHandoffMiddleware)
+
+    # Every authoritative store has opened by this point. Validate once before
+    # returning the application so an incoherent physical layout cannot serve.
+    app.state.store_catalog = store_catalog
+    try:
+        store_catalog.validate()
+    except StoreCatalogError as exc:
+        _log(f"ERROR startup: store catalog validation failed: {exc}")
+        raise
 
     return app

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -1801,7 +1801,7 @@ def create_api(
         hook_manager=hooks,
     )
     _comms_db = db_path.replace(".db", "_agent_comms.db")
-    comms = AgentComms(db_path=_comms_db)
+    comms = AgentComms(db_path=_comms_db, catalog=store_catalog)
 
     # Auth-failure tracker — counts SDK auth errors across all streaming
     # sessions on this host and decides when to alert the operator. The
@@ -4161,6 +4161,7 @@ def create_api(
         db_path=db_path.replace(".db", "_plugins.db"),
         api_url="http://localhost:8888",
         working_dir=default_working_dir,
+        catalog=store_catalog,
     )
     plugins.discover_all(project_root=str(_pinky_root))
     # Re-enable previously enabled plugins
@@ -4214,6 +4215,7 @@ def create_api(
     librarian_runner = LibrarianRunner(
         kb_store=kb,
         db_path=db_path.replace(".db", "_librarian_state.db"),
+        catalog=store_catalog,
     )
     app.state.librarian_runner = librarian_runner
 

--- a/src/pinky_daemon/app_store.py
+++ b/src/pinky_daemon/app_store.py
@@ -18,6 +18,8 @@ import time
 from dataclasses import dataclass
 from pathlib import Path
 
+from pinky_daemon.store_catalog import StoreCatalog
+
 
 def _log(msg: str) -> None:
     print(msg, file=sys.stderr, flush=True)
@@ -74,12 +76,26 @@ class App:
 class AppStore:
     """SQLite-backed app storage."""
 
-    def __init__(self, db_path: str = "data/apps.db") -> None:
+    def __init__(
+        self,
+        db_path: str = "data/apps.db",
+        *,
+        catalog: StoreCatalog | None = None,
+    ) -> None:
         Path(db_path).parent.mkdir(parents=True, exist_ok=True)
         self._db_path = db_path
         self._db = sqlite3.connect(db_path, check_same_thread=False)
-        self._db.execute("PRAGMA journal_mode=WAL")
+        journal_mode = str(
+            self._db.execute("PRAGMA journal_mode=WAL").fetchone()[0]
+        ).lower()
         self._db.execute("PRAGMA foreign_keys=ON")
+        if catalog is not None:
+            catalog.register(
+                "apps",
+                db_path,
+                journal_mode=journal_mode,
+                owner=type(self).__name__,
+            )
         self._init_tables()
 
     def _init_tables(self) -> None:

--- a/src/pinky_daemon/conversation_store.py
+++ b/src/pinky_daemon/conversation_store.py
@@ -19,6 +19,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 from pinky_daemon.db_journal import configure_rollback_journal
+from pinky_daemon.store_catalog import StoreCatalog
 
 
 def _fts5_phrase(query: str) -> str:
@@ -83,8 +84,14 @@ class ConversationStore:
     Uses FTS5 for fast keyword search across all conversations.
     """
 
-    def __init__(self, db_path: str = "data/conversations.db") -> None:
+    def __init__(
+        self,
+        db_path: str = "data/conversations.db",
+        *,
+        catalog: StoreCatalog | None = None,
+    ) -> None:
         self._db_path = db_path
+        self._catalog = catalog
         Path(db_path).parent.mkdir(parents=True, exist_ok=True)
         self._thread_local = threading.local()
         self._init_schema()
@@ -100,7 +107,14 @@ class ConversationStore:
             # sqlite client opening this live DB and closing cannot unlink the
             # -wal/-shm out from under the daemon's connection. Sets busy_timeout
             # internally. See pinky_daemon.db_journal.
-            configure_rollback_journal(connection, busy_ms=30000)
+            journal_mode = configure_rollback_journal(connection, busy_ms=30000)
+            if self._catalog is not None:
+                self._catalog.register(
+                    "conversations",
+                    self._db_path,
+                    journal_mode=journal_mode,
+                    owner=type(self).__name__,
+                )
             self._thread_local.connection = connection
         return connection
 

--- a/src/pinky_daemon/dream_runner.py
+++ b/src/pinky_daemon/dream_runner.py
@@ -39,6 +39,7 @@ from pinky_daemon.auth import (
 )
 from pinky_daemon.dream_prompt import DREAM_SYSTEM_PROMPT
 from pinky_daemon.sdk_runner import SDKRunner, SDKRunnerConfig
+from pinky_daemon.store_catalog import StoreCatalog
 from pinky_daemon.tmux_dream_runner import TmuxDreamConfig, TmuxDreamRunner
 
 
@@ -138,10 +139,12 @@ class DreamRunner:
         setting_provider: Callable[[str], str] | None = None,
         signing_key_provider: Callable[[str], str | None] | None = None,
         owner_notify_callback: Callable[[str, str], object] | None = None,
+        catalog: StoreCatalog | None = None,
     ) -> None:
         Path(db_path).parent.mkdir(parents=True, exist_ok=True)
         self._db_path = db_path
         self._thread_local = threading.local()
+        self._catalog = catalog
         self._history_provider = history_provider
         # Optional () -> owner-profile dict, used to derive high-value entity
         # names for KG proactive-surfacing materiality. May be None.
@@ -167,8 +170,17 @@ class DreamRunner:
         connection = getattr(self._thread_local, "connection", None)
         if connection is None:
             connection = sqlite3.connect(self._db_path)
-            connection.execute("PRAGMA journal_mode=WAL")
+            journal_mode = str(
+                connection.execute("PRAGMA journal_mode=WAL").fetchone()[0]
+            ).lower()
             connection.execute("PRAGMA busy_timeout=30000")
+            if self._catalog is not None:
+                self._catalog.register(
+                    "dream_state",
+                    self._db_path,
+                    journal_mode=journal_mode,
+                    owner=type(self).__name__,
+                )
             self._thread_local.connection = connection
         return connection
 

--- a/src/pinky_daemon/hooks.py
+++ b/src/pinky_daemon/hooks.py
@@ -23,6 +23,8 @@ from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
 
+from pinky_daemon.store_catalog import StoreCatalog
+
 
 def _log(msg: str) -> None:
     print(msg, file=sys.stderr, flush=True)
@@ -121,9 +123,15 @@ class AuditEntry:
 class AuditStore:
     """SQLite-backed audit trail for hook events."""
 
-    def __init__(self, db_path: str = "data/audit.db") -> None:
+    def __init__(
+        self,
+        db_path: str = "data/audit.db",
+        *,
+        catalog: StoreCatalog | None = None,
+    ) -> None:
         Path(db_path).parent.mkdir(parents=True, exist_ok=True)
         self._db_path = db_path
+        self._catalog = catalog
         self._thread_local = threading.local()
         self._init_tables()
 
@@ -133,8 +141,17 @@ class AuditStore:
         connection = getattr(self._thread_local, "connection", None)
         if connection is None:
             connection = sqlite3.connect(self._db_path)
-            connection.execute("PRAGMA journal_mode=WAL")
+            journal_mode = str(
+                connection.execute("PRAGMA journal_mode=WAL").fetchone()[0]
+            ).lower()
             connection.execute("PRAGMA busy_timeout=30000")
+            if self._catalog is not None:
+                self._catalog.register(
+                    "audit",
+                    self._db_path,
+                    journal_mode=journal_mode,
+                    owner=type(self).__name__,
+                )
             self._thread_local.connection = connection
         return connection
 

--- a/src/pinky_daemon/kb_store.py
+++ b/src/pinky_daemon/kb_store.py
@@ -34,6 +34,8 @@ from pathlib import Path
 
 import yaml
 
+from pinky_daemon.store_catalog import StoreCatalog
+
 
 def _log(msg: str) -> None:
     print(msg, file=sys.stderr, flush=True)
@@ -161,8 +163,14 @@ class KBStats:
 class KBStore:
     """Knowledge Base store — flat files + SQLite FTS5 index."""
 
-    def __init__(self, data_dir: str | Path) -> None:
+    def __init__(
+        self,
+        data_dir: str | Path,
+        *,
+        catalog: StoreCatalog | None = None,
+    ) -> None:
         self.data_dir = Path(data_dir)
+        self._catalog = catalog
         self.kb_dir = self.data_dir / "kb"
         self.raw_dir = self.kb_dir / "raw"
         self.wiki_dir = self.kb_dir / "wiki"
@@ -177,9 +185,18 @@ class KBStore:
 
     def _conn(self) -> sqlite3.Connection:
         conn = sqlite3.connect(str(self.db_path))
-        conn.execute("PRAGMA journal_mode=WAL")
+        journal_mode = str(
+            conn.execute("PRAGMA journal_mode=WAL").fetchone()[0]
+        ).lower()
         conn.execute("PRAGMA foreign_keys=ON")
         conn.row_factory = sqlite3.Row
+        if self._catalog is not None:
+            self._catalog.register(
+                "kb",
+                self.db_path,
+                journal_mode=journal_mode,
+                owner=type(self).__name__,
+            )
         return conn
 
     def _init_db(self) -> None:

--- a/src/pinky_daemon/librarian_runner.py
+++ b/src/pinky_daemon/librarian_runner.py
@@ -22,6 +22,7 @@ from pathlib import Path
 from pinky_daemon.kb_store import _FRONTMATTER_RE, KBStore, _content_hash
 from pinky_daemon.librarian_prompt import LIBRARIAN_SYSTEM_PROMPT
 from pinky_daemon.sdk_runner import SDKRunner, SDKRunnerConfig
+from pinky_daemon.store_catalog import StoreCatalog
 
 
 def _log(msg: str) -> None:
@@ -58,16 +59,27 @@ class LibrarianRunner:
         self,
         kb_store: KBStore,
         db_path: str | Path = "data/librarian_state.db",
+        *,
+        catalog: StoreCatalog | None = None,
     ) -> None:
         self._kb = kb_store
         self._db_path = Path(db_path)
+        self._catalog = catalog
         self._db_path.parent.mkdir(parents=True, exist_ok=True)
         self._init_db()
 
     def _conn(self) -> sqlite3.Connection:
         conn = sqlite3.connect(str(self._db_path))
-        conn.execute("PRAGMA journal_mode=WAL")
+        journal_mode = str(conn.execute("PRAGMA journal_mode=WAL").fetchone()[0]).lower()
         conn.row_factory = sqlite3.Row
+        if self._catalog is not None:
+            self._catalog.register(
+                "librarian_state",
+                self._db_path,
+                journal_mode=journal_mode,
+                owner="LibrarianRunner",
+                criticality="derived",
+            )
         return conn
 
     def _init_db(self) -> None:

--- a/src/pinky_daemon/mesh_store.py
+++ b/src/pinky_daemon/mesh_store.py
@@ -29,6 +29,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Literal
 
+from pinky_daemon.store_catalog import StoreCatalog
+
 # -- Records -------------------------------------------------------------------
 
 
@@ -99,11 +101,25 @@ class MeshStore:
     own concurrency story.
     """
 
-    def __init__(self, db_path: str = "data/mesh.db") -> None:
+    def __init__(
+        self,
+        db_path: str = "data/mesh.db",
+        *,
+        catalog: StoreCatalog | None = None,
+    ) -> None:
         Path(db_path).parent.mkdir(parents=True, exist_ok=True)
         self._db = sqlite3.connect(db_path, check_same_thread=False)
-        self._db.execute("PRAGMA journal_mode=WAL")
+        journal_mode = str(
+            self._db.execute("PRAGMA journal_mode=WAL").fetchone()[0]
+        ).lower()
         self._db.execute("PRAGMA foreign_keys=ON")
+        if catalog is not None:
+            catalog.register(
+                "mesh",
+                db_path,
+                journal_mode=journal_mode,
+                owner=type(self).__name__,
+            )
         self._lock = threading.RLock()
         self._init_tables()
 

--- a/src/pinky_daemon/message_context_store.py
+++ b/src/pinky_daemon/message_context_store.py
@@ -9,6 +9,8 @@ import time
 from pathlib import Path
 from typing import Any
 
+from pinky_daemon.store_catalog import StoreCatalog
+
 DEFAULT_RETENTION_DAYS = 30
 DEFAULT_MAX_PER_AGENT = 1000
 
@@ -22,6 +24,7 @@ class MessageContextStore:
         *,
         retention_days: int = DEFAULT_RETENTION_DAYS,
         max_per_agent: int = DEFAULT_MAX_PER_AGENT,
+        catalog: StoreCatalog | None = None,
     ) -> None:
         self.db_path = db_path
         self.retention_days = max(1, retention_days)
@@ -30,8 +33,17 @@ class MessageContextStore:
         Path(db_path).parent.mkdir(parents=True, exist_ok=True)
         self._db = sqlite3.connect(db_path, check_same_thread=False)
         self._db.row_factory = sqlite3.Row
-        self._db.execute("PRAGMA journal_mode=WAL")
+        journal_mode = str(
+            self._db.execute("PRAGMA journal_mode=WAL").fetchone()[0]
+        ).lower()
         self._db.execute("PRAGMA busy_timeout=5000")
+        if catalog is not None:
+            catalog.register(
+                "message_context",
+                db_path,
+                journal_mode=journal_mode,
+                owner=type(self).__name__,
+            )
         self._create_schema()
         self._ensure_columns()
         self._ensure_identity_key()

--- a/src/pinky_daemon/outreach_config.py
+++ b/src/pinky_daemon/outreach_config.py
@@ -18,6 +18,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 from pinky_daemon.db_journal import configure_rollback_journal
+from pinky_daemon.store_catalog import StoreCatalog
 
 
 def _log(msg: str) -> None:
@@ -52,13 +53,25 @@ class PlatformConfig:
 class OutreachConfigStore:
     """SQLite-backed outreach platform configuration."""
 
-    def __init__(self, db_path: str = "data/outreach_config.db") -> None:
+    def __init__(
+        self,
+        db_path: str = "data/outreach_config.db",
+        *,
+        catalog: StoreCatalog | None = None,
+    ) -> None:
         Path(db_path).parent.mkdir(parents=True, exist_ok=True)
         self._db = sqlite3.connect(db_path, check_same_thread=False)
         # #889: rollback (TRUNCATE) journal mode, NOT WAL — an external sqlite
         # client's open/close can't unlink -wal/-shm out from under the daemon.
         # See pinky_daemon.db_journal.
-        configure_rollback_journal(self._db)
+        journal_mode = configure_rollback_journal(self._db)
+        if catalog is not None:
+            catalog.register(
+                "outreach_config",
+                db_path,
+                journal_mode=journal_mode,
+                owner=type(self).__name__,
+            )
         self._init_tables()
 
     def _init_tables(self) -> None:

--- a/src/pinky_daemon/plugin_manager.py
+++ b/src/pinky_daemon/plugin_manager.py
@@ -38,6 +38,8 @@ from typing import Any, Callable
 
 import yaml
 
+from pinky_daemon.store_catalog import StoreCatalog
+
 
 def _log(msg: str) -> None:
     print(msg, file=sys.stderr, flush=True)
@@ -116,12 +118,14 @@ class PluginContext:
         db_path: str = "",
         api_url: str = "http://localhost:8888",
         working_dir: str = ".",
+        catalog: StoreCatalog | None = None,
     ):
         self.plugin_name = plugin_name
         self._api_url = api_url
         self._working_dir = Path(working_dir)
         self._db: sqlite3.Connection | None = None
         self._db_path = db_path
+        self._catalog = catalog
         self._tools: dict[str, Callable] = {}
         self._hooks: dict[str, list[Callable]] = {}
 
@@ -139,7 +143,16 @@ class PluginContext:
                 data_dir.mkdir(parents=True, exist_ok=True)
                 self._db_path = str(data_dir / "plugins.db")
             self._db = sqlite3.connect(self._db_path, check_same_thread=False)
-            self._db.execute("PRAGMA journal_mode=WAL")
+            journal_mode = str(
+                self._db.execute("PRAGMA journal_mode=WAL").fetchone()[0]
+            ).lower()
+            if self._catalog is not None:
+                self._catalog.register(
+                    "plugins",
+                    self._db_path,
+                    journal_mode=journal_mode,
+                    owner="PluginManager",
+                )
         return self._db
 
     def create_table(self, table_name: str, schema: str) -> None:
@@ -281,12 +294,14 @@ class PluginManager:
         db_path: str = "data/plugins.db",
         api_url: str = "http://localhost:8888",
         working_dir: str = ".",
+        catalog: StoreCatalog | None = None,
     ):
         self._plugins: dict[str, PluginInfo] = {}
         self._contexts: dict[str, PluginContext] = {}
         self._db_path = db_path
         self._api_url = api_url
         self._working_dir = working_dir
+        self._catalog = catalog
 
         # State persistence
         self._state_db_path = db_path
@@ -296,7 +311,14 @@ class PluginManager:
         """Initialize the plugin state tracking table."""
         Path(self._state_db_path).parent.mkdir(parents=True, exist_ok=True)
         db = sqlite3.connect(self._state_db_path, check_same_thread=False)
-        db.execute("PRAGMA journal_mode=WAL")
+        journal_mode = str(db.execute("PRAGMA journal_mode=WAL").fetchone()[0]).lower()
+        if self._catalog is not None:
+            self._catalog.register(
+                "plugins",
+                self._state_db_path,
+                journal_mode=journal_mode,
+                owner="PluginManager",
+            )
         db.execute("""
             CREATE TABLE IF NOT EXISTS plugin_state (
                 name TEXT PRIMARY KEY,
@@ -435,6 +457,7 @@ class PluginManager:
             db_path=self._db_path,
             api_url=self._api_url,
             working_dir=self._working_dir,
+            catalog=self._catalog,
         )
 
         # Load the plugin module

--- a/src/pinky_daemon/presentation_store.py
+++ b/src/pinky_daemon/presentation_store.py
@@ -23,6 +23,8 @@ import time
 from dataclasses import dataclass
 from pathlib import Path
 
+from pinky_daemon.store_catalog import StoreCatalog
+
 
 def _log(msg: str) -> None:
     print(msg, file=sys.stderr, flush=True)
@@ -125,9 +127,15 @@ class PresentationVersion:
 class PresentationStore:
     """SQLite-backed presentation storage with versioning."""
 
-    def __init__(self, db_path: str = "data/presentations.db") -> None:
+    def __init__(
+        self,
+        db_path: str = "data/presentations.db",
+        *,
+        catalog: StoreCatalog | None = None,
+    ) -> None:
         Path(db_path).parent.mkdir(parents=True, exist_ok=True)
         self._db_path = db_path
+        self._catalog = catalog
         self._thread_local = threading.local()
         self._init_tables()
 
@@ -137,9 +145,18 @@ class PresentationStore:
         connection = getattr(self._thread_local, "connection", None)
         if connection is None:
             connection = sqlite3.connect(self._db_path)
-            connection.execute("PRAGMA journal_mode=WAL")
+            journal_mode = str(
+                connection.execute("PRAGMA journal_mode=WAL").fetchone()[0]
+            ).lower()
             connection.execute("PRAGMA busy_timeout=30000")
             connection.execute("PRAGMA foreign_keys=ON")
+            if self._catalog is not None:
+                self._catalog.register(
+                    "presentations",
+                    self._db_path,
+                    journal_mode=journal_mode,
+                    owner=type(self).__name__,
+                )
             self._thread_local.connection = connection
         return connection
 

--- a/src/pinky_daemon/research_store.py
+++ b/src/pinky_daemon/research_store.py
@@ -23,6 +23,8 @@ import time
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from pinky_daemon.store_catalog import StoreCatalog
+
 
 def _log(msg: str) -> None:
     print(msg, file=sys.stderr, flush=True)
@@ -135,9 +137,15 @@ class PeerReview:
 class ResearchStore:
     """SQLite-backed research pipeline management."""
 
-    def __init__(self, db_path: str = "data/research.db") -> None:
+    def __init__(
+        self,
+        db_path: str = "data/research.db",
+        *,
+        catalog: StoreCatalog | None = None,
+    ) -> None:
         Path(db_path).parent.mkdir(parents=True, exist_ok=True)
         self._db_path = db_path
+        self._catalog = catalog
         self._thread_local = threading.local()
         self._init_tables()
 
@@ -147,9 +155,18 @@ class ResearchStore:
         connection = getattr(self._thread_local, "connection", None)
         if connection is None:
             connection = sqlite3.connect(self._db_path)
-            connection.execute("PRAGMA journal_mode=WAL")
+            journal_mode = str(
+                connection.execute("PRAGMA journal_mode=WAL").fetchone()[0]
+            ).lower()
             connection.execute("PRAGMA busy_timeout=30000")
             connection.execute("PRAGMA foreign_keys=ON")
+            if self._catalog is not None:
+                self._catalog.register(
+                    "research",
+                    self._db_path,
+                    journal_mode=journal_mode,
+                    owner=type(self).__name__,
+                )
             self._thread_local.connection = connection
         return connection
 

--- a/src/pinky_daemon/session_store.py
+++ b/src/pinky_daemon/session_store.py
@@ -20,6 +20,10 @@ import time
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from pinky_daemon.store_catalog import StoreCatalog
+
+SESSION_DB_OWNER = "SessionStore+SessionEventStore"
+
 
 def _log(msg: str) -> None:
     print(msg, file=sys.stderr, flush=True)
@@ -59,9 +63,15 @@ class SessionRecord:
 class SessionStore:
     """SQLite-backed session persistence."""
 
-    def __init__(self, db_path: str = "data/sessions.db") -> None:
+    def __init__(
+        self,
+        db_path: str = "data/sessions.db",
+        *,
+        catalog: StoreCatalog | None = None,
+    ) -> None:
         Path(db_path).parent.mkdir(parents=True, exist_ok=True)
         self._db_path = db_path
+        self._catalog = catalog
         self._thread_local = threading.local()
         self._init_tables()
 
@@ -71,8 +81,17 @@ class SessionStore:
         connection = getattr(self._thread_local, "connection", None)
         if connection is None:
             connection = sqlite3.connect(self._db_path)
-            connection.execute("PRAGMA journal_mode=WAL")
+            journal_mode = str(
+                connection.execute("PRAGMA journal_mode=WAL").fetchone()[0]
+            ).lower()
             connection.execute("PRAGMA busy_timeout=30000")
+            if self._catalog is not None:
+                self._catalog.register(
+                    "sessions",
+                    self._db_path,
+                    journal_mode=journal_mode,
+                    owner=SESSION_DB_OWNER,
+                )
             self._thread_local.connection = connection
         return connection
 
@@ -302,9 +321,15 @@ class SessionStore:
 class SessionEventStore:
     """SQLite-backed store for session lifecycle events."""
 
-    def __init__(self, db_path: str = "data/sessions.db") -> None:
+    def __init__(
+        self,
+        db_path: str = "data/sessions.db",
+        *,
+        catalog: StoreCatalog | None = None,
+    ) -> None:
         Path(db_path).parent.mkdir(parents=True, exist_ok=True)
         self._db_path = db_path
+        self._catalog = catalog
         self._thread_local = threading.local()
         self._init_tables()
 
@@ -314,8 +339,17 @@ class SessionEventStore:
         connection = getattr(self._thread_local, "connection", None)
         if connection is None:
             connection = sqlite3.connect(self._db_path)
-            connection.execute("PRAGMA journal_mode=WAL")
+            journal_mode = str(
+                connection.execute("PRAGMA journal_mode=WAL").fetchone()[0]
+            ).lower()
             connection.execute("PRAGMA busy_timeout=30000")
+            if self._catalog is not None:
+                self._catalog.register(
+                    "session_events",
+                    self._db_path,
+                    journal_mode=journal_mode,
+                    owner=SESSION_DB_OWNER,
+                )
             self._thread_local.connection = connection
         return connection
 

--- a/src/pinky_daemon/skill_store.py
+++ b/src/pinky_daemon/skill_store.py
@@ -29,6 +29,8 @@ from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
 
+from pinky_daemon.store_catalog import StoreCatalog
+
 
 def _log(msg: str) -> None:
     print(msg, file=sys.stderr, flush=True)
@@ -141,9 +143,15 @@ def _row_to_skill(row: tuple) -> Skill:
 class SkillStore:
     """SQLite-backed skill registry with per-agent assignment."""
 
-    def __init__(self, db_path: str = "data/skills.db") -> None:
+    def __init__(
+        self,
+        db_path: str = "data/skills.db",
+        *,
+        catalog: StoreCatalog | None = None,
+    ) -> None:
         Path(db_path).parent.mkdir(parents=True, exist_ok=True)
         self._db_path = db_path
+        self._catalog = catalog
         self._thread_local = threading.local()
         self._init_tables()
 
@@ -153,9 +161,18 @@ class SkillStore:
         connection = getattr(self._thread_local, "connection", None)
         if connection is None:
             connection = sqlite3.connect(self._db_path)
-            connection.execute("PRAGMA journal_mode=WAL")
+            journal_mode = str(
+                connection.execute("PRAGMA journal_mode=WAL").fetchone()[0]
+            ).lower()
             connection.execute("PRAGMA busy_timeout=30000")
             connection.execute("PRAGMA foreign_keys=ON")
+            if self._catalog is not None:
+                self._catalog.register(
+                    "skills",
+                    self._db_path,
+                    journal_mode=journal_mode,
+                    owner=type(self).__name__,
+                )
             self._thread_local.connection = connection
         return connection
 

--- a/src/pinky_daemon/store_catalog.py
+++ b/src/pinky_daemon/store_catalog.py
@@ -184,15 +184,17 @@ class StoreCatalog:
             return True
         if not raw_path.startswith("file:"):
             return False
-        uri_path, separator, query = raw_path.partition("?")
+        uri, _, _fragment = raw_path.partition("#")
+        uri_path, separator, query = uri.partition("?")
         if uri_path == "file::memory:":
             return True
         if not separator:
             return False
-        return any(
-            key.lower() == "mode" and value.lower() == "memory"
-            for key, value in parse_qsl(query, keep_blank_values=True)
-        )
+        effective_mode: str | None = None
+        for key, value in parse_qsl(query, keep_blank_values=True):
+            if key == "mode":
+                effective_mode = value
+        return effective_mode == "memory"
 
     def _is_under_expected_root(self, path: str) -> bool:
         try:

--- a/src/pinky_daemon/store_catalog.py
+++ b/src/pinky_daemon/store_catalog.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 import threading
 from dataclasses import dataclass
+from urllib.parse import parse_qsl
 
 
 @dataclass(frozen=True, slots=True)
@@ -17,6 +18,7 @@ class StoreRecord:
     owner: str
     criticality: str
     dev_ino: tuple[int, int] | None
+    is_memory: bool
 
 
 class StoreCatalogError(RuntimeError):
@@ -54,6 +56,7 @@ class StoreCatalog:
         so :meth:`validate` can report the complete conflict at the boot gate.
         """
         raw_path = os.fspath(path)
+        is_memory = self._is_memory_path(raw_path)
         resolved_path = os.path.realpath(raw_path)
         record = StoreRecord(
             logical_name=logical_name,
@@ -61,7 +64,8 @@ class StoreCatalog:
             journal_mode=journal_mode.lower(),
             owner=owner,
             criticality=criticality,
-            dev_ino=self._stat_identity(resolved_path),
+            dev_ino=None if is_memory else self._stat_identity(resolved_path),
+            is_memory=is_memory,
         )
         used_relative_path = not os.path.isabs(raw_path)
 
@@ -74,6 +78,7 @@ class StoreCatalog:
                     and current.resolved_path == record.resolved_path
                     and current.journal_mode == record.journal_mode
                     and current.criticality == record.criticality
+                    and current.is_memory == record.is_memory
                 ):
                     entry.record = record
                     entry.used_relative_path = entry.used_relative_path or used_relative_path
@@ -96,7 +101,7 @@ class StoreCatalog:
 
         for entry in entries:
             record = entry.record
-            if record.journal_mode == "memory":
+            if record.is_memory:
                 continue
             if entry.used_relative_path:
                 violations.append("relative path input for " + self._format_record(record))
@@ -120,7 +125,7 @@ class StoreCatalog:
 
         for index, left in enumerate(records):
             for right in records[index + 1 :]:
-                if "memory" in {left.journal_mode, right.journal_mode}:
+                if left.is_memory or right.is_memory:
                     continue
                 same_realpath = left.resolved_path == right.resolved_path
                 same_inode = (
@@ -161,7 +166,7 @@ class StoreCatalog:
     def _refresh_identities(self) -> None:
         for entry in self._entries:
             record = entry.record
-            dev_ino = self._stat_identity(record.resolved_path)
+            dev_ino = None if record.is_memory else self._stat_identity(record.resolved_path)
             if dev_ino != record.dev_ino:
                 entry.record = StoreRecord(
                     logical_name=record.logical_name,
@@ -170,7 +175,24 @@ class StoreCatalog:
                     owner=record.owner,
                     criticality=record.criticality,
                     dev_ino=dev_ino,
+                    is_memory=record.is_memory,
                 )
+
+    @staticmethod
+    def _is_memory_path(raw_path: str) -> bool:
+        if raw_path == ":memory:":
+            return True
+        if not raw_path.startswith("file:"):
+            return False
+        uri_path, separator, query = raw_path.partition("?")
+        if uri_path == "file::memory:":
+            return True
+        if not separator:
+            return False
+        return any(
+            key.lower() == "mode" and value.lower() == "memory"
+            for key, value in parse_qsl(query, keep_blank_values=True)
+        )
 
     def _is_under_expected_root(self, path: str) -> bool:
         try:
@@ -183,5 +205,5 @@ class StoreCatalog:
         return (
             f"{record.logical_name!r} owner={record.owner!r} "
             f"path={record.resolved_path!r} journal_mode={record.journal_mode!r} "
-            f"dev_ino={record.dev_ino!r}"
+            f"dev_ino={record.dev_ino!r} is_memory={record.is_memory!r}"
         )

--- a/src/pinky_daemon/store_catalog.py
+++ b/src/pinky_daemon/store_catalog.py
@@ -1,0 +1,187 @@
+"""Canonical inventory and boot-time validation for daemon SQLite stores."""
+
+from __future__ import annotations
+
+import os
+import threading
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class StoreRecord:
+    """One logical store's observed physical SQLite identity."""
+
+    logical_name: str
+    resolved_path: str
+    journal_mode: str
+    owner: str
+    criticality: str
+    dev_ino: tuple[int, int] | None
+
+
+class StoreCatalogError(RuntimeError):
+    """Raised when the daemon's store layout is unsafe or incoherent."""
+
+
+@dataclass(slots=True)
+class _CatalogEntry:
+    record: StoreRecord
+    used_relative_path: bool
+
+
+class StoreCatalog:
+    """Observe store connection policy and reject an incoherent boot layout."""
+
+    def __init__(self, expected_root: str | os.PathLike[str] | None = None) -> None:
+        root = os.getcwd() if expected_root is None else os.fspath(expected_root)
+        self._expected_root = os.path.realpath(root)
+        self._entries: list[_CatalogEntry] = []
+        self._lock = threading.RLock()
+
+    def register(
+        self,
+        logical_name: str,
+        path: str | os.PathLike[str],
+        *,
+        journal_mode: str,
+        owner: str,
+        criticality: str = "authoritative",
+    ) -> None:
+        """Record one store connection, canonicalized to physical path identity.
+
+        Repeated connection opens for the same logical name, owner, path, and
+        policy refresh the existing record. Divergent declarations are retained
+        so :meth:`validate` can report the complete conflict at the boot gate.
+        """
+        raw_path = os.fspath(path)
+        resolved_path = os.path.realpath(raw_path)
+        record = StoreRecord(
+            logical_name=logical_name,
+            resolved_path=resolved_path,
+            journal_mode=journal_mode.lower(),
+            owner=owner,
+            criticality=criticality,
+            dev_ino=self._stat_identity(resolved_path),
+        )
+        used_relative_path = not os.path.isabs(raw_path)
+
+        with self._lock:
+            for entry in self._entries:
+                current = entry.record
+                if (
+                    current.logical_name == record.logical_name
+                    and current.owner == record.owner
+                    and current.resolved_path == record.resolved_path
+                    and current.journal_mode == record.journal_mode
+                    and current.criticality == record.criticality
+                ):
+                    entry.record = record
+                    entry.used_relative_path = entry.used_relative_path or used_relative_path
+                    return
+            self._entries.append(
+                _CatalogEntry(
+                    record=record,
+                    used_relative_path=used_relative_path,
+                )
+            )
+
+    def validate(self) -> None:
+        """Raise when registered stores do not form one coherent layout."""
+        with self._lock:
+            self._refresh_identities()
+            entries = list(self._entries)
+
+        violations: list[str] = []
+        records = [entry.record for entry in entries]
+
+        for entry in entries:
+            record = entry.record
+            if record.journal_mode == "memory":
+                continue
+            if entry.used_relative_path:
+                violations.append("relative path input for " + self._format_record(record))
+            if not os.path.isabs(record.resolved_path):
+                violations.append("unresolved non-absolute path for " + self._format_record(record))
+            if not self._is_under_expected_root(record.resolved_path):
+                violations.append(
+                    f"path is outside expected root {self._expected_root!r}: "
+                    + self._format_record(record)
+                )
+
+        records_by_logical_name: dict[str, list[StoreRecord]] = {}
+        for record in records:
+            records_by_logical_name.setdefault(record.logical_name, []).append(record)
+        for logical_name, matching_records in records_by_logical_name.items():
+            if len({record.resolved_path for record in matching_records}) > 1:
+                violations.append(
+                    f"duplicate logical name {logical_name!r} has divergent paths: "
+                    + "; ".join(self._format_record(record) for record in matching_records)
+                )
+
+        for index, left in enumerate(records):
+            for right in records[index + 1 :]:
+                if "memory" in {left.journal_mode, right.journal_mode}:
+                    continue
+                same_realpath = left.resolved_path == right.resolved_path
+                same_inode = (
+                    left.dev_ino is not None
+                    and right.dev_ino is not None
+                    and left.dev_ino == right.dev_ino
+                )
+                if not (same_realpath or same_inode):
+                    continue
+                pair = f"{self._format_record(left)}; {self._format_record(right)}"
+                if left.journal_mode != right.journal_mode:
+                    violations.append("journal mode mismatch on same physical file: " + pair)
+                if left.logical_name != right.logical_name and left.owner != right.owner:
+                    violations.append(
+                        "different logical stores share the same physical file "
+                        "without a shared owner identity: " + pair
+                    )
+
+        if violations:
+            raise StoreCatalogError(
+                "Store catalog validation failed:\n- " + "\n- ".join(violations)
+            )
+
+    def snapshot(self) -> list[StoreRecord]:
+        """Return the current canonical records in registration order."""
+        with self._lock:
+            self._refresh_identities()
+            return [entry.record for entry in self._entries]
+
+    @staticmethod
+    def _stat_identity(path: str) -> tuple[int, int] | None:
+        try:
+            stat = os.stat(path)
+        except OSError:
+            return None
+        return (stat.st_dev, stat.st_ino)
+
+    def _refresh_identities(self) -> None:
+        for entry in self._entries:
+            record = entry.record
+            dev_ino = self._stat_identity(record.resolved_path)
+            if dev_ino != record.dev_ino:
+                entry.record = StoreRecord(
+                    logical_name=record.logical_name,
+                    resolved_path=record.resolved_path,
+                    journal_mode=record.journal_mode,
+                    owner=record.owner,
+                    criticality=record.criticality,
+                    dev_ino=dev_ino,
+                )
+
+    def _is_under_expected_root(self, path: str) -> bool:
+        try:
+            return os.path.commonpath((self._expected_root, path)) == self._expected_root
+        except ValueError:
+            return False
+
+    @staticmethod
+    def _format_record(record: StoreRecord) -> str:
+        return (
+            f"{record.logical_name!r} owner={record.owner!r} "
+            f"path={record.resolved_path!r} journal_mode={record.journal_mode!r} "
+            f"dev_ino={record.dev_ino!r}"
+        )

--- a/src/pinky_daemon/task_store.py
+++ b/src/pinky_daemon/task_store.py
@@ -22,6 +22,8 @@ import time
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from pinky_daemon.store_catalog import StoreCatalog
+
 
 def _log(msg: str) -> None:
     print(msg, file=sys.stderr, flush=True)
@@ -183,9 +185,15 @@ class Task:
 class TaskStore:
     """SQLite-backed task management."""
 
-    def __init__(self, db_path: str = "data/tasks.db") -> None:
+    def __init__(
+        self,
+        db_path: str = "data/tasks.db",
+        *,
+        catalog: StoreCatalog | None = None,
+    ) -> None:
         Path(db_path).parent.mkdir(parents=True, exist_ok=True)
         self._db_path = db_path
+        self._catalog = catalog
         self._thread_local = threading.local()
         self._init_tables()
 
@@ -195,9 +203,18 @@ class TaskStore:
         connection = getattr(self._thread_local, "connection", None)
         if connection is None:
             connection = sqlite3.connect(self._db_path)
-            connection.execute("PRAGMA journal_mode=WAL")
+            journal_mode = str(
+                connection.execute("PRAGMA journal_mode=WAL").fetchone()[0]
+            ).lower()
             connection.execute("PRAGMA busy_timeout=30000")
             connection.execute("PRAGMA foreign_keys=ON")
+            if self._catalog is not None:
+                self._catalog.register(
+                    "tasks",
+                    self._db_path,
+                    journal_mode=journal_mode,
+                    owner=type(self).__name__,
+                )
             self._thread_local.connection = connection
         return connection
 

--- a/src/pinky_daemon/trigger_store.py
+++ b/src/pinky_daemon/trigger_store.py
@@ -20,6 +20,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from pinky_daemon.db_journal import configure_rollback_journal
+from pinky_daemon.store_catalog import StoreCatalog
 
 
 def _log(msg: str) -> None:
@@ -76,9 +77,15 @@ class Trigger:
 class TriggerStore:
     """SQLite-backed store for triggers."""
 
-    def __init__(self, db_path: str = "data/triggers.db") -> None:
+    def __init__(
+        self,
+        db_path: str = "data/triggers.db",
+        *,
+        catalog: StoreCatalog | None = None,
+    ) -> None:
         Path(db_path).parent.mkdir(parents=True, exist_ok=True)
         self._db_path = db_path
+        self._catalog = catalog
         self._thread_local = threading.local()
         self._init_table()
         self._migrate()
@@ -92,9 +99,16 @@ class TriggerStore:
             # #889: rollback (TRUNCATE) journal mode, NOT WAL — an external sqlite
             # client's open/close can't unlink -wal/-shm out from under the daemon.
             # Sets busy_timeout internally. See pinky_daemon.db_journal.
-            configure_rollback_journal(connection, busy_ms=30000)
+            journal_mode = configure_rollback_journal(connection, busy_ms=30000)
             connection.execute("PRAGMA foreign_keys=ON")
             connection.row_factory = sqlite3.Row
+            if self._catalog is not None:
+                self._catalog.register(
+                    "triggers",
+                    self._db_path,
+                    journal_mode=journal_mode,
+                    owner=type(self).__name__,
+                )
             self._thread_local.connection = connection
         return connection
 

--- a/src/pinky_daemon/user_profile_store.py
+++ b/src/pinky_daemon/user_profile_store.py
@@ -19,6 +19,7 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 
 from pinky_daemon.db_journal import configure_rollback_journal
+from pinky_daemon.store_catalog import StoreCatalog
 
 
 @dataclass
@@ -80,9 +81,15 @@ class Relationship:
 class UserProfileStore:
     """SQLite-backed store for structured user profiles."""
 
-    def __init__(self, db_path: str = "data/user_profiles.db") -> None:
+    def __init__(
+        self,
+        db_path: str = "data/user_profiles.db",
+        *,
+        catalog: StoreCatalog | None = None,
+    ) -> None:
         Path(db_path).parent.mkdir(parents=True, exist_ok=True)
         self._db_path = db_path
+        self._catalog = catalog
         self._thread_local = threading.local()
         self._init_tables()
 
@@ -98,7 +105,14 @@ class UserProfileStore:
             # coordination for fresh readers → SQLITE_IOERR across all reader connections (2026-08-17
             # dream failures). Rollback mode has no -wal/-shm to orphan; the busy_timeout
             # absorbs the whole-file-lock serialization. See pinky_daemon.db_journal.
-            configure_rollback_journal(connection, busy_ms=30000)
+            journal_mode = configure_rollback_journal(connection, busy_ms=30000)
+            if self._catalog is not None:
+                self._catalog.register(
+                    "user_profiles",
+                    self._db_path,
+                    journal_mode=journal_mode,
+                    owner=type(self).__name__,
+                )
             self._thread_local.connection = connection
         return connection
 

--- a/src/pinky_daemon/voice_store.py
+++ b/src/pinky_daemon/voice_store.py
@@ -21,6 +21,8 @@ import uuid
 from dataclasses import dataclass
 from pathlib import Path
 
+from pinky_daemon.store_catalog import StoreCatalog
+
 
 def _log(msg: str) -> None:
     print(msg, file=sys.stderr, flush=True)
@@ -216,9 +218,15 @@ _MIGRATIONS: dict[str, list[tuple[str, str]]] = {
 class VoiceStore:
     """SQLite-backed store for voice call state."""
 
-    def __init__(self, db_path: str = "data/voice_calls.db") -> None:
+    def __init__(
+        self,
+        db_path: str = "data/voice_calls.db",
+        *,
+        catalog: StoreCatalog | None = None,
+    ) -> None:
         Path(db_path).parent.mkdir(parents=True, exist_ok=True)
         self._db_path = db_path
+        self._catalog = catalog
         self._thread_local = threading.local()
         self._init_tables()
         self._migrate()
@@ -229,10 +237,19 @@ class VoiceStore:
         connection = getattr(self._thread_local, "connection", None)
         if connection is None:
             connection = sqlite3.connect(self._db_path)
-            connection.execute("PRAGMA journal_mode=WAL")
+            journal_mode = str(
+                connection.execute("PRAGMA journal_mode=WAL").fetchone()[0]
+            ).lower()
             connection.execute("PRAGMA busy_timeout=30000")
             connection.execute("PRAGMA foreign_keys=ON")
             connection.row_factory = sqlite3.Row
+            if self._catalog is not None:
+                self._catalog.register(
+                    "voice",
+                    self._db_path,
+                    journal_mode=journal_mode,
+                    owner=type(self).__name__,
+                )
             self._thread_local.connection = connection
         return connection
 

--- a/tests/test_store_catalog.py
+++ b/tests/test_store_catalog.py
@@ -135,7 +135,10 @@ def test_in_memory_connections_do_not_false_alias(tmp_path: Path) -> None:
         ":memory:",
         "file::memory:",
         "file::memory:?cache=shared",
+        "file::memory:?cache=shared#frag",
         "file:shared-cache?mode=memory&cache=shared",
+        "file:shared-cache?mode=memory#frag",
+        "file:shared-cache?mode=rwc&mode=memory",
     ],
 )
 def test_in_memory_identity_comes_from_raw_path(tmp_path: Path, path: str) -> None:
@@ -144,6 +147,27 @@ def test_in_memory_identity_comes_from_raw_path(tmp_path: Path, path: str) -> No
 
     assert catalog.snapshot()[0].is_memory is True
     catalog.validate()
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        "MODE=memory",
+        "mode=memory&mode=rwc",
+    ],
+)
+def test_non_effective_memory_uri_mode_is_not_exempted(tmp_path: Path, query: str) -> None:
+    expected_root = tmp_path / "data"
+    expected_root.mkdir()
+    outside = tmp_path / "outside.db"
+    outside.touch()
+    catalog = StoreCatalog(expected_root=expected_root)
+    uri = f"file:{outside}?{query}"
+    _register(catalog, "tasks", uri, journal_mode="memory", owner="TaskStore")
+
+    assert catalog.snapshot()[0].is_memory is False
+    with pytest.raises(StoreCatalogError):
+        catalog.validate()
 
 
 def test_on_disk_memory_mode_alias_is_not_exempt(tmp_path: Path) -> None:

--- a/tests/test_store_catalog.py
+++ b/tests/test_store_catalog.py
@@ -40,6 +40,7 @@ def test_register_snapshot_round_trip(tmp_path: Path) -> None:
             owner="TaskStore",
             criticality="authoritative",
             dev_ino=(stat.st_dev, stat.st_ino),
+            is_memory=False,
         )
     ]
 
@@ -126,6 +127,46 @@ def test_in_memory_connections_do_not_false_alias(tmp_path: Path) -> None:
     )
 
     catalog.validate()
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        ":memory:",
+        "file::memory:",
+        "file::memory:?cache=shared",
+        "file:shared-cache?mode=memory&cache=shared",
+    ],
+)
+def test_in_memory_identity_comes_from_raw_path(tmp_path: Path, path: str) -> None:
+    catalog = StoreCatalog(expected_root=tmp_path)
+    _register(catalog, "tasks", path, journal_mode="memory", owner="TaskStore")
+
+    assert catalog.snapshot()[0].is_memory is True
+    catalog.validate()
+
+
+def test_on_disk_memory_mode_alias_is_not_exempt(tmp_path: Path) -> None:
+    shared = tmp_path / "shared.db"
+    shared.touch()
+    catalog = StoreCatalog(expected_root=tmp_path)
+    _register(catalog, "tasks", shared, journal_mode="memory", owner="TaskStore")
+    _register(catalog, "audit", shared, journal_mode="memory", owner="AuditStore")
+
+    with pytest.raises(StoreCatalogError, match="same physical file"):
+        catalog.validate()
+
+
+def test_on_disk_memory_mode_outside_root_is_not_exempt(tmp_path: Path) -> None:
+    expected_root = tmp_path / "data"
+    expected_root.mkdir()
+    outside = tmp_path / "outside.db"
+    outside.touch()
+    catalog = StoreCatalog(expected_root=expected_root)
+    _register(catalog, "tasks", outside, journal_mode="memory", owner="TaskStore")
+
+    with pytest.raises(StoreCatalogError, match="expected root"):
+        catalog.validate()
 
 
 def test_relative_path_fails_validation(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -227,6 +268,94 @@ def test_symlink_and_target_are_detected_as_same_inode(tmp_path: Path) -> None:
         catalog.validate()
 
 
+def test_hardlinks_are_detected_as_same_inode(tmp_path: Path) -> None:
+    target = tmp_path / "tasks.db"
+    target.touch()
+    alias = tmp_path / "audit.db"
+    os.link(target, alias)
+    catalog = StoreCatalog(expected_root=tmp_path)
+    _register(catalog, "tasks", target, owner="TaskStore")
+    _register(catalog, "audit", alias, owner="AuditStore")
+
+    records = catalog.snapshot()
+    assert records[0].resolved_path != records[1].resolved_path
+    assert records[0].dev_ino == records[1].dev_ino
+    with pytest.raises(StoreCatalogError, match="same physical file"):
+        catalog.validate()
+
+
+def test_agent_comms_participates_in_alias_validation(tmp_path: Path) -> None:
+    from pinky_daemon.agent_comms import AgentComms
+
+    shared = tmp_path / "shared.db"
+    catalog = StoreCatalog(expected_root=tmp_path)
+    _register(catalog, "tasks", shared, owner="TaskStore")
+
+    AgentComms(db_path=str(shared), catalog=catalog)
+
+    record = next(record for record in catalog.snapshot() if record.logical_name == "agent_comms")
+    assert record.owner == "AgentComms"
+    assert record.criticality == "authoritative"
+    with pytest.raises(StoreCatalogError, match="same physical file"):
+        catalog.validate()
+
+
+def test_plugin_manager_participates_in_alias_validation(tmp_path: Path) -> None:
+    from pinky_daemon.plugin_manager import PluginManager
+
+    shared = tmp_path / "shared.db"
+    catalog = StoreCatalog(expected_root=tmp_path)
+    _register(catalog, "tasks", shared, owner="TaskStore")
+
+    PluginManager(db_path=str(shared), working_dir=str(tmp_path), catalog=catalog)
+
+    record = next(record for record in catalog.snapshot() if record.logical_name == "plugins")
+    assert record.owner == "PluginManager"
+    assert record.criticality == "authoritative"
+    with pytest.raises(StoreCatalogError, match="same physical file"):
+        catalog.validate()
+
+
+def test_plugin_context_registers_the_manager_store_identity(tmp_path: Path) -> None:
+    from pinky_daemon.plugin_manager import PluginContext
+
+    shared = tmp_path / "shared.db"
+    catalog = StoreCatalog(expected_root=tmp_path)
+    _register(catalog, "tasks", shared, owner="TaskStore")
+    context = PluginContext("example", db_path=str(shared), catalog=catalog)
+
+    _ = context.db
+
+    record = next(record for record in catalog.snapshot() if record.logical_name == "plugins")
+    assert record.owner == "PluginManager"
+    with pytest.raises(StoreCatalogError, match="same physical file"):
+        catalog.validate()
+    context.close()
+
+
+def test_librarian_runner_participates_in_alias_validation(tmp_path: Path) -> None:
+    from pinky_daemon.kb_store import KBStore
+    from pinky_daemon.librarian_runner import LibrarianRunner
+
+    shared = tmp_path / "shared.db"
+    catalog = StoreCatalog(expected_root=tmp_path)
+    _register(catalog, "tasks", shared, owner="TaskStore")
+
+    LibrarianRunner(
+        kb_store=KBStore(data_dir=tmp_path / "kb-data"),
+        db_path=shared,
+        catalog=catalog,
+    )
+
+    record = next(
+        record for record in catalog.snapshot() if record.logical_name == "librarian_state"
+    )
+    assert record.owner == "LibrarianRunner"
+    assert record.criticality == "derived"
+    with pytest.raises(StoreCatalogError, match="same physical file"):
+        catalog.validate()
+
+
 def test_create_api_registers_all_authoritative_stores_and_validates_once(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -248,6 +377,7 @@ def test_create_api_registers_all_authoritative_stores_and_validates_once(
     records = validation_snapshots[0]
     assert {record.logical_name for record in records} == {
         "conversations",
+        "agent_comms",
         "tasks",
         "triggers",
         "outreach_config",
@@ -262,13 +392,21 @@ def test_create_api_registers_all_authoritative_stores_and_validates_once(
         "presentations",
         "apps",
         "skills",
+        "plugins",
         "voice",
         "audit",
         "message_context",
         "kb",
+        "librarian_state",
         "dream_state",
     }
+    assert len(records) == 23
+    assert len({record.resolved_path for record in records}) == 22
     assert {record.journal_mode for record in records} == {"truncate", "wal"}
+    assert (
+        next(record for record in records if record.logical_name == "librarian_state").criticality
+        == "derived"
+    )
     session_records = [
         record for record in records if record.logical_name in {"sessions", "session_events"}
     ]

--- a/tests/test_store_catalog.py
+++ b/tests/test_store_catalog.py
@@ -1,0 +1,296 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from pinky_daemon.store_catalog import StoreCatalog, StoreCatalogError, StoreRecord
+
+
+def _register(
+    catalog: StoreCatalog,
+    logical_name: str,
+    path: Path | str,
+    *,
+    journal_mode: str = "wal",
+    owner: str | None = None,
+) -> None:
+    catalog.register(
+        logical_name,
+        path,
+        journal_mode=journal_mode,
+        owner=owner or f"{logical_name.title()}Store",
+    )
+
+
+def test_register_snapshot_round_trip(tmp_path: Path) -> None:
+    db_path = tmp_path / "tasks.db"
+    db_path.touch()
+    catalog = StoreCatalog(expected_root=tmp_path)
+
+    _register(catalog, "tasks", db_path, owner="TaskStore")
+
+    stat = db_path.stat()
+    assert catalog.snapshot() == [
+        StoreRecord(
+            logical_name="tasks",
+            resolved_path=os.path.realpath(db_path),
+            journal_mode="wal",
+            owner="TaskStore",
+            criticality="authoritative",
+            dev_ino=(stat.st_dev, stat.st_ino),
+        )
+    ]
+
+
+def test_realpath_canonicalization_is_idempotent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    target = tmp_path / "tasks.db"
+    target.touch()
+    alias = tmp_path / "tasks-alias.db"
+    alias.symlink_to(target)
+    catalog = StoreCatalog(expected_root=tmp_path)
+    monkeypatch.chdir(tmp_path)
+
+    _register(catalog, "tasks", "tasks.db", owner="TaskStore")
+    _register(catalog, "tasks", target, owner="TaskStore")
+    _register(catalog, "tasks", alias, owner="TaskStore")
+
+    records = catalog.snapshot()
+    assert len(records) == 1
+    assert records[0].resolved_path == os.path.realpath(target)
+
+
+def test_aliasing_with_different_owners_and_modes_fails(tmp_path: Path) -> None:
+    shared = tmp_path / "shared.db"
+    shared.touch()
+    catalog = StoreCatalog(expected_root=tmp_path)
+    _register(catalog, "sessions", shared, journal_mode="wal", owner="SessionStore")
+    _register(
+        catalog,
+        "session_events",
+        shared,
+        journal_mode="truncate",
+        owner="SessionEventStore",
+    )
+
+    with pytest.raises(StoreCatalogError) as exc_info:
+        catalog.validate()
+
+    message = str(exc_info.value)
+    assert "sessions" in message
+    assert "session_events" in message
+    assert "wal" in message
+    assert "truncate" in message
+
+
+def test_aliasing_with_identical_mode_and_shared_owner_passes(tmp_path: Path) -> None:
+    shared = tmp_path / "sessions.db"
+    shared.touch()
+    catalog = StoreCatalog(expected_root=tmp_path)
+    owner = "SessionStore+SessionEventStore"
+    _register(catalog, "sessions", shared, owner=owner)
+    _register(catalog, "session_events", shared, owner=owner)
+
+    catalog.validate()
+
+
+def test_journal_mode_mismatch_on_shared_file_fails(tmp_path: Path) -> None:
+    shared = tmp_path / "shared.db"
+    shared.touch()
+    catalog = StoreCatalog(expected_root=tmp_path)
+    _register(catalog, "tasks", shared, journal_mode="wal", owner="TaskWriter")
+    _register(catalog, "tasks", shared, journal_mode="truncate", owner="TaskReader")
+
+    with pytest.raises(StoreCatalogError, match="journal mode"):
+        catalog.validate()
+
+
+def test_in_memory_connections_do_not_false_alias(tmp_path: Path) -> None:
+    catalog = StoreCatalog(expected_root=tmp_path)
+    _register(
+        catalog,
+        "tasks",
+        ":memory:",
+        journal_mode="memory",
+        owner="TaskStore",
+    )
+    _register(
+        catalog,
+        "audit",
+        ":memory:",
+        journal_mode="memory",
+        owner="AuditStore",
+    )
+
+    catalog.validate()
+
+
+def test_relative_path_fails_validation(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    catalog = StoreCatalog(expected_root=tmp_path)
+    _register(catalog, "tasks", "tasks.db", owner="TaskStore")
+
+    with pytest.raises(StoreCatalogError, match="relative path"):
+        catalog.validate()
+
+
+def test_path_outside_expected_root_fails_validation(tmp_path: Path) -> None:
+    expected_root = tmp_path / "data"
+    expected_root.mkdir()
+    outside = tmp_path / "outside.db"
+    catalog = StoreCatalog(expected_root=expected_root)
+    _register(catalog, "tasks", outside, owner="TaskStore")
+
+    with pytest.raises(StoreCatalogError, match="expected root"):
+        catalog.validate()
+
+
+def test_unopened_absolute_store_does_not_fail(tmp_path: Path) -> None:
+    catalog = StoreCatalog(expected_root=tmp_path)
+    _register(catalog, "tasks", tmp_path / "not-opened.db", owner="TaskStore")
+
+    catalog.validate()
+    assert catalog.snapshot()[0].dev_ino is None
+
+
+def test_duplicate_logical_name_with_divergent_path_fails(tmp_path: Path) -> None:
+    catalog = StoreCatalog(expected_root=tmp_path)
+    _register(catalog, "tasks", tmp_path / "tasks-a.db", owner="TaskStore")
+    _register(catalog, "tasks", tmp_path / "tasks-b.db", owner="TaskStore")
+
+    with pytest.raises(StoreCatalogError) as exc_info:
+        catalog.validate()
+
+    message = str(exc_info.value)
+    assert "duplicate logical name" in message
+    assert "tasks-a.db" in message
+    assert "tasks-b.db" in message
+
+
+def test_clean_production_shaped_layout_passes(tmp_path: Path) -> None:
+    catalog = StoreCatalog(expected_root=tmp_path)
+    stores = {
+        "conversations": ("truncate", "ConversationStore"),
+        "tasks": ("wal", "TaskStore"),
+        "triggers": ("truncate", "TriggerStore"),
+        "outreach_config": ("truncate", "OutreachConfigStore"),
+        "user_profiles": ("truncate", "UserProfileStore"),
+        "agents": ("truncate", "AgentRegistry"),
+        "activity": ("wal", "ActivityStore"),
+        "analytics": ("wal", "AnalyticsStore"),
+        "mesh": ("wal", "MeshStore"),
+        "research": ("wal", "ResearchStore"),
+        "presentations": ("wal", "PresentationStore"),
+        "apps": ("wal", "AppStore"),
+        "skills": ("wal", "SkillStore"),
+        "voice": ("wal", "VoiceStore"),
+        "audit": ("wal", "AuditStore"),
+        "message_context": ("wal", "MessageContextStore"),
+        "kb": ("wal", "KBStore"),
+        "dream_state": ("wal", "DreamRunner"),
+    }
+    for logical_name, (journal_mode, owner) in stores.items():
+        db_path = tmp_path / f"{logical_name}.db"
+        db_path.touch()
+        _register(
+            catalog,
+            logical_name,
+            db_path,
+            journal_mode=journal_mode,
+            owner=owner,
+        )
+
+    sessions_path = tmp_path / "sessions.db"
+    sessions_path.touch()
+    session_owner = "SessionStore+SessionEventStore"
+    _register(catalog, "sessions", sessions_path, owner=session_owner)
+    _register(catalog, "session_events", sessions_path, owner=session_owner)
+
+    catalog.validate()
+
+
+def test_symlink_and_target_are_detected_as_same_inode(tmp_path: Path) -> None:
+    target = tmp_path / "shared.db"
+    target.touch()
+    alias = tmp_path / "shared-alias.db"
+    alias.symlink_to(target)
+    catalog = StoreCatalog(expected_root=tmp_path)
+    _register(catalog, "tasks", target, owner="TaskStore")
+    _register(catalog, "audit", alias, owner="AuditStore")
+
+    records = catalog.snapshot()
+    assert records[0].dev_ino == records[1].dev_ino
+    with pytest.raises(StoreCatalogError, match="same physical file"):
+        catalog.validate()
+
+
+def test_create_api_registers_all_authoritative_stores_and_validates_once(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from pinky_daemon.api import create_api
+
+    validation_snapshots: list[list[StoreRecord]] = []
+    original_validate = StoreCatalog.validate
+
+    def validate_spy(catalog: StoreCatalog) -> None:
+        validation_snapshots.append(catalog.snapshot())
+        original_validate(catalog)
+
+    monkeypatch.setattr(StoreCatalog, "validate", validate_spy)
+
+    app = create_api(db_path=str(tmp_path / "conversations.db"))
+
+    assert len(validation_snapshots) == 1
+    assert app.state.store_catalog.snapshot() == validation_snapshots[0]
+    records = validation_snapshots[0]
+    assert {record.logical_name for record in records} == {
+        "conversations",
+        "tasks",
+        "triggers",
+        "outreach_config",
+        "user_profiles",
+        "agents",
+        "sessions",
+        "session_events",
+        "activity",
+        "analytics",
+        "mesh",
+        "research",
+        "presentations",
+        "apps",
+        "skills",
+        "voice",
+        "audit",
+        "message_context",
+        "kb",
+        "dream_state",
+    }
+    assert {record.journal_mode for record in records} == {"truncate", "wal"}
+    session_records = [
+        record for record in records if record.logical_name in {"sessions", "session_events"}
+    ]
+    assert len(session_records) == 2
+    assert len({record.resolved_path for record in session_records}) == 1
+    assert {record.journal_mode for record in session_records} == {"wal"}
+    assert {record.owner for record in session_records} == {"SessionStore+SessionEventStore"}
+
+
+def test_create_api_logs_and_reraises_catalog_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    from pinky_daemon.api import create_api
+
+    def fail_validation(_catalog: StoreCatalog) -> None:
+        raise StoreCatalogError("incoherent test layout")
+
+    monkeypatch.setattr(StoreCatalog, "validate", fail_validation)
+
+    with pytest.raises(StoreCatalogError, match="incoherent test layout"):
+        create_api(db_path=str(tmp_path / "conversations.db"))
+
+    assert "ERROR startup: store catalog validation failed" in capsys.readouterr().err


### PR DESCRIPTION
## What

Introduces a `StoreCatalog` that observes every daemon SQLite store's physical identity at connection open and validates that the boot layout is coherent — a fail-loud boot gate against the class of incoherent store layouts behind the deleted-WAL corruption family (#889). Additive and observe-only: no store-access refactor, no journal-policy change, no path-ownership inversion.

## Why

The daemon opens ~20 authoritative SQLite stores whose physical paths are derived by string manipulation across several construction sites, with a couple wired via bare CWD-relative defaults. Nothing owns the logical-store → physical-file mapping, so two stores can silently alias the same file (with divergent connection/journal policies), or a CWD-relative default can resolve to an unexpected file. That is the "multiple storage authorities / path-identity drift" substrate. The catalog turns an incoherent layout into a loud boot failure instead of a latent corruption vector.

## What it does

- New `src/pinky_daemon/store_catalog.py`: `StoreCatalog` / `StoreRecord` / `StoreCatalogError`. Records each store's realpath + `(st_dev, st_ino)` identity + **observed** `PRAGMA journal_mode` (the effective mode, not a declared literal) + owner + criticality.
- All 20 authoritative stores register at connection open.
- `validate()` (fail-loud, reports every violation at once) rejects: relative / unresolved / outside-expected-root paths; a logical name mapped to divergent paths; two different logical stores sharing one physical file without a shared owner identity; and journal-mode incoherence on a shared file. It uses resolved-path + inode identity, not string equality.
- `SessionStore` and `SessionEventStore` intentionally share the sessions DB under one explicit shared owner identity (both observe WAL); the physical split stays deferred.
- `journal_mode='memory'` (in-memory connections) is excluded from filesystem-root and physical-alias checks.
- `create_api` canonicalizes the base DB path, injects one fresh catalog, wires the two previously CWD-relative stores to explicit data-root paths, and calls `validate()` exactly once after the last store opens, immediately before returning the app. `StoreCatalogError` is logged loudly and re-raised — the daemon refuses to serve an incoherent layout.

## Scope / non-goals

Additive observe-and-validate only. No journal-policy change (that shipped in #1107), no repository/API seam, no path-ownership inversion, no snapshot tool — those are later increments.

## Tests

`tests/test_store_catalog.py` — red-first (collection failed before the module existed). Covers realpath canonicalization; inode identity via symlink; aliasing pass (shared file + identical mode + shared owner) and fail (divergent mode); relative / unresolved / outside-root rejections; duplicate-logical-name divergent path; two independent `:memory:` stores not false-aliasing; and a clean production-shaped layout passing.

Local verification: focused store/catalog matrix 572 passed; catalog suite 14 passed; bounded broad gate (`pytest -q --ignore=tests/test_api.py`) 4794 passed / 4 skipped; ruff clean. The known-slow `test_api` lane is left to CI as the terminal full-suite authority.

_No UI in this change — daemon + tests only, so no screenshot is attached._

🤖 Opened by barsik