### PR TITLE
feat(#619): StoreCatalog filesystem reconciliation (P0.1.1 structural coverage)

### DIFF
--- a/src/pinky_daemon/store_catalog.py
+++ b/src/pinky_daemon/store_catalog.py
@@ -57,7 +57,6 @@ class _FilesystemDatabase:
     relative_path: str
     resolved_path: str
     dev_ino: tuple[int, int]
-    warning_eligible: bool
 
 
 class StoreCatalog:
@@ -225,7 +224,9 @@ class StoreCatalog:
                 )
                 continue
 
-            if database.resolved_path in registered_realpaths or not database.warning_eligible:
+            if database.resolved_path in registered_realpaths or self._is_in_ignored_directory(
+                database.resolved_path
+            ):
                 continue
 
             matching_patterns = {
@@ -291,11 +292,12 @@ class StoreCatalog:
 
     def _enumerate_database_files(self) -> list[_FilesystemDatabase]:
         databases: list[_FilesystemDatabase] = []
-        pending_directories = [(self._expected_root, True)]
+        pending_directories = [self._expected_root]
+        # Alias-coverage cycle guard only; warning policy is derived from each file realpath.
         visited_directories: set[tuple[int, int]] = set()
 
         while pending_directories:
-            directory, warning_eligible = pending_directories.pop()
+            directory = pending_directories.pop()
             resolved_directory = os.path.realpath(directory)
             if not self._is_under_expected_root(resolved_directory):
                 raise StoreCatalogError(
@@ -323,7 +325,7 @@ class StoreCatalog:
             except OSError as exc:
                 self._raise_inspection_error("directory", directory, exc)
 
-            child_directories: list[tuple[str, bool]] = []
+            child_directories: list[str] = []
             for entry in entries:
                 discovered_path = entry.path
                 resolved_path = os.path.realpath(discovered_path)
@@ -339,12 +341,7 @@ class StoreCatalog:
                             f"directory symlink escapes expected root {self._expected_root!r}: "
                             f"path={discovered_path!r} resolved_path={resolved_path!r}"
                         )
-                    child_directories.append(
-                        (
-                            discovered_path,
-                            warning_eligible and not self._is_ignored_directory(entry.name),
-                        )
-                    )
+                    child_directories.append(discovered_path)
                     continue
 
                 if not entry.name.endswith(".db") or entry.name.endswith(_SQLITE_SIDECAR_SUFFIXES):
@@ -357,7 +354,7 @@ class StoreCatalog:
                     )
                 if not stat.S_ISREG(entry_stat.st_mode):
                     continue
-                relative_path = os.path.relpath(discovered_path, self._expected_root).replace(
+                relative_path = os.path.relpath(resolved_path, self._expected_root).replace(
                     os.sep, "/"
                 )
                 databases.append(
@@ -365,7 +362,6 @@ class StoreCatalog:
                         relative_path=relative_path,
                         resolved_path=resolved_path,
                         dev_ino=(entry_stat.st_dev, entry_stat.st_ino),
-                        warning_eligible=warning_eligible,
                     )
                 )
             pending_directories.extend(reversed(child_directories))
@@ -383,6 +379,11 @@ class StoreCatalog:
     def _is_ignored_directory(name: str) -> bool:
         tokens = [token for token in re.split(r"[._-]+", name.casefold()) if token]
         return any(token in _IGNORED_DIRECTORY_KINDS for token in tokens)
+
+    def _is_in_ignored_directory(self, resolved_path: str) -> bool:
+        relative_path = os.path.relpath(resolved_path, self._expected_root)
+        directory_names = relative_path.split(os.sep)[:-1]
+        return any(self._is_ignored_directory(name) for name in directory_names)
 
     @staticmethod
     def _allowlist_pattern_matches(pattern: str, relative_path: str) -> bool:

--- a/src/pinky_daemon/store_catalog.py
+++ b/src/pinky_daemon/store_catalog.py
@@ -57,6 +57,7 @@ class _FilesystemDatabase:
     relative_path: str
     resolved_path: str
     dev_ino: tuple[int, int]
+    warning_eligible: bool
 
 
 class StoreCatalog:
@@ -208,18 +209,12 @@ class StoreCatalog:
                     record.resolved_path
                 )
 
-        databases, warnings = self._enumerate_database_files()
+        databases = self._enumerate_database_files()
+        warnings: list[str] = []
         alias_violations: list[str] = []
         matched_allowlist_patterns: set[str] = set()
 
         for database in databases:
-            matching_patterns = {
-                pattern
-                for pattern in self._silence_allowlist
-                if self._allowlist_pattern_matches(pattern, database.relative_path)
-            }
-            matched_allowlist_patterns.update(matching_patterns)
-
             registered_inode_paths = registered_paths_by_inode.get(database.dev_ino, set())
             if registered_inode_paths and database.resolved_path not in registered_inode_paths:
                 alias_violations.append(
@@ -230,7 +225,16 @@ class StoreCatalog:
                 )
                 continue
 
-            if database.resolved_path in registered_realpaths or matching_patterns:
+            if database.resolved_path in registered_realpaths or not database.warning_eligible:
+                continue
+
+            matching_patterns = {
+                pattern
+                for pattern in self._silence_allowlist
+                if self._allowlist_pattern_matches(pattern, database.relative_path)
+            }
+            matched_allowlist_patterns.update(matching_patterns)
+            if matching_patterns:
                 continue
 
             warnings.append(
@@ -285,50 +289,95 @@ class StoreCatalog:
                     is_memory=record.is_memory,
                 )
 
-    def _enumerate_database_files(self) -> tuple[list[_FilesystemDatabase], list[str]]:
+    def _enumerate_database_files(self) -> list[_FilesystemDatabase]:
         databases: list[_FilesystemDatabase] = []
-        warnings: list[str] = []
+        pending_directories = [(self._expected_root, True)]
+        visited_directories: set[tuple[int, int]] = set()
 
-        def record_walk_error(exc: OSError) -> None:
-            warnings.append(
-                "could not inspect database directory: "
-                f"path={exc.filename!r} error={type(exc).__name__}: {exc}"
-            )
+        while pending_directories:
+            directory, warning_eligible = pending_directories.pop()
+            resolved_directory = os.path.realpath(directory)
+            if not self._is_under_expected_root(resolved_directory):
+                raise StoreCatalogError(
+                    "Store catalog filesystem alias coverage failed:\n- "
+                    f"directory symlink escapes expected root {self._expected_root!r}: "
+                    f"path={directory!r} resolved_path={resolved_directory!r}"
+                )
+            try:
+                directory_stat = os.stat(resolved_directory)
+            except OSError as exc:
+                self._raise_inspection_error("directory", directory, exc)
+            if not stat.S_ISDIR(directory_stat.st_mode):
+                raise StoreCatalogError(
+                    "Store catalog filesystem alias coverage failed:\n- "
+                    f"database traversal path is not a directory: path={directory!r}"
+                )
+            directory_identity = (directory_stat.st_dev, directory_stat.st_ino)
+            if directory_identity in visited_directories:
+                continue
+            visited_directories.add(directory_identity)
 
-        for directory, subdirectories, filenames in os.walk(
-            self._expected_root,
-            followlinks=False,
-            onerror=record_walk_error,
-        ):
-            subdirectories[:] = sorted(
-                name for name in subdirectories if not self._is_ignored_directory(name)
-            )
-            for filename in sorted(filenames):
-                if not filename.endswith(".db") or filename.endswith(_SQLITE_SIDECAR_SUFFIXES):
+            try:
+                with os.scandir(resolved_directory) as iterator:
+                    entries = sorted(iterator, key=lambda entry: entry.name)
+            except OSError as exc:
+                self._raise_inspection_error("directory", directory, exc)
+
+            child_directories: list[tuple[str, bool]] = []
+            for entry in entries:
+                discovered_path = entry.path
+                resolved_path = os.path.realpath(discovered_path)
+                try:
+                    entry_stat = os.stat(resolved_path)
+                except OSError as exc:
+                    self._raise_inspection_error("file or directory", discovered_path, exc)
+
+                if stat.S_ISDIR(entry_stat.st_mode):
+                    if not self._is_under_expected_root(resolved_path):
+                        raise StoreCatalogError(
+                            "Store catalog filesystem alias coverage failed:\n- "
+                            f"directory symlink escapes expected root {self._expected_root!r}: "
+                            f"path={discovered_path!r} resolved_path={resolved_path!r}"
+                        )
+                    child_directories.append(
+                        (
+                            discovered_path,
+                            warning_eligible and not self._is_ignored_directory(entry.name),
+                        )
+                    )
                     continue
-                discovered_path = os.path.join(directory, filename)
+
+                if not entry.name.endswith(".db") or entry.name.endswith(_SQLITE_SIDECAR_SUFFIXES):
+                    continue
+                if not self._is_under_expected_root(resolved_path):
+                    raise StoreCatalogError(
+                        "Store catalog filesystem alias coverage failed:\n- "
+                        f"database symlink escapes expected root {self._expected_root!r}: "
+                        f"path={discovered_path!r} resolved_path={resolved_path!r}"
+                    )
+                if not stat.S_ISREG(entry_stat.st_mode):
+                    continue
                 relative_path = os.path.relpath(discovered_path, self._expected_root).replace(
                     os.sep, "/"
                 )
-                resolved_path = os.path.realpath(discovered_path)
-                try:
-                    file_stat = os.stat(resolved_path)
-                except OSError as exc:
-                    warnings.append(
-                        "could not inspect database file: "
-                        f"path={relative_path!r} error={type(exc).__name__}: {exc}"
-                    )
-                    continue
-                if not stat.S_ISREG(file_stat.st_mode):
-                    continue
                 databases.append(
                     _FilesystemDatabase(
                         relative_path=relative_path,
                         resolved_path=resolved_path,
-                        dev_ino=(file_stat.st_dev, file_stat.st_ino),
+                        dev_ino=(entry_stat.st_dev, entry_stat.st_ino),
+                        warning_eligible=warning_eligible,
                     )
                 )
-        return databases, warnings
+            pending_directories.extend(reversed(child_directories))
+        return databases
+
+    @staticmethod
+    def _raise_inspection_error(kind: str, path: str, exc: OSError) -> None:
+        raise StoreCatalogError(
+            "Store catalog filesystem alias coverage failed:\n- "
+            f"could not inspect database {kind}: path={path!r} "
+            f"error={type(exc).__name__}: {exc}"
+        ) from exc
 
     @staticmethod
     def _is_ignored_directory(name: str) -> bool:

--- a/src/pinky_daemon/store_catalog.py
+++ b/src/pinky_daemon/store_catalog.py
@@ -193,9 +193,11 @@ class StoreCatalog:
         """Reconcile registered stores with SQLite files found below the data root.
 
         A distinct path sharing a registered store's inode is unsafe and fails
-        closed. Standalone unclaimed databases and stale warning suppressions are
-        surfaced as warnings so inventory drift cannot remain invisible or brick
-        an otherwise safe boot.
+        closed. Inspection failures within a registered store's path footprint
+        also fail closed; unrelated unreadable paths warn instead. Standalone
+        unclaimed databases and stale warning suppressions are surfaced as
+        warnings so inventory drift cannot remain invisible or brick an otherwise
+        safe boot.
         """
         with self._lock:
             self._refresh_identities()
@@ -209,8 +211,7 @@ class StoreCatalog:
                     record.resolved_path
                 )
 
-        databases = self._enumerate_database_files()
-        warnings: list[str] = []
+        databases, warnings = self._enumerate_database_files(registered_realpaths)
         alias_violations: list[str] = []
         matched_allowlist_patterns: set[str] = set()
 
@@ -291,8 +292,11 @@ class StoreCatalog:
                     is_memory=record.is_memory,
                 )
 
-    def _enumerate_database_files(self) -> list[_FilesystemDatabase]:
+    def _enumerate_database_files(
+        self, registered_realpaths: set[str]
+    ) -> tuple[list[_FilesystemDatabase], list[str]]:
         databases: list[_FilesystemDatabase] = []
+        warnings: list[str] = []
         pending_directories = [self._expected_root]
         # Alias-coverage cycle guard only; warning policy is derived from each file realpath.
         visited_directories: set[tuple[int, int]] = set()
@@ -304,23 +308,41 @@ class StoreCatalog:
             except OSError as exc:
                 if self._is_missing_path_error(exc):
                     continue
-                self._raise_inspection_error("directory", directory, exc)
-            if not self._is_under_expected_root(resolved_directory):
-                raise StoreCatalogError(
-                    "Store catalog filesystem alias coverage failed:\n- "
-                    f"directory symlink escapes expected root {self._expected_root!r}: "
-                    f"path={directory!r} resolved_path={resolved_directory!r}"
+                self._warn_or_raise_inspection_error(
+                    "directory",
+                    directory,
+                    exc,
+                    footprint_path=os.path.abspath(directory),
+                    registered_realpaths=registered_realpaths,
+                    warnings=warnings,
                 )
+                continue
             try:
                 directory_stat = os.stat(resolved_directory)
             except OSError as exc:
                 if self._is_missing_path_error(exc):
                     continue
-                self._raise_inspection_error("directory", directory, exc)
+                self._warn_or_raise_inspection_error(
+                    "directory",
+                    directory,
+                    exc,
+                    footprint_path=resolved_directory,
+                    registered_realpaths=registered_realpaths,
+                    warnings=warnings,
+                )
+                continue
             if not stat.S_ISDIR(directory_stat.st_mode):
+                database = self._filesystem_database_for_path(
+                    directory, resolved_directory, directory_stat
+                )
+                if database is not None:
+                    databases.append(database)
+                continue
+            if not self._is_under_expected_root(resolved_directory):
                 raise StoreCatalogError(
                     "Store catalog filesystem alias coverage failed:\n- "
-                    f"database traversal path is not a directory: path={directory!r}"
+                    f"directory symlink escapes expected root {self._expected_root!r}: "
+                    f"path={directory!r} resolved_path={resolved_directory!r}"
                 )
             directory_identity = (directory_stat.st_dev, directory_stat.st_ino)
             if directory_identity in visited_directories:
@@ -333,7 +355,15 @@ class StoreCatalog:
             except OSError as exc:
                 if self._is_missing_path_error(exc):
                     continue
-                self._raise_inspection_error("directory", directory, exc)
+                self._warn_or_raise_inspection_error(
+                    "directory",
+                    directory,
+                    exc,
+                    footprint_path=resolved_directory,
+                    registered_realpaths=registered_realpaths,
+                    warnings=warnings,
+                )
+                continue
 
             child_directories: list[str] = []
             for entry in entries:
@@ -343,13 +373,29 @@ class StoreCatalog:
                 except OSError as exc:
                     if self._is_missing_path_error(exc):
                         continue
-                    self._raise_inspection_error("file or directory", discovered_path, exc)
+                    self._warn_or_raise_inspection_error(
+                        "file or directory",
+                        discovered_path,
+                        exc,
+                        footprint_path=os.path.abspath(discovered_path),
+                        registered_realpaths=registered_realpaths,
+                        warnings=warnings,
+                    )
+                    continue
                 try:
                     entry_stat = os.stat(resolved_path)
                 except OSError as exc:
                     if self._is_missing_path_error(exc):
                         continue
-                    self._raise_inspection_error("file or directory", discovered_path, exc)
+                    self._warn_or_raise_inspection_error(
+                        "file or directory",
+                        discovered_path,
+                        exc,
+                        footprint_path=resolved_path,
+                        registered_realpaths=registered_realpaths,
+                        warnings=warnings,
+                    )
+                    continue
 
                 if stat.S_ISDIR(entry_stat.st_mode):
                     if not self._is_under_expected_root(resolved_path):
@@ -361,28 +407,65 @@ class StoreCatalog:
                     child_directories.append(discovered_path)
                     continue
 
-                if not entry.name.endswith(".db") or entry.name.endswith(_SQLITE_SIDECAR_SUFFIXES):
-                    continue
-                if not self._is_under_expected_root(resolved_path):
-                    raise StoreCatalogError(
-                        "Store catalog filesystem alias coverage failed:\n- "
-                        f"database symlink escapes expected root {self._expected_root!r}: "
-                        f"path={discovered_path!r} resolved_path={resolved_path!r}"
-                    )
-                if not stat.S_ISREG(entry_stat.st_mode):
-                    continue
-                relative_path = os.path.relpath(resolved_path, self._expected_root).replace(
-                    os.sep, "/"
+                database = self._filesystem_database_for_path(
+                    discovered_path, resolved_path, entry_stat
                 )
-                databases.append(
-                    _FilesystemDatabase(
-                        relative_path=relative_path,
-                        resolved_path=resolved_path,
-                        dev_ino=(entry_stat.st_dev, entry_stat.st_ino),
-                    )
-                )
+                if database is not None:
+                    databases.append(database)
             pending_directories.extend(reversed(child_directories))
-        return databases
+        return databases, warnings
+
+    def _filesystem_database_for_path(
+        self,
+        discovered_path: str,
+        resolved_path: str,
+        path_stat: os.stat_result,
+    ) -> _FilesystemDatabase | None:
+        name = os.path.basename(discovered_path)
+        if not name.endswith(".db") or name.endswith(_SQLITE_SIDECAR_SUFFIXES):
+            return None
+        if not self._is_under_expected_root(resolved_path):
+            raise StoreCatalogError(
+                "Store catalog filesystem alias coverage failed:\n- "
+                f"database symlink escapes expected root {self._expected_root!r}: "
+                f"path={discovered_path!r} resolved_path={resolved_path!r}"
+            )
+        if not stat.S_ISREG(path_stat.st_mode):
+            return None
+        relative_path = os.path.relpath(resolved_path, self._expected_root).replace(os.sep, "/")
+        return _FilesystemDatabase(
+            relative_path=relative_path,
+            resolved_path=resolved_path,
+            dev_ino=(path_stat.st_dev, path_stat.st_ino),
+        )
+
+    def _warn_or_raise_inspection_error(
+        self,
+        kind: str,
+        path: str,
+        exc: OSError,
+        *,
+        footprint_path: str,
+        registered_realpaths: set[str],
+        warnings: list[str],
+    ) -> None:
+        if self._registered_store_at_or_under(footprint_path, registered_realpaths):
+            self._raise_inspection_error(kind, path, exc)
+        warnings.append(
+            f"could not inspect database {kind} outside registered store footprint; "
+            f"skipping: path={path!r} error={type(exc).__name__}: {exc}"
+        )
+
+    @staticmethod
+    def _registered_store_at_or_under(path: str, registered_realpaths: set[str]) -> bool:
+        normalized_path = os.path.normpath(path)
+        path_prefix = (
+            normalized_path if normalized_path.endswith(os.sep) else normalized_path + os.sep
+        )
+        return any(
+            store_path == normalized_path or store_path.startswith(path_prefix)
+            for store_path in registered_realpaths
+        )
 
     @staticmethod
     def _raise_inspection_error(kind: str, path: str, exc: OSError) -> None:

--- a/src/pinky_daemon/store_catalog.py
+++ b/src/pinky_daemon/store_catalog.py
@@ -2,10 +2,31 @@
 
 from __future__ import annotations
 
+import fnmatch
+import logging
 import os
+import re
+import stat
 import threading
+from collections.abc import Mapping
 from dataclasses import dataclass
 from urllib.parse import parse_qsl
+
+logger = logging.getLogger("pinky.store_catalog")
+
+
+DEFAULT_FILESYSTEM_SILENCE_ALLOWLIST: dict[str, str] = {
+    "hub.db": "pinky_hub component store; not owned by the API daemon",
+    "pinky.db": "poll-mode --mode daemon base; unused in API mode",
+    "pinkybot.db": "legacy daemon base; not owned by the current API daemon",
+    "daemon.db": "zero-byte legacy daemon orphan; pending operator cleanup",
+    "messages.db": "zero-byte legacy message-store orphan; pending operator cleanup",
+    "pinky_daemon.db": "zero-byte legacy API-daemon orphan; pending operator cleanup",
+    "scheduler.db": "zero-byte legacy scheduler orphan; pending operator cleanup",
+}
+
+_SQLITE_SIDECAR_SUFFIXES = ("-wal", "-shm", "-journal")
+_IGNORED_DIRECTORY_KINDS = frozenset({"snapshot", "snapshots", "temp", "temporary", "tmp"})
 
 
 @dataclass(frozen=True, slots=True)
@@ -31,12 +52,28 @@ class _CatalogEntry:
     used_relative_path: bool
 
 
+@dataclass(frozen=True, slots=True)
+class _FilesystemDatabase:
+    relative_path: str
+    resolved_path: str
+    dev_ino: tuple[int, int]
+
+
 class StoreCatalog:
     """Observe store connection policy and reject an incoherent boot layout."""
 
-    def __init__(self, expected_root: str | os.PathLike[str] | None = None) -> None:
+    def __init__(
+        self,
+        expected_root: str | os.PathLike[str] | None = None,
+        *,
+        silence_allowlist: Mapping[str, str] | None = None,
+    ) -> None:
         root = os.getcwd() if expected_root is None else os.fspath(expected_root)
         self._expected_root = os.path.realpath(root)
+        configured_allowlist = (
+            DEFAULT_FILESYSTEM_SILENCE_ALLOWLIST if silence_allowlist is None else silence_allowlist
+        )
+        self._silence_allowlist = dict(configured_allowlist)
         self._entries: list[_CatalogEntry] = []
         self._lock = threading.RLock()
 
@@ -90,8 +127,8 @@ class StoreCatalog:
                 )
             )
 
-    def validate(self) -> None:
-        """Raise when registered stores do not form one coherent layout."""
+    def validate(self) -> list[str]:
+        """Raise for an unsafe layout and return filesystem hygiene warnings."""
         with self._lock:
             self._refresh_identities()
             entries = list(self._entries)
@@ -149,6 +186,76 @@ class StoreCatalog:
                 "Store catalog validation failed:\n- " + "\n- ".join(violations)
             )
 
+        return self.reconcile_filesystem()
+
+    def reconcile_filesystem(self) -> list[str]:
+        """Reconcile registered stores with SQLite files found below the data root.
+
+        A distinct path sharing a registered store's inode is unsafe and fails
+        closed. Standalone unclaimed databases and stale warning suppressions are
+        surfaced as warnings so inventory drift cannot remain invisible or brick
+        an otherwise safe boot.
+        """
+        with self._lock:
+            self._refresh_identities()
+            records = [entry.record for entry in self._entries if not entry.record.is_memory]
+
+        registered_realpaths = {record.resolved_path for record in records}
+        registered_paths_by_inode: dict[tuple[int, int], set[str]] = {}
+        for record in records:
+            if record.dev_ino is not None:
+                registered_paths_by_inode.setdefault(record.dev_ino, set()).add(
+                    record.resolved_path
+                )
+
+        databases, warnings = self._enumerate_database_files()
+        alias_violations: list[str] = []
+        matched_allowlist_patterns: set[str] = set()
+
+        for database in databases:
+            matching_patterns = {
+                pattern
+                for pattern in self._silence_allowlist
+                if self._allowlist_pattern_matches(pattern, database.relative_path)
+            }
+            matched_allowlist_patterns.update(matching_patterns)
+
+            registered_inode_paths = registered_paths_by_inode.get(database.dev_ino, set())
+            if registered_inode_paths and database.resolved_path not in registered_inode_paths:
+                alias_violations.append(
+                    "unregistered path aliases registered store inode: "
+                    f"path={database.relative_path!r} resolved_path={database.resolved_path!r} "
+                    f"dev_ino={database.dev_ino!r} "
+                    f"registered_realpaths={sorted(registered_inode_paths)!r}"
+                )
+                continue
+
+            if database.resolved_path in registered_realpaths or matching_patterns:
+                continue
+
+            warnings.append(
+                "unclaimed database file: "
+                f"path={database.relative_path!r} resolved_path={database.resolved_path!r} "
+                f"dev_ino={database.dev_ino!r}"
+            )
+
+        if alias_violations:
+            raise StoreCatalogError(
+                "Store catalog filesystem reconciliation failed:\n- "
+                + "\n- ".join(alias_violations)
+            )
+
+        for pattern, reason in self._silence_allowlist.items():
+            if pattern not in matched_allowlist_patterns:
+                warnings.append(
+                    f"dead silence-allowlist entry {pattern!r} matched no database files "
+                    f"(reason: {reason})"
+                )
+
+        for warning in warnings:
+            logger.warning("STORE CATALOG WARNING: %s", warning)
+        return warnings
+
     def snapshot(self) -> list[StoreRecord]:
         """Return the current canonical records in registration order."""
         with self._lock:
@@ -177,6 +284,62 @@ class StoreCatalog:
                     dev_ino=dev_ino,
                     is_memory=record.is_memory,
                 )
+
+    def _enumerate_database_files(self) -> tuple[list[_FilesystemDatabase], list[str]]:
+        databases: list[_FilesystemDatabase] = []
+        warnings: list[str] = []
+
+        def record_walk_error(exc: OSError) -> None:
+            warnings.append(
+                "could not inspect database directory: "
+                f"path={exc.filename!r} error={type(exc).__name__}: {exc}"
+            )
+
+        for directory, subdirectories, filenames in os.walk(
+            self._expected_root,
+            followlinks=False,
+            onerror=record_walk_error,
+        ):
+            subdirectories[:] = sorted(
+                name for name in subdirectories if not self._is_ignored_directory(name)
+            )
+            for filename in sorted(filenames):
+                if not filename.endswith(".db") or filename.endswith(_SQLITE_SIDECAR_SUFFIXES):
+                    continue
+                discovered_path = os.path.join(directory, filename)
+                relative_path = os.path.relpath(discovered_path, self._expected_root).replace(
+                    os.sep, "/"
+                )
+                resolved_path = os.path.realpath(discovered_path)
+                try:
+                    file_stat = os.stat(resolved_path)
+                except OSError as exc:
+                    warnings.append(
+                        "could not inspect database file: "
+                        f"path={relative_path!r} error={type(exc).__name__}: {exc}"
+                    )
+                    continue
+                if not stat.S_ISREG(file_stat.st_mode):
+                    continue
+                databases.append(
+                    _FilesystemDatabase(
+                        relative_path=relative_path,
+                        resolved_path=resolved_path,
+                        dev_ino=(file_stat.st_dev, file_stat.st_ino),
+                    )
+                )
+        return databases, warnings
+
+    @staticmethod
+    def _is_ignored_directory(name: str) -> bool:
+        tokens = [token for token in re.split(r"[._-]+", name.casefold()) if token]
+        return any(token in _IGNORED_DIRECTORY_KINDS for token in tokens)
+
+    @staticmethod
+    def _allowlist_pattern_matches(pattern: str, relative_path: str) -> bool:
+        normalized_pattern = pattern.replace(os.sep, "/")
+        candidate = relative_path if "/" in normalized_pattern else os.path.basename(relative_path)
+        return fnmatch.fnmatchcase(candidate, normalized_pattern)
 
     @staticmethod
     def _is_memory_path(raw_path: str) -> bool:

--- a/src/pinky_daemon/store_catalog.py
+++ b/src/pinky_daemon/store_catalog.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import errno
 import fnmatch
 import logging
 import os
@@ -298,7 +299,12 @@ class StoreCatalog:
 
         while pending_directories:
             directory = pending_directories.pop()
-            resolved_directory = os.path.realpath(directory)
+            try:
+                resolved_directory = os.path.realpath(directory)
+            except OSError as exc:
+                if self._is_missing_path_error(exc):
+                    continue
+                self._raise_inspection_error("directory", directory, exc)
             if not self._is_under_expected_root(resolved_directory):
                 raise StoreCatalogError(
                     "Store catalog filesystem alias coverage failed:\n- "
@@ -308,6 +314,8 @@ class StoreCatalog:
             try:
                 directory_stat = os.stat(resolved_directory)
             except OSError as exc:
+                if self._is_missing_path_error(exc):
+                    continue
                 self._raise_inspection_error("directory", directory, exc)
             if not stat.S_ISDIR(directory_stat.st_mode):
                 raise StoreCatalogError(
@@ -323,15 +331,24 @@ class StoreCatalog:
                 with os.scandir(resolved_directory) as iterator:
                     entries = sorted(iterator, key=lambda entry: entry.name)
             except OSError as exc:
+                if self._is_missing_path_error(exc):
+                    continue
                 self._raise_inspection_error("directory", directory, exc)
 
             child_directories: list[str] = []
             for entry in entries:
                 discovered_path = entry.path
-                resolved_path = os.path.realpath(discovered_path)
+                try:
+                    resolved_path = os.path.realpath(discovered_path)
+                except OSError as exc:
+                    if self._is_missing_path_error(exc):
+                        continue
+                    self._raise_inspection_error("file or directory", discovered_path, exc)
                 try:
                     entry_stat = os.stat(resolved_path)
                 except OSError as exc:
+                    if self._is_missing_path_error(exc):
+                        continue
                     self._raise_inspection_error("file or directory", discovered_path, exc)
 
                 if stat.S_ISDIR(entry_stat.st_mode):
@@ -374,6 +391,10 @@ class StoreCatalog:
             f"could not inspect database {kind}: path={path!r} "
             f"error={type(exc).__name__}: {exc}"
         ) from exc
+
+    @staticmethod
+    def _is_missing_path_error(exc: OSError) -> bool:
+        return isinstance(exc, FileNotFoundError) or exc.errno == errno.ENOENT
 
     @staticmethod
     def _is_ignored_directory(name: str) -> bool:

--- a/tests/test_store_catalog.py
+++ b/tests/test_store_catalog.py
@@ -332,7 +332,7 @@ def test_reconcile_rejects_unregistered_hardlink_to_registered_store(tmp_path: P
     _register(catalog, "tasks", registered, owner="TaskStore")
 
     with pytest.raises(StoreCatalogError, match="unregistered path aliases registered store inode"):
-        catalog.reconcile_filesystem()
+        catalog.validate()
 
 
 def test_reconcile_warns_for_unclaimed_file_without_failing(
@@ -342,7 +342,7 @@ def test_reconcile_warns_for_unclaimed_file_without_failing(
     orphan.touch()
     catalog = StoreCatalog(expected_root=tmp_path, silence_allowlist={})
 
-    warnings = catalog.reconcile_filesystem()
+    warnings = catalog.validate()
 
     assert len(warnings) == 1
     assert "unclaimed database file" in warnings[0]
@@ -387,7 +387,7 @@ def test_reconcile_excludes_sidecars_and_temp_snapshot_directories(tmp_path: Pat
     registered.touch()
     for suffix in ("-wal", "-shm", "-journal"):
         (tmp_path / f"tasks.db{suffix}").touch()
-    for directory_name in ("tmp", "snapshots"):
+    for directory_name in ("tmp", "snapshots", "pre-migration-snapshot"):
         ignored_dir = tmp_path / directory_name
         ignored_dir.mkdir()
         (ignored_dir / "ignored.db").touch()

--- a/tests/test_store_catalog.py
+++ b/tests/test_store_catalog.py
@@ -409,7 +409,7 @@ def test_reconcile_rejects_alias_behind_symlinked_directory(tmp_path: Path) -> N
     catalog = StoreCatalog(expected_root=expected_root, silence_allowlist={})
     _register(catalog, "tasks", registered, owner="TaskStore")
 
-    with pytest.raises(StoreCatalogError):
+    with pytest.raises(StoreCatalogError, match="directory symlink escapes expected root"):
         catalog.validate()
 
 

--- a/tests/test_store_catalog.py
+++ b/tests/test_store_catalog.py
@@ -254,7 +254,6 @@ def test_clean_production_shaped_layout_passes(tmp_path: Path) -> None:
         "voice": ("wal", "VoiceStore"),
         "audit": ("wal", "AuditStore"),
         "message_context": ("wal", "MessageContextStore"),
-        "kb": ("wal", "KBStore"),
         "dream_state": ("wal", "DreamRunner"),
     }
     for logical_name, (journal_mode, owner) in stores.items():
@@ -268,13 +267,29 @@ def test_clean_production_shaped_layout_passes(tmp_path: Path) -> None:
             owner=owner,
         )
 
+    kb_path = tmp_path / "kb" / "kb.db"
+    kb_path.parent.mkdir()
+    kb_path.touch()
+    _register(catalog, "kb", kb_path, owner="KBStore")
+
     sessions_path = tmp_path / "sessions.db"
     sessions_path.touch()
     session_owner = "SessionStore+SessionEventStore"
     _register(catalog, "sessions", sessions_path, owner=session_owner)
     _register(catalog, "session_events", sessions_path, owner=session_owner)
 
-    catalog.validate()
+    for allowlisted_name in (
+        "hub.db",
+        "pinky.db",
+        "pinkybot.db",
+        "daemon.db",
+        "messages.db",
+        "pinky_daemon.db",
+        "scheduler.db",
+    ):
+        (tmp_path / allowlisted_name).touch()
+
+    assert catalog.validate() == []
 
 
 def test_symlink_and_target_are_detected_as_same_inode(tmp_path: Path) -> None:
@@ -306,6 +321,100 @@ def test_hardlinks_are_detected_as_same_inode(tmp_path: Path) -> None:
     assert records[0].dev_ino == records[1].dev_ino
     with pytest.raises(StoreCatalogError, match="same physical file"):
         catalog.validate()
+
+
+def test_reconcile_rejects_unregistered_hardlink_to_registered_store(tmp_path: Path) -> None:
+    registered = tmp_path / "tasks.db"
+    registered.touch()
+    allowlisted_alias = tmp_path / "hub.db"
+    os.link(registered, allowlisted_alias)
+    catalog = StoreCatalog(expected_root=tmp_path)
+    _register(catalog, "tasks", registered, owner="TaskStore")
+
+    with pytest.raises(StoreCatalogError, match="unregistered path aliases registered store inode"):
+        catalog.reconcile_filesystem()
+
+
+def test_reconcile_warns_for_unclaimed_file_without_failing(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    orphan = tmp_path / "orphan.db"
+    orphan.touch()
+    catalog = StoreCatalog(expected_root=tmp_path, silence_allowlist={})
+
+    warnings = catalog.reconcile_filesystem()
+
+    assert len(warnings) == 1
+    assert "unclaimed database file" in warnings[0]
+    assert os.path.realpath(orphan) in warnings[0]
+    assert warnings[0] in caplog.text
+
+
+def test_reconcile_silences_allowlisted_unclaimed_file(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    nested = tmp_path / "component"
+    nested.mkdir()
+    (nested / "known-benign.db").touch()
+    catalog = StoreCatalog(
+        expected_root=tmp_path,
+        silence_allowlist={"known-*.db": "fixture owned by another component"},
+    )
+
+    assert catalog.reconcile_filesystem() == []
+    assert "STORE CATALOG WARNING" not in caplog.text
+
+
+def test_reconcile_warns_for_dead_silence_allowlist_entry(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    catalog = StoreCatalog(
+        expected_root=tmp_path,
+        silence_allowlist={"missing-*.db": "obsolete fixture"},
+    )
+
+    warnings = catalog.reconcile_filesystem()
+
+    assert len(warnings) == 1
+    assert "dead silence-allowlist entry" in warnings[0]
+    assert "missing-*.db" in warnings[0]
+    assert "obsolete fixture" in warnings[0]
+    assert warnings[0] in caplog.text
+
+
+def test_reconcile_excludes_sidecars_and_temp_snapshot_directories(tmp_path: Path) -> None:
+    registered = tmp_path / "tasks.db"
+    registered.touch()
+    for suffix in ("-wal", "-shm", "-journal"):
+        (tmp_path / f"tasks.db{suffix}").touch()
+    for directory_name in ("tmp", "snapshots"):
+        ignored_dir = tmp_path / directory_name
+        ignored_dir.mkdir()
+        (ignored_dir / "ignored.db").touch()
+    catalog = StoreCatalog(expected_root=tmp_path, silence_allowlist={})
+    _register(catalog, "tasks", registered, owner="TaskStore")
+
+    assert catalog.reconcile_filesystem() == []
+
+
+def test_reconcile_recognizes_nested_kb_store_as_claimed(tmp_path: Path) -> None:
+    kb_dir = tmp_path / "kb"
+    kb_dir.mkdir()
+    kb_path = kb_dir / "kb.db"
+    kb_path.touch()
+    catalog = StoreCatalog(expected_root=tmp_path, silence_allowlist={})
+    _register(catalog, "kb", kb_path, owner="KBStore")
+
+    assert catalog.reconcile_filesystem() == []
+
+
+def test_reconcile_does_not_flag_registered_store_file(tmp_path: Path) -> None:
+    registered = tmp_path / "tasks.db"
+    registered.touch()
+    catalog = StoreCatalog(expected_root=tmp_path, silence_allowlist={})
+    _register(catalog, "tasks", registered, owner="TaskStore")
+
+    assert catalog.reconcile_filesystem() == []
 
 
 def test_agent_comms_participates_in_alias_validation(tmp_path: Path) -> None:

--- a/tests/test_store_catalog.py
+++ b/tests/test_store_catalog.py
@@ -397,6 +397,35 @@ def test_reconcile_excludes_sidecars_and_temp_snapshot_directories(tmp_path: Pat
     assert catalog.reconcile_filesystem() == []
 
 
+def test_reconcile_warns_for_normal_orphan_reached_first_through_snapshot_symlink(
+    tmp_path: Path,
+) -> None:
+    normal_dir = tmp_path / "zzz-data"
+    normal_dir.mkdir()
+    orphan = normal_dir / "orphan.db"
+    orphan.touch()
+    (tmp_path / "snapshots").symlink_to(normal_dir, target_is_directory=True)
+    catalog = StoreCatalog(expected_root=tmp_path, silence_allowlist={})
+
+    warnings = catalog.validate()
+
+    assert len(warnings) == 1
+    assert "path='zzz-data/orphan.db'" in warnings[0]
+    assert os.path.realpath(orphan) in warnings[0]
+
+
+def test_reconcile_quiets_snapshot_orphan_reached_first_through_normal_symlink(
+    tmp_path: Path,
+) -> None:
+    snapshot_dir = tmp_path / "snapshots"
+    snapshot_dir.mkdir()
+    (snapshot_dir / "orphan.db").touch()
+    (tmp_path / "aaa-link").symlink_to(snapshot_dir, target_is_directory=True)
+    catalog = StoreCatalog(expected_root=tmp_path, silence_allowlist={})
+
+    assert catalog.validate() == []
+
+
 def test_reconcile_rejects_alias_behind_symlinked_directory(tmp_path: Path) -> None:
     expected_root = tmp_path / "data"
     expected_root.mkdir()

--- a/tests/test_store_catalog.py
+++ b/tests/test_store_catalog.py
@@ -397,6 +397,70 @@ def test_reconcile_excludes_sidecars_and_temp_snapshot_directories(tmp_path: Pat
     assert catalog.reconcile_filesystem() == []
 
 
+def test_reconcile_rejects_alias_behind_symlinked_directory(tmp_path: Path) -> None:
+    expected_root = tmp_path / "data"
+    expected_root.mkdir()
+    registered = expected_root / "tasks.db"
+    registered.touch()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    os.link(registered, outside / "alias.db")
+    (expected_root / "linked").symlink_to(outside, target_is_directory=True)
+    catalog = StoreCatalog(expected_root=expected_root, silence_allowlist={})
+    _register(catalog, "tasks", registered, owner="TaskStore")
+
+    with pytest.raises(StoreCatalogError):
+        catalog.validate()
+
+
+def test_reconcile_rejects_alias_in_snapshot_directory(tmp_path: Path) -> None:
+    registered = tmp_path / "tasks.db"
+    registered.touch()
+    snapshot_dir = tmp_path / "snapshots"
+    snapshot_dir.mkdir()
+    os.link(registered, snapshot_dir / "alias.db")
+    catalog = StoreCatalog(expected_root=tmp_path, silence_allowlist={})
+    _register(catalog, "tasks", registered, owner="TaskStore")
+
+    with pytest.raises(StoreCatalogError, match="unregistered path aliases registered store inode"):
+        catalog.validate()
+
+
+def test_reconcile_fails_closed_when_directory_cannot_be_inspected(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    registered = tmp_path / "tasks.db"
+    registered.touch()
+    unreadable = tmp_path / "unreadable"
+    unreadable.mkdir()
+    os.link(registered, unreadable / "alias.db")
+    catalog = StoreCatalog(expected_root=tmp_path, silence_allowlist={})
+    _register(catalog, "tasks", registered, owner="TaskStore")
+    original_scandir = os.scandir
+
+    def deny_unreadable(path: str | os.PathLike[str]) -> os.ScandirIterator[str]:
+        if os.path.realpath(path) == os.path.realpath(unreadable):
+            raise PermissionError("test directory is unreadable")
+        return original_scandir(path)
+
+    monkeypatch.setattr(os, "scandir", deny_unreadable)
+
+    with pytest.raises(StoreCatalogError, match="could not inspect database directory"):
+        catalog.validate()
+
+
+def test_reconcile_symlink_cycle_terminates_cleanly(tmp_path: Path) -> None:
+    registered = tmp_path / "tasks.db"
+    registered.touch()
+    nested = tmp_path / "nested"
+    nested.mkdir()
+    (nested / "loop").symlink_to(tmp_path, target_is_directory=True)
+    catalog = StoreCatalog(expected_root=tmp_path, silence_allowlist={})
+    _register(catalog, "tasks", registered, owner="TaskStore")
+
+    assert catalog.validate() == []
+
+
 def test_reconcile_recognizes_nested_kb_store_as_claimed(tmp_path: Path) -> None:
     kb_dir = tmp_path / "kb"
     kb_dir.mkdir()

--- a/tests/test_store_catalog.py
+++ b/tests/test_store_catalog.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import stat
 from pathlib import Path
 
 import pytest
@@ -489,27 +490,119 @@ def test_reconcile_rejects_alias_in_snapshot_directory(tmp_path: Path) -> None:
         catalog.validate()
 
 
-def test_reconcile_fails_closed_when_directory_cannot_be_inspected(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+def test_unreadable_unrelated_dir_warns_not_fails(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
 ) -> None:
     registered = tmp_path / "tasks.db"
     registered.touch()
     unreadable = tmp_path / "unreadable"
     unreadable.mkdir()
-    os.link(registered, unreadable / "alias.db")
     catalog = StoreCatalog(expected_root=tmp_path, silence_allowlist={})
     _register(catalog, "tasks", registered, owner="TaskStore")
-    original_scandir = os.scandir
 
-    def deny_unreadable(path: str | os.PathLike[str]) -> os.ScandirIterator[str]:
-        if os.path.realpath(path) == os.path.realpath(unreadable):
-            raise PermissionError("test directory is unreadable")
-        return original_scandir(path)
+    unreadable.chmod(0o000)
+    try:
+        warnings = catalog.validate()
+    finally:
+        unreadable.chmod(0o755)
 
-    monkeypatch.setattr(os, "scandir", deny_unreadable)
+    assert len(warnings) == 1
+    assert "could not inspect database directory" in warnings[0]
+    assert "outside registered store footprint" in warnings[0]
+    assert os.fspath(unreadable) in warnings[0]
+    assert warnings[0] in caplog.text
+
+
+def test_unreadable_store_footprint_dir_fails_closed(tmp_path: Path) -> None:
+    unreadable = tmp_path / "unreadable"
+    unreadable.mkdir()
+    registered = unreadable / "tasks.db"
+    registered.touch()
+    catalog = StoreCatalog(expected_root=tmp_path, silence_allowlist={})
+    _register(catalog, "tasks", registered, owner="TaskStore")
+
+    unreadable.chmod(0o000)
+    try:
+        with pytest.raises(StoreCatalogError, match="could not inspect database directory"):
+            catalog.validate()
+    finally:
+        unreadable.chmod(0o755)
+
+
+def test_traversal_non_directory_entry_skipped(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    registered = tmp_path / "tasks.db"
+    registered.touch()
+    raced_file = tmp_path / "raced.db"
+    raced_file.touch()
+    catalog = StoreCatalog(expected_root=tmp_path, silence_allowlist={})
+    _register(catalog, "tasks", registered, owner="TaskStore")
+    original_stat = os.stat
+    raced_file_stat_calls = 0
+
+    def directory_then_file(
+        path: str | os.PathLike[str], *args: object, **kwargs: object
+    ) -> os.stat_result:
+        nonlocal raced_file_stat_calls
+        result = original_stat(path, *args, **kwargs)
+        if os.path.abspath(path) != os.path.abspath(raced_file):
+            return result
+        raced_file_stat_calls += 1
+        if raced_file_stat_calls == 1:
+            values = list(result)
+            values[0] = stat.S_IFDIR | 0o755
+            return os.stat_result(values)
+        return result
+
+    monkeypatch.setattr(os, "stat", directory_then_file)
+
+    warnings = catalog.validate()
+
+    assert raced_file_stat_calls == 2
+    assert len(warnings) == 1
+    assert "unclaimed database file" in warnings[0]
+    assert os.path.realpath(raced_file) in warnings[0]
+
+
+def test_create_api_boots_with_unreadable_unrelated_sibling(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    from pinky_daemon.api import create_api
+
+    unreadable = tmp_path / "snap-private-tmp"
+    unreadable.mkdir()
+    unreadable.chmod(0o000)
+    try:
+        app = create_api(db_path=str(tmp_path / "conversations.db"))
+    finally:
+        unreadable.chmod(0o755)
+
+    assert app.state.store_catalog is not None
+    assert "could not inspect database directory" in caplog.text
+    assert "outside registered store footprint" in caplog.text
+    assert os.fspath(unreadable) in caplog.text
+
+
+def test_create_api_fails_closed_with_unreadable_store_footprint(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from pinky_daemon.api import create_api
+
+    kb_dir = tmp_path / "kb"
+    original_validate = StoreCatalog.validate
+
+    def validate_with_unreadable_kb(catalog: StoreCatalog) -> list[str]:
+        kb_dir.chmod(0o000)
+        try:
+            return original_validate(catalog)
+        finally:
+            kb_dir.chmod(0o755)
+
+    monkeypatch.setattr(StoreCatalog, "validate", validate_with_unreadable_kb)
 
     with pytest.raises(StoreCatalogError, match="could not inspect database directory"):
-        catalog.validate()
+        create_api(db_path=str(tmp_path / "conversations.db"))
 
 
 def test_reconcile_symlink_cycle_terminates_cleanly(tmp_path: Path) -> None:

--- a/tests/test_store_catalog.py
+++ b/tests/test_store_catalog.py
@@ -426,6 +426,40 @@ def test_reconcile_quiets_snapshot_orphan_reached_first_through_normal_symlink(
     assert catalog.validate() == []
 
 
+def test_reconcile_skips_dangling_config_symlink(tmp_path: Path) -> None:
+    shared_home = tmp_path / "shared"
+    shared_home.mkdir()
+    agent_home = tmp_path / "agent" / ".codex"
+    agent_home.mkdir(parents=True)
+    (agent_home / "config.toml").symlink_to(shared_home / "config.toml")
+    catalog = StoreCatalog(expected_root=tmp_path, silence_allowlist={})
+
+    assert catalog.validate() == []
+
+
+def test_reconcile_skips_dangling_database_symlink(tmp_path: Path) -> None:
+    (tmp_path / "foo.db").symlink_to(tmp_path / "missing.db")
+    catalog = StoreCatalog(expected_root=tmp_path, silence_allowlist={})
+
+    assert catalog.validate() == []
+
+
+def test_create_api_boots_with_dangling_config_symlink_below_data_root(tmp_path: Path) -> None:
+    from pinky_daemon.api import create_api
+
+    shared_home = tmp_path / "shared"
+    shared_home.mkdir()
+    agent_home = tmp_path / "agent" / ".codex"
+    agent_home.mkdir(parents=True)
+    config_link = agent_home / "config.toml"
+    config_link.symlink_to(shared_home / "config.toml")
+
+    app = create_api(db_path=str(tmp_path / "conversations.db"))
+
+    assert app.state.store_catalog is not None
+    assert config_link.is_symlink()
+
+
 def test_reconcile_rejects_alias_behind_symlinked_directory(tmp_path: Path) -> None:
     expected_root = tmp_path / "data"
     expected_root.mkdir()


### PR DESCRIPTION
## What

Adds filesystem reconciliation to `StoreCatalog` (P0.1.1) — the structural coverage guarantee that closes the discipline-dependence of the P0.1 boot gate. A `reconcile_filesystem()` pass runs after the existing per-record checks and cross-checks the on-disk `*.db` inventory against the registered stores.

## Why

P0.1's boot gate only validates **registered** records, so a forgotten store opener — or a rogue on-disk file aliasing a live store — was invisible to it. This closes that gap: the actual #889 corruption vector (an unregistered on-disk path aliasing a **live registered** store's inode) becomes a hard boot failure, and any other unclaimed `.db` is surfaced loudly.

## What it does

`reconcile_filesystem()` (called only after the P0.1 per-record checks pass):

- Recursively walks `*.db` under the real `expected_root` (sorted, includes nested `kb/kb.db`, prunes temp/snapshot directory tokens, excludes `-wal`/`-shm`/`-journal` sidecars), recording realpath + `(st_dev, st_ino)`.
- **HARD FAIL (`StoreCatalogError`, never allowlistable):** a distinct enumerated realpath that shares a **registered** store's inode — a rogue hardlink / forgotten aliasing opener. Proven by a test that hardlinks the default-allowlisted `hub.db` to registered `tasks.db` and **still raises** — suppression can never cross this boundary.
- **LOUD WARN (returns + logs `STORE CATALOG WARNING`, does not fail):** an enumerated `.db` not claimed by any registered record and not in the silence-allowlist. A forgotten store or orphan surfaces visibly but never bricks the boot.
- Silence-allowlist suppresses **only** unclaimed-file warnings (basename/path globs, each with a reason); an allowlist entry matching no on-disk file warns as **dead** so suppressions keep shrinking.

## Design rationale

The #889 danger is specifically an unregistered path aliasing a **live** registered inode — so that condition is structurally hard-failed and never allowlistable. A standalone unique-inode orphan is inventory drift, not itself a corruption vector; warn-not-fail keeps the boot **deploy-safe by construction** (no un-inventoried orphan can refuse a boot) while making forgotten stores visible.

## Scope / non-goals

No runtime/post-boot monitoring; no auto-delete/quarantine of orphans (operator action only); no change to P0.1's per-record checks or the P0.2 CI guard. Silence-allowlist seeded with the current known-benign non-daemon-store files (`hub.db`, `pinky.db`, `pinkybot.db`, `daemon.db`, `messages.db`, `pinky_daemon.db`, `scheduler.db`), each with a reason.

## Tests

Red-first: `pytest -k 'reconcile or clean_production_shaped_layout'` failed 8/8 before implementation. Green: the hardlink-alias-raises-despite-allowlist proof (core), unclaimed-warns-not-raises, allowlisted-silent, dead-entry-warns, sidecars-excluded, registered-own-file-claimed, and a clean prod-shaped layout (all registered + nested KB + seeded strays → zero warnings). `tests/test_store_catalog.py` 37 passed; suite-wide `pytest --collect-only` 5,284 collected exit 0; ruff check + format + `git diff --check` clean.

_Test + daemon-internal change, no UI — no screenshot attached._

🤖 Opened by barsik