### PR TITLE
P0.3: owner-controlled snapshot tool (storage-authority #619)

### DIFF
--- a/scripts/store_snapshot.py
+++ b/scripts/store_snapshot.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Request daemon-owned SQLite snapshots; never open a live store directly."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+
+from pinky_daemon.auth import build_internal_auth_headers
+
+SNAPSHOT_PATH = "/internal/stores/snapshot"
+
+
+def _default_api_url() -> str:
+    port = os.environ.get("PINKY_API_PORT", "8888").strip() or "8888"
+    return f"http://127.0.0.1:{port}"
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Ask the PinkyBot daemon to produce a verified store snapshot. "
+            "This wrapper never opens a SQLite database."
+        )
+    )
+    parser.add_argument(
+        "--logical-name",
+        default="",
+        help="Catalog logical name; omit to snapshot all authoritative stores.",
+    )
+    parser.add_argument(
+        "--as-agent",
+        default=os.environ.get("PINKY_AGENT_NAME", ""),
+        help="Registered non-isolated caller identity (or PINKY_AGENT_NAME).",
+    )
+    parser.add_argument(
+        "--api-url",
+        default=_default_api_url(),
+        help="Daemon base URL (default: http://127.0.0.1:$PINKY_API_PORT).",
+    )
+    parser.add_argument("--timeout", type=float, default=300.0)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _parser()
+    args = parser.parse_args(argv)
+    agent_name = args.as_agent.strip()
+    if not agent_name:
+        parser.error("pass --as-agent or set PINKY_AGENT_NAME")
+
+    secret = os.environ.get("PINKY_AGENT_KEY", "").strip()
+    if not secret:
+        secret = os.environ.get("PINKY_SESSION_SECRET", "").strip()
+    if not secret:
+        parser.error("PINKY_AGENT_KEY or PINKY_SESSION_SECRET is required")
+
+    body = {}
+    if args.logical_name.strip():
+        body["logical_name"] = args.logical_name.strip()
+    encoded = json.dumps(body, separators=(",", ":")).encode("utf-8")
+    headers = {
+        "Content-Type": "application/json",
+        **build_internal_auth_headers(
+            secret,
+            agent_name=agent_name,
+            method="POST",
+            path=SNAPSHOT_PATH,
+        ),
+    }
+    request = urllib.request.Request(
+        args.api_url.rstrip("/") + SNAPSHOT_PATH,
+        data=encoded,
+        method="POST",
+        headers=headers,
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=args.timeout) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")
+        print(f"snapshot request failed: HTTP {exc.code}: {detail}", file=sys.stderr)
+        return 1
+    except (OSError, ValueError) as exc:
+        print(f"snapshot request failed: {exc}", file=sys.stderr)
+        return 1
+
+    had_error = False
+    for result in payload.get("snapshots", []):
+        snapshot_path = result.get("snapshot_path")
+        if snapshot_path:
+            print(snapshot_path)
+            continue
+        had_error = True
+        names = ",".join(result.get("logical_names", [])) or "unknown"
+        print(
+            f"{names}: {result.get('error') or result.get('verification') or 'snapshot failed'}",
+            file=sys.stderr,
+        )
+    return 1 if had_error else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/store_snapshot.py
+++ b/scripts/store_snapshot.py
@@ -89,16 +89,17 @@ def main(argv: list[str] | None = None) -> int:
         print(f"snapshot request failed: {exc}", file=sys.stderr)
         return 1
 
-    had_error = False
+    had_error = payload.get("status") in {"partial_success", "failed"}
     for result in payload.get("snapshots", []):
-        snapshot_path = result.get("snapshot_path")
-        if snapshot_path:
-            print(snapshot_path)
+        if result.get("status") == "published" and result.get("path"):
+            print(result["path"])
             continue
         had_error = True
-        names = ",".join(result.get("logical_names", [])) or "unknown"
+        names = ",".join(result.get("logical_names", []))
+        if not names:
+            names = result.get("logical_name") or "unknown"
         print(
-            f"{names}: {result.get('error') or result.get('verification') or 'snapshot failed'}",
+            f"{names}: {result.get('error') or 'snapshot failed'}",
             file=sys.stderr,
         )
     return 1 if had_error else 0

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -5165,8 +5165,29 @@ def create_api(
         caller: str,
         logical_name: str | None,
         result: SnapshotResult | None,
+        *,
+        selection_error: StoreSnapshotSelectionError | None = None,
     ) -> None:
         requested_names = [logical_name] if logical_name is not None else ["*authoritative*"]
+        if selection_error is not None:
+            audit.log(
+                "store_snapshot",
+                agent_name=caller,
+                tool_name="store_snapshot",
+                tool_input_summary=json.dumps(
+                    {
+                        "requested": requested_names,
+                        "logical_names": [],
+                        "status": "denied",
+                        "path": None,
+                        "verification": "not_run",
+                        "error": str(selection_error),
+                    },
+                    separators=(",", ":"),
+                ),
+                success=False,
+            )
+            return
         if result is None:
             audit.log(
                 "store_snapshot",
@@ -5178,6 +5199,7 @@ def create_api(
                         "logical_names": [],
                         "status": "success",
                         "path": None,
+                        "verification": "no_matching_authoritative_stores",
                         "error": None,
                     },
                     separators=(",", ":"),
@@ -5194,6 +5216,7 @@ def create_api(
                     "logical_names": list(result.logical_names),
                     "status": result.status,
                     "path": result.snapshot_path,
+                    "verification": result.verification,
                     "error": str(result.error) if result.error is not None else None,
                 },
                 separators=(",", ":"),
@@ -5239,6 +5262,18 @@ def create_api(
                 ),
             )
         except StoreSnapshotSelectionError as exc:
+            try:
+                _audit_store_snapshot(
+                    caller,
+                    req.logical_name,
+                    None,
+                    selection_error=exc,
+                )
+            except Exception as audit_exc:
+                error = StoreSnapshotError("snapshot selection-denial audit failed")
+                error.__cause__ = audit_exc
+                _log(f"store-snapshot: selection audit failed for caller={caller!r}")
+                raise HTTPException(500, "store snapshot failed") from error
             raise HTTPException(400, str(exc)) from exc
         except StoreSnapshotError as exc:
             _log(f"store-snapshot: failed for caller={caller!r}: {type(exc).__name__}")

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -197,6 +197,7 @@ from pinky_daemon.skill_loader import discover_all_skills, register_discovered_s
 from pinky_daemon.skill_store import SkillStore
 from pinky_daemon.store_catalog import StoreCatalog, StoreCatalogError
 from pinky_daemon.store_snapshot import (
+    SnapshotResult,
     StoreSnapshotError,
     StoreSnapshotSelectionError,
     StoreSnapshotService,
@@ -5163,45 +5164,50 @@ def create_api(
     def _audit_store_snapshot(
         caller: str,
         logical_name: str | None,
-        results,
+        result: SnapshotResult | None,
     ) -> None:
         requested_names = [logical_name] if logical_name is not None else ["*authoritative*"]
-        if not results:
+        if result is None:
             audit.log(
                 "store_snapshot",
                 agent_name=caller,
                 tool_name="store_snapshot",
                 tool_input_summary=json.dumps(
                     {
-                        "logical_name": logical_name,
-                        "requested_logical_names": requested_names,
-                        "result_logical_names": [],
-                        "snapshot_paths": [],
-                        "verification": "no_matching_authoritative_stores",
+                        "requested": requested_names,
+                        "logical_names": [],
+                        "status": "success",
+                        "path": None,
+                        "error": None,
                     },
                     separators=(",", ":"),
                 ),
             )
             return
-        for result in results:
-            paths = [result.snapshot_path] if result.snapshot_path is not None else []
-            audit.log(
-                "store_snapshot",
-                agent_name=caller,
-                tool_name="store_snapshot",
-                tool_input_summary=json.dumps(
-                    {
-                        "logical_name": logical_name,
-                        "requested_logical_names": requested_names,
-                        "result_logical_names": list(result.logical_names),
-                        "snapshot_paths": paths,
-                        "verification": result.verification,
-                        "error": result.error,
-                    },
-                    separators=(",", ":"),
-                ),
-                success=result.error is None,
-            )
+        audit.log(
+            "store_snapshot",
+            agent_name=caller,
+            tool_name="store_snapshot",
+            tool_input_summary=json.dumps(
+                {
+                    "requested": requested_names,
+                    "logical_names": list(result.logical_names),
+                    "status": result.status,
+                    "path": result.snapshot_path,
+                    "error": str(result.error) if result.error is not None else None,
+                },
+                separators=(",", ":"),
+            ),
+            success=result.status == "published",
+        )
+
+    def _store_snapshot_batch_status(results: list[SnapshotResult]) -> str:
+        published = sum(result.status == "published" for result in results)
+        if published == len(results):
+            return "success"
+        if published == 0:
+            return "failed"
+        return "partial_success"
 
     @app.post("/internal/stores/snapshot")
     async def create_store_snapshot(req: StoreSnapshotRequest, request: Request):
@@ -5226,15 +5232,30 @@ def create_api(
             results = await asyncio.to_thread(
                 store_snapshot_service.create_snapshots,
                 req.logical_name,
+                on_outcome=lambda result: _audit_store_snapshot(
+                    caller,
+                    req.logical_name,
+                    result,
+                ),
             )
         except StoreSnapshotSelectionError as exc:
             raise HTTPException(400, str(exc)) from exc
         except StoreSnapshotError as exc:
             _log(f"store-snapshot: failed for caller={caller!r}: {type(exc).__name__}")
             raise HTTPException(500, "store snapshot failed") from exc
+        except Exception as exc:
+            error = StoreSnapshotError(
+                f"unexpected snapshot batch failure: {type(exc).__name__}: {exc}"
+            )
+            _log(f"store-snapshot: failed for caller={caller!r}: {type(exc).__name__}")
+            raise HTTPException(500, "store snapshot failed") from error
 
-        _audit_store_snapshot(caller, req.logical_name, results)
-        return {"snapshots": [result.to_dict() for result in results]}
+        if not results:
+            _audit_store_snapshot(caller, req.logical_name, None)
+        return {
+            "status": _store_snapshot_batch_status(results),
+            "snapshots": [result.to_dict() for result in results],
+        }
 
     # ── Request Timing Middleware ──────────────────────────────
     # Logs slow requests and adds Server-Timing header for frontend diagnostics.

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -23,6 +23,7 @@ import re
 import shutil
 import sys
 import tempfile
+import threading
 import time
 import urllib.parse
 import urllib.request
@@ -114,6 +115,7 @@ from pinky_daemon.api_models import (
     SetMainAgentRequest,
     SetModelRequest,
     SpawnSessionRequest,
+    StoreSnapshotRequest,
     TmuxPaneKeysRequest,
     TransportStopFailureRequest,
     TransportToolResultRequest,
@@ -194,6 +196,11 @@ from pinky_daemon.shared_mcp import (
 from pinky_daemon.skill_loader import discover_all_skills, register_discovered_skills
 from pinky_daemon.skill_store import SkillStore
 from pinky_daemon.store_catalog import StoreCatalog, StoreCatalogError
+from pinky_daemon.store_snapshot import (
+    StoreSnapshotError,
+    StoreSnapshotSelectionError,
+    StoreSnapshotService,
+)
 from pinky_daemon.streaming_session import _1M_MODELS, is_1m_model
 from pinky_daemon.task_store import TaskStore
 
@@ -1696,12 +1703,14 @@ def create_api(
     db_path = os.path.realpath(db_path)
     _data_dir = Path(db_path).parent
     store_catalog = StoreCatalog(expected_root=_data_dir)
+    store_snapshot_service = StoreSnapshotService(store_catalog)
 
     app = FastAPI(
         title="Pinky",
         description="Stateful Claude Code session API",
         version="0.1.0",
     )
+    app.state.store_snapshot_service = store_snapshot_service
     app.state.ferry_listener = FerryListenerState.from_config(FerryConfig.from_env())
 
     @app.exception_handler(RequestValidationError)
@@ -1778,6 +1787,7 @@ def create_api(
     audit = AuditStore(
         db_path=db_path.replace(".db", "_audit.db"), catalog=store_catalog
     )
+    app.state.audit = audit
     hooks = HookManager(audit_store=audit)
 
     # In-memory live status for agents (updated by POST /agents/{name}/status).
@@ -4614,6 +4624,7 @@ def create_api(
         "/skills",
         "/outreach",
         "/system",
+        "/internal",
         "/settings",
         "/scheduler",
         "/activity",
@@ -5116,6 +5127,114 @@ def create_api(
         if _auth_deny_mode == "shadow":
             _log(f"auth: would-deny (shadow) {request.method} {path}")
         return await call_next(request)
+
+    # Store snapshots expose authoritative data, so this surface is both
+    # signature-only and intentionally low-rate. The middleware authenticates
+    # HMAC requests, while the handler repeats that exact check to exclude a UI
+    # session cookie and explicitly excludes isolated tenants from fleet-wide
+    # storage access.
+    _STORE_SNAPSHOT_RATE_LIMIT = 2  # noqa: N806 - create_api-local policy constant
+    _STORE_SNAPSHOT_RATE_WINDOW = 60.0  # noqa: N806
+    _store_snapshot_attempts: dict[str, list[float]] = {}
+    _store_snapshot_rate_lock = threading.Lock()
+
+    def _check_store_snapshot_rate_limit(caller: str) -> None:
+        now = time.monotonic()
+        with _store_snapshot_rate_lock:
+            active = [
+                attempt
+                for attempt in _store_snapshot_attempts.get(caller, [])
+                if now - attempt < _STORE_SNAPSHOT_RATE_WINDOW
+            ]
+            if len(active) >= _STORE_SNAPSHOT_RATE_LIMIT:
+                retry_after = max(
+                    1,
+                    int(_STORE_SNAPSHOT_RATE_WINDOW - (now - active[0])) + 1,
+                )
+                _store_snapshot_attempts[caller] = active
+                raise HTTPException(
+                    status_code=429,
+                    detail="store snapshot rate limit exceeded",
+                    headers={"Retry-After": str(retry_after)},
+                )
+            active.append(now)
+            _store_snapshot_attempts[caller] = active
+
+    def _audit_store_snapshot(
+        caller: str,
+        logical_name: str | None,
+        results,
+    ) -> None:
+        requested_names = [logical_name] if logical_name is not None else ["*authoritative*"]
+        if not results:
+            audit.log(
+                "store_snapshot",
+                agent_name=caller,
+                tool_name="store_snapshot",
+                tool_input_summary=json.dumps(
+                    {
+                        "logical_name": logical_name,
+                        "requested_logical_names": requested_names,
+                        "result_logical_names": [],
+                        "snapshot_paths": [],
+                        "verification": "no_matching_authoritative_stores",
+                    },
+                    separators=(",", ":"),
+                ),
+            )
+            return
+        for result in results:
+            paths = [result.snapshot_path] if result.snapshot_path is not None else []
+            audit.log(
+                "store_snapshot",
+                agent_name=caller,
+                tool_name="store_snapshot",
+                tool_input_summary=json.dumps(
+                    {
+                        "logical_name": logical_name,
+                        "requested_logical_names": requested_names,
+                        "result_logical_names": list(result.logical_names),
+                        "snapshot_paths": paths,
+                        "verification": result.verification,
+                        "error": result.error,
+                    },
+                    separators=(",", ":"),
+                ),
+                success=result.error is None,
+            )
+
+    @app.post("/internal/stores/snapshot")
+    async def create_store_snapshot(req: StoreSnapshotRequest, request: Request):
+        if not _has_valid_internal_auth(request):
+            raise HTTPException(403, "valid signed internal HMAC required")
+        caller = request.headers.get(INTERNAL_AGENT_HEADER, "").strip()
+        try:
+            caller_record = agents.get(caller)
+        except Exception as exc:
+            _log(
+                f"store-snapshot: caller lookup failed for {caller!r}: "
+                f"{type(exc).__name__} — denying"
+            )
+            caller_record = None
+        if caller_record is None:
+            raise HTTPException(403, "registered operator agent required")
+        if getattr(caller_record, "isolated", False):
+            raise HTTPException(403, "isolated agents may not snapshot daemon stores")
+
+        _check_store_snapshot_rate_limit(caller)
+        try:
+            results = await asyncio.to_thread(
+                store_snapshot_service.create_snapshots,
+                req.logical_name,
+            )
+        except StoreSnapshotSelectionError as exc:
+            raise HTTPException(400, str(exc)) from exc
+        except StoreSnapshotError as exc:
+            _log(f"store-snapshot: failed for caller={caller!r}: {type(exc).__name__}")
+            raise HTTPException(500, "store snapshot failed") from exc
+
+        _audit_store_snapshot(caller, req.logical_name, results)
+        return {"snapshots": [result.to_dict() for result in results]}
 
     # ── Request Timing Middleware ──────────────────────────────
     # Logs slow requests and adds Server-Timing header for frontend diagnostics.

--- a/src/pinky_daemon/api_models.py
+++ b/src/pinky_daemon/api_models.py
@@ -80,6 +80,12 @@ class UpdatePasswordRequest(BaseModel):
     password: str
 
 
+class StoreSnapshotRequest(BaseModel):
+    """Select one catalog store, or omit the name for all authoritative stores."""
+
+    logical_name: str | None = Field(default=None, min_length=1, max_length=200)
+
+
 class SessionResponse(BaseModel):
     """Session info returned by API."""
 

--- a/src/pinky_daemon/store_catalog.py
+++ b/src/pinky_daemon/store_catalog.py
@@ -78,6 +78,11 @@ class StoreCatalog:
         self._entries: list[_CatalogEntry] = []
         self._lock = threading.RLock()
 
+    @property
+    def expected_root(self) -> str:
+        """Return the canonical filesystem root this catalog governs."""
+        return self._expected_root
+
     def register(
         self,
         logical_name: str,

--- a/src/pinky_daemon/store_snapshot.py
+++ b/src/pinky_daemon/store_snapshot.py
@@ -115,7 +115,7 @@ class StoreSnapshotService:
     def _snapshot_outcome(self, store: _SelectedStore) -> SnapshotResult:
         try:
             return self._snapshot_selected(store)
-        except Exception as exc:
+        except (StoreSnapshotError, sqlite3.Error, OSError) as exc:
             error = self._as_snapshot_error(store, exc)
             return SnapshotResult(
                 logical_names=store.logical_names,

--- a/src/pinky_daemon/store_snapshot.py
+++ b/src/pinky_daemon/store_snapshot.py
@@ -12,6 +12,7 @@ import uuid
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import Callable, Literal
 
 from pinky_daemon.store_catalog import StoreCatalog, StoreRecord
 
@@ -40,15 +41,29 @@ class SnapshotResult:
     logical_names: tuple[str, ...]
     snapshot_path: str | None
     verification: str
-    error: str | None = None
+    error: StoreSnapshotError | None = None
+
+    @property
+    def logical_name(self) -> str:
+        return self.logical_names[0]
+
+    @property
+    def status(self) -> Literal["published", "failed"]:
+        if self.snapshot_path is not None and self.error is None:
+            return "published"
+        return "failed"
 
     def to_dict(self) -> dict[str, object]:
-        return {
+        payload: dict[str, object] = {
+            "logical_name": self.logical_name,
             "logical_names": list(self.logical_names),
-            "snapshot_path": self.snapshot_path,
-            "verification": self.verification,
-            "error": self.error,
+            "status": self.status,
         }
+        if self.status == "published":
+            payload["path"] = self.snapshot_path
+        else:
+            payload["error"] = str(self.error or "snapshot failed")
+        return payload
 
 
 @dataclass(frozen=True, slots=True)
@@ -74,7 +89,12 @@ class StoreSnapshotService:
     def __init__(self, catalog: StoreCatalog) -> None:
         self._catalog = catalog
 
-    def create_snapshots(self, logical_name: str | None = None) -> list[SnapshotResult]:
+    def create_snapshots(
+        self,
+        logical_name: str | None = None,
+        *,
+        on_outcome: Callable[[SnapshotResult], None] | None = None,
+    ) -> list[SnapshotResult]:
         """Snapshot one named store or every authoritative filesystem store.
 
         The global lock serializes backup work across all service instances. A
@@ -84,7 +104,61 @@ class StoreSnapshotService:
         """
         with _SNAPSHOT_LOCK:
             selected = self._select(logical_name)
-            return [self._snapshot_selected(store) for store in selected]
+            results = []
+            for store in selected:
+                result = self._snapshot_outcome(store)
+                if on_outcome is not None:
+                    self._report_outcome(result, on_outcome)
+                results.append(result)
+            return results
+
+    def _snapshot_outcome(self, store: _SelectedStore) -> SnapshotResult:
+        try:
+            return self._snapshot_selected(store)
+        except Exception as exc:
+            error = self._as_snapshot_error(store, exc)
+            return SnapshotResult(
+                logical_names=store.logical_names,
+                snapshot_path=None,
+                verification="failed",
+                error=error,
+            )
+
+    @staticmethod
+    def _as_snapshot_error(
+        store: _SelectedStore,
+        exc: Exception,
+    ) -> StoreSnapshotError:
+        if isinstance(exc, StoreSnapshotError):
+            return exc
+        error = StoreSnapshotError(
+            f"{type(exc).__name__} while snapshotting {store.logical_names[0]!r}: {exc}"
+        )
+        error.__cause__ = exc
+        return error
+
+    @staticmethod
+    def _report_outcome(
+        result: SnapshotResult,
+        on_outcome: Callable[[SnapshotResult], None],
+    ) -> None:
+        try:
+            on_outcome(result)
+        except Exception as exc:
+            # A published path is not allowed to outlive a failed audit write.
+            # This cleanup is only for audit infrastructure failure; a sibling
+            # store's corruption never removes an already-audited good copy.
+            if result.status == "published" and result.snapshot_path is not None:
+                try:
+                    Path(result.snapshot_path).unlink()
+                except OSError as cleanup_exc:
+                    raise StoreSnapshotError(
+                        "snapshot audit failed and the unaudited artifact "
+                        f"could not be removed: {result.snapshot_path!r}"
+                    ) from cleanup_exc
+            raise StoreSnapshotError(
+                f"snapshot outcome audit failed for {result.logical_name!r}"
+            ) from exc
 
     def _select(self, logical_name: str | None) -> list[_SelectedStore]:
         records = self._catalog.snapshot()
@@ -164,7 +238,7 @@ class StoreSnapshotService:
                 logical_names=store.logical_names,
                 snapshot_path=None,
                 verification="skipped",
-                error="source_missing",
+                error=StoreSnapshotError("source_missing"),
             )
         if not stat.S_ISREG(source_stat.st_mode):
             raise StoreSnapshotSelectionError(
@@ -198,7 +272,7 @@ class StoreSnapshotService:
                         logical_names=store.logical_names,
                         snapshot_path=None,
                         verification="skipped",
-                        error="source_missing",
+                        error=StoreSnapshotError("source_missing"),
                     )
                 raise
             temp_stat = temp_path.stat()

--- a/src/pinky_daemon/store_snapshot.py
+++ b/src/pinky_daemon/store_snapshot.py
@@ -1,0 +1,300 @@
+"""Daemon-owned, catalog-selected consistent snapshots of SQLite stores."""
+
+from __future__ import annotations
+
+import os
+import re
+import sqlite3
+import stat
+import tempfile
+import threading
+import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+from pinky_daemon.store_catalog import StoreCatalog, StoreRecord
+
+BACKUP_PAGES = 64
+BACKUP_SLEEP_SECONDS = 0.01
+_SNAPSHOT_LOCK = threading.Lock()
+_SAFE_FILENAME = re.compile(r"[^a-zA-Z0-9_.-]+")
+
+
+class StoreSnapshotError(RuntimeError):
+    """Base error for daemon-owned store snapshots."""
+
+
+class StoreSnapshotSelectionError(StoreSnapshotError):
+    """Raised when a request cannot be resolved safely through the catalog."""
+
+
+class StoreSnapshotVerificationError(StoreSnapshotError):
+    """Raised when a completed copy fails its integrity or inode checks."""
+
+
+@dataclass(frozen=True, slots=True)
+class SnapshotResult:
+    """One physical store copy, which may represent several logical stores."""
+
+    logical_names: tuple[str, ...]
+    snapshot_path: str | None
+    verification: str
+    error: str | None = None
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "logical_names": list(self.logical_names),
+            "snapshot_path": self.snapshot_path,
+            "verification": self.verification,
+            "error": self.error,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class _SelectedStore:
+    resolved_path: str
+    records: tuple[StoreRecord, ...]
+
+    @property
+    def logical_names(self) -> tuple[str, ...]:
+        return tuple(dict.fromkeys(record.logical_name for record in self.records))
+
+    @property
+    def dev_ino(self) -> tuple[int, int] | None:
+        identities = {record.dev_ino for record in self.records if record.dev_ino is not None}
+        if not identities:
+            return None
+        return next(iter(identities))
+
+
+class StoreSnapshotService:
+    """Produce verified copies without exposing live database files to callers."""
+
+    def __init__(self, catalog: StoreCatalog) -> None:
+        self._catalog = catalog
+
+    def create_snapshots(self, logical_name: str | None = None) -> list[SnapshotResult]:
+        """Snapshot one named store or every authoritative filesystem store.
+
+        The global lock serializes backup work across all service instances. A
+        single catalog snapshot is selected and grouped before any source is
+        opened, so shared physical stores produce one copy with all associated
+        logical names.
+        """
+        with _SNAPSHOT_LOCK:
+            selected = self._select(logical_name)
+            return [self._snapshot_selected(store) for store in selected]
+
+    def _select(self, logical_name: str | None) -> list[_SelectedStore]:
+        records = self._catalog.snapshot()
+        if logical_name is not None:
+            requested = [record for record in records if record.logical_name == logical_name]
+            if not requested:
+                raise StoreSnapshotSelectionError(
+                    f"unregistered store logical_name={logical_name!r}"
+                )
+            if any(record.is_memory for record in requested):
+                raise StoreSnapshotSelectionError(
+                    f"in-memory store cannot be snapshotted: {logical_name!r}"
+                )
+            selected_paths = {record.resolved_path for record in requested}
+            if len(selected_paths) != 1:
+                raise StoreSnapshotSelectionError(
+                    f"logical_name has divergent registered paths: {logical_name!r}"
+                )
+        else:
+            requested = [
+                record
+                for record in records
+                if record.criticality == "authoritative" and not record.is_memory
+            ]
+            selected_paths = {record.resolved_path for record in requested}
+
+        # Once a physical path is selected, report every logical store the
+        # catalog associates with it. This preserves shared-owner identities
+        # such as sessions + session_events while still making only one copy.
+        matching = [
+            record
+            for record in records
+            if not record.is_memory and record.resolved_path in selected_paths
+        ]
+
+        grouped: dict[str, list[StoreRecord]] = {}
+        for record in matching:
+            self._validate_record_path(record)
+            grouped.setdefault(record.resolved_path, []).append(record)
+        for path, group in grouped.items():
+            identities = {record.dev_ino for record in group if record.dev_ino is not None}
+            if len(identities) > 1:
+                raise StoreSnapshotSelectionError(
+                    f"catalog records disagree on source identity: path={path!r}"
+                )
+        return [
+            _SelectedStore(resolved_path=path, records=tuple(group))
+            for path, group in grouped.items()
+        ]
+
+    def _validate_record_path(self, record: StoreRecord) -> None:
+        root = self._catalog.expected_root
+        registered_path = record.resolved_path
+        if not os.path.isabs(registered_path) or not self._is_under_root(root, registered_path):
+            raise StoreSnapshotSelectionError(
+                f"registered store path is outside expected root {root!r}: "
+                f"logical_name={record.logical_name!r} path={registered_path!r}"
+            )
+        current_realpath = os.path.realpath(registered_path)
+        if current_realpath != registered_path:
+            raise StoreSnapshotSelectionError(
+                "registered store path no longer resolves to its catalog identity: "
+                f"logical_name={record.logical_name!r} registered={registered_path!r} "
+                f"current={current_realpath!r}"
+            )
+        if not self._is_under_root(root, current_realpath):
+            raise StoreSnapshotSelectionError(
+                f"registered store path resolves outside expected root {root!r}: "
+                f"logical_name={record.logical_name!r} path={current_realpath!r}"
+            )
+
+    def _snapshot_selected(self, store: _SelectedStore) -> SnapshotResult:
+        try:
+            source_stat = os.stat(store.resolved_path)
+        except FileNotFoundError:
+            return SnapshotResult(
+                logical_names=store.logical_names,
+                snapshot_path=None,
+                verification="skipped",
+                error="source_missing",
+            )
+        if not stat.S_ISREG(source_stat.st_mode):
+            raise StoreSnapshotSelectionError(
+                f"registered store is not a regular file: {store.resolved_path!r}"
+            )
+        source_identity = (source_stat.st_dev, source_stat.st_ino)
+        if store.dev_ino is not None and source_identity != store.dev_ino:
+            raise StoreSnapshotSelectionError(
+                f"registered store identity changed before snapshot: {store.resolved_path!r}"
+            )
+
+        output_dir = self._snapshot_directory()
+        stem = _SAFE_FILENAME.sub("_", store.logical_names[0]).strip("._-") or "store"
+        timestamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%S.%fZ")
+        unique = uuid.uuid4().hex
+        final_path = output_dir / f"{stem}-{timestamp}-{unique}.db"
+        descriptor, temp_name = tempfile.mkstemp(
+            dir=output_dir,
+            prefix=f".{stem}-",
+            suffix=".tmp",
+        )
+        os.close(descriptor)
+        temp_path = Path(temp_name)
+
+        try:
+            try:
+                self._backup_and_verify(store.resolved_path, temp_path, source_identity)
+            except (FileNotFoundError, sqlite3.OperationalError):
+                if not os.path.exists(store.resolved_path):
+                    return SnapshotResult(
+                        logical_names=store.logical_names,
+                        snapshot_path=None,
+                        verification="skipped",
+                        error="source_missing",
+                    )
+                raise
+            temp_stat = temp_path.stat()
+            if (temp_stat.st_dev, temp_stat.st_ino) == (
+                source_stat.st_dev,
+                source_stat.st_ino,
+            ):
+                raise StoreSnapshotVerificationError(
+                    f"snapshot aliases source inode: {store.resolved_path!r}"
+                )
+            os.replace(temp_path, final_path)
+            return SnapshotResult(
+                logical_names=store.logical_names,
+                snapshot_path=str(final_path),
+                verification="ok",
+            )
+        finally:
+            try:
+                temp_path.unlink()
+            except FileNotFoundError:
+                pass
+
+    def _backup_and_verify(
+        self,
+        source_path: str,
+        destination_path: Path,
+        expected_identity: tuple[int, int],
+    ) -> None:
+        source: sqlite3.Connection | None = None
+        destination: sqlite3.Connection | None = None
+        try:
+            # The source connection deliberately executes no SQL at all — in
+            # particular, never PRAGMA journal_mode. The Online Backup API is
+            # the only operation performed against the live registered store.
+            self._assert_source_identity(source_path, expected_identity)
+            source = sqlite3.connect(
+                Path(source_path).as_uri() + "?mode=ro",
+                uri=True,
+                timeout=30,
+            )
+            self._assert_source_identity(source_path, expected_identity)
+            destination = sqlite3.connect(destination_path, timeout=30)
+            source.backup(
+                destination,
+                pages=BACKUP_PAGES,
+                progress=self._backup_progress,
+                sleep=BACKUP_SLEEP_SECONDS,
+            )
+            self._assert_source_identity(source_path, expected_identity)
+            check_rows = destination.execute("PRAGMA quick_check").fetchall()
+            if check_rows != [("ok",)]:
+                raise StoreSnapshotVerificationError(f"snapshot quick_check failed: {check_rows!r}")
+        finally:
+            if destination is not None:
+                destination.close()
+            if source is not None:
+                source.close()
+
+    def _assert_source_identity(
+        self,
+        source_path: str,
+        expected_identity: tuple[int, int],
+    ) -> None:
+        current_realpath = os.path.realpath(source_path)
+        current_stat = os.stat(source_path)
+        current_identity = (current_stat.st_dev, current_stat.st_ino)
+        if (
+            current_realpath != source_path
+            or current_identity != expected_identity
+            or not stat.S_ISREG(current_stat.st_mode)
+        ):
+            raise StoreSnapshotSelectionError(
+                f"registered store identity changed during snapshot: {source_path!r}"
+            )
+
+    def _backup_progress(self, _status: int, _remaining: int, _total: int) -> None:
+        """Backup progress seam for deterministic concurrency contract tests."""
+
+    def _snapshot_directory(self) -> Path:
+        root = self._catalog.expected_root
+        directory = Path(root) / "snapshots"
+        directory.mkdir(mode=0o700, parents=True, exist_ok=True)
+        resolved_directory = os.path.realpath(directory)
+        expected_directory = os.path.join(root, "snapshots")
+        if resolved_directory != expected_directory or not self._is_under_root(
+            root, resolved_directory
+        ):
+            raise StoreSnapshotSelectionError(
+                f"snapshot directory resolves outside expected root {root!r}: "
+                f"path={resolved_directory!r}"
+            )
+        return Path(resolved_directory)
+
+    @staticmethod
+    def _is_under_root(root: str, path: str) -> bool:
+        try:
+            return os.path.commonpath((root, path)) == root
+        except ValueError:
+            return False

--- a/tests/test_no_direct_db_open.py
+++ b/tests/test_no_direct_db_open.py
@@ -114,6 +114,16 @@ DIRECT_OPEN_ALLOWLIST = {
             "Creates per-agent signing-key DBs during provisioning; P1 routes behind the seam."
         ),
     ),
+    DirectOpenIdentity(
+        "src/pinky_daemon/store_snapshot.py",
+        "StoreSnapshotService._backup_and_verify",
+    ): AllowlistEntry(
+        expected_count=2,
+        reason=(
+            "Daemon-internal storage authority opens one catalog-selected source and one "
+            "fresh destination for SQLite Online Backup API snapshots (#1112)."
+        ),
+    ),
 }
 
 

--- a/tests/test_store_snapshot.py
+++ b/tests/test_store_snapshot.py
@@ -161,6 +161,101 @@ def test_snapshot_directory_stays_clean_under_catalog_reconciliation(tmp_path: P
     assert catalog.reconcile_filesystem() == []
 
 
+def test_explicit_selection_returns_all_logical_names_for_shared_physical_store(
+    tmp_path: Path,
+) -> None:
+    snapshot = _snapshot_module()
+    source = tmp_path / "shared.db"
+    connection, mode = _create_store(source)
+    connection.close()
+    catalog = _catalog_for(
+        tmp_path,
+        source,
+        logical_name="sessions",
+        journal_mode=mode,
+    )
+    catalog.register(
+        "session_events",
+        source,
+        journal_mode=mode,
+        owner="test-owner",
+    )
+
+    [result] = snapshot.StoreSnapshotService(catalog).create_snapshots("sessions")
+
+    assert result.logical_names == ("sessions", "session_events")
+
+
+def test_path_retargeted_after_selection_is_rejected_before_sqlite_open(
+    tmp_path: Path,
+) -> None:
+    snapshot = _snapshot_module()
+    root = tmp_path / "data"
+    source = root / "primary.db"
+    source_connection, mode = _create_store(source)
+    source_connection.close()
+    outside = tmp_path / "outside.db"
+    outside_connection, _outside_mode = _create_store(outside)
+    outside_connection.close()
+    catalog = _catalog_for(root, source, journal_mode=mode)
+
+    class RetargetingSnapshotService(snapshot.StoreSnapshotService):
+        def _backup_and_verify(self, source_path: str, destination_path: Path, *args) -> None:
+            Path(source_path).unlink()
+            Path(source_path).symlink_to(outside)
+            return super()._backup_and_verify(source_path, destination_path, *args)
+
+    service = RetargetingSnapshotService(catalog)
+
+    with pytest.raises(snapshot.StoreSnapshotSelectionError, match="identity"):
+        service.create_snapshots("primary")
+
+
+def test_source_and_destination_connections_close_when_verification_fails(
+    tmp_path: Path,
+) -> None:
+    snapshot = _snapshot_module()
+    source_path = tmp_path / "source.db"
+    source_path.touch()
+    source_stat = source_path.stat()
+    identity = (source_stat.st_dev, source_stat.st_ino)
+
+    class SourceConnection:
+        closed = False
+
+        def backup(self, _destination, **_kwargs) -> None:
+            return None
+
+        def close(self) -> None:
+            self.closed = True
+
+    class DestinationConnection:
+        closed = False
+
+        def execute(self, statement: str):
+            assert statement == "PRAGMA quick_check"
+            return self
+
+        def fetchall(self) -> list[tuple[str]]:
+            return [("corrupt",)]
+
+        def close(self) -> None:
+            self.closed = True
+
+    source = SourceConnection()
+    destination = DestinationConnection()
+    service = snapshot.StoreSnapshotService(StoreCatalog(expected_root=tmp_path))
+
+    with (
+        patch.object(snapshot.sqlite3, "connect", side_effect=[source, destination]),
+        pytest.raises(snapshot.StoreSnapshotVerificationError, match="quick_check"),
+    ):
+        service._backup_and_verify(source_path.as_posix(), tmp_path / "copy.tmp", identity)
+
+    assert source.closed is True
+    assert destination.closed is True
+
+
 def test_snapshot_is_consistent_when_source_commit_lands_mid_backup(tmp_path: Path) -> None:
     snapshot = _snapshot_module()
     source = tmp_path / "busy.db"

--- a/tests/test_store_snapshot.py
+++ b/tests/test_store_snapshot.py
@@ -541,6 +541,8 @@ def test_snapshot_selection_denial_is_audited(
     assert response.status_code == 400
     entries = client.app.state.audit.get_log(event="store_snapshot", limit=5)
     assert len(entries) == 1
+    assert entries[0].agent_name == "operator"
+    assert entries[0].success is False
     summary = json.loads(entries[0].tool_input_summary)
     assert summary == {
         "requested": [logical_name],
@@ -572,6 +574,7 @@ def test_unexpected_per_store_exception_reaches_controlled_500(
 
     assert response.status_code == 500
     assert response.json() == {"detail": "store snapshot failed"}
+    assert client.app.state.audit.get_log(event="store_snapshot", limit=5) == []
 
 
 def test_missing_registered_store_is_reported_without_sinking_batch(tmp_path: Path) -> None:

--- a/tests/test_store_snapshot.py
+++ b/tests/test_store_snapshot.py
@@ -62,12 +62,16 @@ def _catalog_for(
     return catalog
 
 
-def _live_sidecars(path: Path) -> set[str]:
-    return {
-        suffix
-        for suffix in ("-wal", "-shm", "-journal")
-        if path.with_name(path.name + suffix).exists()
-    }
+def _live_sidecar_inodes(path: Path) -> dict[str, tuple[int, int]]:
+    identities = {}
+    for suffix in ("-wal", "-shm", "-journal"):
+        sidecar = path.with_name(path.name + suffix)
+        try:
+            sidecar_stat = sidecar.stat()
+        except FileNotFoundError:
+            continue
+        identities[suffix] = (sidecar_stat.st_dev, sidecar_stat.st_ino)
+    return identities
 
 
 def test_consistent_copy_reproduces_inventory_and_passes_quick_check(tmp_path: Path) -> None:
@@ -92,22 +96,42 @@ def test_consistent_copy_reproduces_inventory_and_passes_quick_check(tmp_path: P
         copy.close()
 
 
-def test_external_snapshot_reader_never_touches_live_sidecars(tmp_path: Path) -> None:
+@pytest.mark.parametrize("requested_mode", ["delete", "wal"])
+def test_snapshot_preserves_live_sidecar_set_inodes_and_journal_mode(
+    tmp_path: Path,
+    requested_mode: str,
+) -> None:
+    """Keep sidecar existence/inodes stable; WAL read-mark bytes may change in place."""
     snapshot = _snapshot_module()
-    source = tmp_path / "rollback.db"
-    authority_connection, mode = _create_store(source, journal_mode="delete")
-    catalog = _catalog_for(tmp_path, source, journal_mode=mode)
-    before = _live_sidecars(source)
-
-    [result] = snapshot.StoreSnapshotService(catalog).create_snapshots("primary")
-    reader = sqlite3.connect(result.snapshot_path)
+    source = tmp_path / f"{requested_mode}.db"
+    authority_connection, observed_mode = _create_store(
+        source,
+        journal_mode=requested_mode,
+    )
+    catalog = _catalog_for(tmp_path, source, journal_mode=observed_mode)
     try:
-        assert reader.execute("SELECT COUNT(*) FROM inventory").fetchone() == (3,)
+        mode_before = str(authority_connection.execute("PRAGMA journal_mode").fetchone()[0]).lower()
+        sidecars_before = _live_sidecar_inodes(source)
+        if observed_mode == "wal":
+            assert {"-wal", "-shm"}.issubset(sidecars_before)
+        else:
+            assert "-shm" not in sidecars_before
+
+        [result] = snapshot.StoreSnapshotService(catalog).create_snapshots("primary")
+
+        mode_after = str(authority_connection.execute("PRAGMA journal_mode").fetchone()[0]).lower()
+        sidecars_after = _live_sidecar_inodes(source)
     finally:
-        reader.close()
         authority_connection.close()
 
-    assert _live_sidecars(source) == before
+    assert result.verification == "ok"
+    assert set(sidecars_after) == set(sidecars_before)
+    assert sidecars_after == sidecars_before
+    assert mode_before == observed_mode
+    assert mode_after == observed_mode
+    # Deliberately do not compare sidecar bytes or mtimes. A WAL reader's
+    # read-mark bookkeeping may legitimately update -shm bytes in place; inode
+    # stability is what proves there was no unlink-and-recreate cycle.
 
 
 @pytest.mark.parametrize("requested_mode", ["delete", "truncate", "wal"])

--- a/tests/test_store_snapshot.py
+++ b/tests/test_store_snapshot.py
@@ -271,8 +271,11 @@ def test_path_retargeted_after_selection_is_rejected_before_sqlite_open(
 
     service = RetargetingSnapshotService(catalog)
 
-    with pytest.raises(snapshot.StoreSnapshotSelectionError, match="identity"):
-        service.create_snapshots("primary")
+    [result] = service.create_snapshots("primary")
+
+    assert result.status == "failed"
+    assert isinstance(result.error, snapshot.StoreSnapshotSelectionError)
+    assert "identity" in str(result.error)
 
 
 def test_source_and_destination_connections_close_when_verification_fails(
@@ -495,15 +498,16 @@ def test_successful_snapshot_request_is_audited_with_caller_selection_and_paths(
     )
 
     assert response.status_code == 200
-    paths = [item["snapshot_path"] for item in response.json()["snapshots"]]
+    assert response.json()["status"] == "success"
+    paths = [item["path"] for item in response.json()["snapshots"]]
     entries = client.app.state.audit.get_log(event="store_snapshot", limit=5)
     assert len(entries) == 1
     entry = entries[0]
     assert entry.agent_name == "operator"
     assert entry.timestamp > 0
     summary = json.loads(entry.tool_input_summary)
-    assert summary["logical_name"] == "conversations"
-    assert summary["snapshot_paths"] == paths
+    assert summary["requested"] == ["conversations"]
+    assert summary["path"] == paths[0]
 
 
 def test_missing_registered_store_is_reported_without_sinking_batch(tmp_path: Path) -> None:
@@ -532,7 +536,8 @@ def test_missing_registered_store_is_reported_without_sinking_batch(tmp_path: Pa
     missing = by_name[("missing",)]
     assert missing.snapshot_path is None
     assert missing.verification == "skipped"
-    assert missing.error == "source_missing"
+    assert isinstance(missing.error, snapshot.StoreSnapshotError)
+    assert str(missing.error) == "source_missing"
 
 
 def test_raw_per_store_database_and_os_errors_are_wrapped_and_batch_continues(
@@ -621,6 +626,28 @@ def test_snapshot_outcome_is_reported_before_the_next_store_starts(
     assert outcomes == results
 
 
+def test_published_artifact_is_removed_if_its_outcome_audit_fails(tmp_path: Path) -> None:
+    snapshot = _snapshot_module()
+    source = tmp_path / "primary.db"
+    connection, mode = _create_store(source)
+    connection.close()
+    service = snapshot.StoreSnapshotService(_catalog_for(tmp_path, source, journal_mode=mode))
+    published_path = None
+
+    def _fail_audit(result) -> None:
+        nonlocal published_path
+        published_path = result.snapshot_path
+        assert published_path is not None
+        assert Path(published_path).is_file()
+        raise OSError("audit database unavailable")
+
+    with pytest.raises(snapshot.StoreSnapshotError, match="outcome audit failed"):
+        service.create_snapshots("primary", on_outcome=_fail_audit)
+
+    assert published_path is not None
+    assert not Path(published_path).exists()
+
+
 def test_corrupt_store_returns_audited_partial_success_after_good_publish(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -667,12 +694,8 @@ def test_corrupt_store_returns_audited_partial_success_after_good_publish(
 
     entries = client.app.state.audit.get_log(event="store_snapshot", limit=500)
     summaries = [json.loads(entry.tool_input_summary) for entry in entries]
-    published_audit = next(
-        item for item in summaries if "round2_good" in item["result_logical_names"]
-    )
-    failed_audit = next(
-        item for item in summaries if "round2_corrupt" in item["result_logical_names"]
-    )
+    published_audit = next(item for item in summaries if "round2_good" in item["logical_names"])
+    failed_audit = next(item for item in summaries if "round2_corrupt" in item["logical_names"])
     assert published_audit["status"] == "published"
     assert published_audit["path"] == published["path"]
     assert failed_audit["status"] == "failed"
@@ -748,14 +771,15 @@ def test_cli_signs_endpoint_request_and_prints_only_returned_copy_path(
         def read(self) -> bytes:
             return json.dumps(
                 {
+                    "status": "success",
                     "snapshots": [
                         {
+                            "logical_name": "conversations",
                             "logical_names": ["conversations"],
-                            "snapshot_path": "/data/snapshots/conversations-copy.db",
-                            "verification": "ok",
-                            "error": None,
+                            "status": "published",
+                            "path": "/data/snapshots/conversations-copy.db",
                         }
-                    ]
+                    ],
                 }
             ).encode()
 

--- a/tests/test_store_snapshot.py
+++ b/tests/test_store_snapshot.py
@@ -508,6 +508,70 @@ def test_successful_snapshot_request_is_audited_with_caller_selection_and_paths(
     summary = json.loads(entry.tool_input_summary)
     assert summary["requested"] == ["conversations"]
     assert summary["path"] == paths[0]
+    assert summary["verification"] == "ok"
+
+
+@pytest.mark.parametrize("denial", ["unregistered", "outside-root"])
+def test_snapshot_selection_denial_is_audited(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    denial: str,
+) -> None:
+    client = _snapshot_api_client(monkeypatch, tmp_path)
+    service = client.app.state.store_snapshot_service
+    logical_name = "round3_unknown"
+    if denial == "outside-root":
+        logical_name = "round3_outside"
+        outside = tmp_path / "outside-root.db"
+        connection, mode = _create_store(outside)
+        connection.close()
+        service._catalog.register(
+            logical_name,
+            outside,
+            journal_mode=mode,
+            owner="test-owner",
+        )
+
+    response = client.post(
+        "/internal/stores/snapshot",
+        headers=_signed_snapshot_headers(client, "operator"),
+        json={"logical_name": logical_name},
+    )
+
+    assert response.status_code == 400
+    entries = client.app.state.audit.get_log(event="store_snapshot", limit=5)
+    assert len(entries) == 1
+    summary = json.loads(entries[0].tool_input_summary)
+    assert summary == {
+        "requested": [logical_name],
+        "logical_names": [],
+        "status": "denied",
+        "path": None,
+        "verification": "not_run",
+        "error": response.json()["detail"],
+    }
+
+
+def test_unexpected_per_store_exception_reaches_controlled_500(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    client = _snapshot_api_client(monkeypatch, tmp_path)
+    service = client.app.state.store_snapshot_service
+
+    def _raise_programming_bug(_selected) -> None:
+        raise TypeError("programming bug")
+
+    monkeypatch.setattr(service, "_snapshot_selected", _raise_programming_bug)
+
+    response = client.post(
+        "/internal/stores/snapshot",
+        headers=_signed_snapshot_headers(client, "operator"),
+        json={"logical_name": "conversations"},
+    )
+
+    assert response.status_code == 500
+    assert response.json() == {"detail": "store snapshot failed"}
 
 
 def test_missing_registered_store_is_reported_without_sinking_batch(tmp_path: Path) -> None:
@@ -648,7 +712,7 @@ def test_published_artifact_is_removed_if_its_outcome_audit_fails(tmp_path: Path
     assert not Path(published_path).exists()
 
 
-def test_corrupt_store_returns_audited_partial_success_after_good_publish(
+def test_good_corrupt_and_missing_stores_return_audited_partial_success(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
@@ -657,6 +721,7 @@ def test_corrupt_store_returns_audited_partial_success_after_good_publish(
     data_root = Path(service._catalog.expected_root)
     good = data_root / "round2-good.db"
     corrupt = data_root / "round2-corrupt.db"
+    missing = data_root / "round3-missing.db"
     good_connection, good_mode = _create_store(good)
     good_connection.close()
     corrupt.write_bytes(b"this is not a sqlite database")
@@ -669,6 +734,12 @@ def test_corrupt_store_returns_audited_partial_success_after_good_publish(
     service._catalog.register(
         "round2_corrupt",
         corrupt,
+        journal_mode="delete",
+        owner="test-owner",
+    )
+    service._catalog.register(
+        "round3_missing",
+        missing,
         journal_mode="delete",
         owner="test-owner",
     )
@@ -685,21 +756,30 @@ def test_corrupt_store_returns_audited_partial_success_after_good_publish(
     by_name = {item["logical_name"]: item for item in payload["snapshots"]}
     published = by_name["round2_good"]
     failed = by_name["round2_corrupt"]
+    skipped = by_name["round3_missing"]
     assert published["status"] == "published"
     assert set(published) >= {"logical_name", "status", "path"}
     assert Path(published["path"]).is_file()
     assert failed["status"] == "failed"
     assert set(failed) >= {"logical_name", "status", "error"}
     assert "DatabaseError" in failed["error"]
+    assert skipped["status"] == "failed"
+    assert skipped["error"] == "source_missing"
 
     entries = client.app.state.audit.get_log(event="store_snapshot", limit=500)
     summaries = [json.loads(entry.tool_input_summary) for entry in entries]
     published_audit = next(item for item in summaries if "round2_good" in item["logical_names"])
     failed_audit = next(item for item in summaries if "round2_corrupt" in item["logical_names"])
+    skipped_audit = next(item for item in summaries if "round3_missing" in item["logical_names"])
     assert published_audit["status"] == "published"
     assert published_audit["path"] == published["path"]
+    assert published_audit["verification"] == "ok"
     assert failed_audit["status"] == "failed"
+    assert failed_audit["verification"] == "failed"
     assert "DatabaseError" in failed_audit["error"]
+    assert skipped_audit["status"] == "failed"
+    assert skipped_audit["verification"] == "skipped"
+    assert skipped_audit["error"] == "source_missing"
 
 
 def test_snapshot_endpoint_rate_limits_before_third_request_does_work(

--- a/tests/test_store_snapshot.py
+++ b/tests/test_store_snapshot.py
@@ -74,6 +74,14 @@ def _live_sidecar_inodes(path: Path) -> dict[str, tuple[int, int]]:
     return identities
 
 
+def _read_journal_mode(path: Path) -> str:
+    connection = sqlite3.connect(path)
+    try:
+        return str(connection.execute("PRAGMA journal_mode").fetchone()[0]).lower()
+    finally:
+        connection.close()
+
+
 def test_consistent_copy_reproduces_inventory_and_passes_quick_check(tmp_path: Path) -> None:
     snapshot = _snapshot_module()
     source = tmp_path / "primary.db"
@@ -96,12 +104,14 @@ def test_consistent_copy_reproduces_inventory_and_passes_quick_check(tmp_path: P
         copy.close()
 
 
-@pytest.mark.parametrize("requested_mode", ["delete", "wal"])
-def test_snapshot_preserves_live_sidecar_set_inodes_and_journal_mode(
+@pytest.mark.parametrize("requested_mode", ["delete", "truncate", "wal"])
+@pytest.mark.parametrize("authority_open", [True, False], ids=["authority-open", "dormant"])
+def test_snapshot_preserves_preexisting_sidecar_inodes_and_journal_mode(
     tmp_path: Path,
     requested_mode: str,
+    authority_open: bool,
 ) -> None:
-    """Keep sidecar existence/inodes stable; WAL read-mark bytes may change in place."""
+    """Never replace preexisting sidecars; WAL coordination files may be created."""
     snapshot = _snapshot_module()
     source = tmp_path / f"{requested_mode}.db"
     authority_connection, observed_mode = _create_store(
@@ -109,29 +119,59 @@ def test_snapshot_preserves_live_sidecar_set_inodes_and_journal_mode(
         journal_mode=requested_mode,
     )
     catalog = _catalog_for(tmp_path, source, journal_mode=observed_mode)
+    if not authority_open:
+        authority_connection.close()
+        authority_connection = None
+
     try:
-        mode_before = str(authority_connection.execute("PRAGMA journal_mode").fetchone()[0]).lower()
-        sidecars_before = _live_sidecar_inodes(source)
-        if observed_mode == "wal":
-            assert {"-wal", "-shm"}.issubset(sidecars_before)
+        if authority_connection is None:
+            mode_before = _read_journal_mode(source)
         else:
-            assert "-shm" not in sidecars_before
+            mode_before = str(
+                authority_connection.execute("PRAGMA journal_mode").fetchone()[0]
+            ).lower()
+            if observed_mode != "wal":
+                # Keep a real rollback journal live so the inode assertion is
+                # load-bearing for DELETE/TRUNCATE as well as WAL sidecars.
+                authority_connection.execute("BEGIN IMMEDIATE")
+                authority_connection.execute(
+                    "UPDATE inventory SET value = value || '-pending' WHERE id = 1"
+                )
+        sidecars_before = _live_sidecar_inodes(source)
+        if observed_mode == "wal" and authority_connection is not None:
+            assert {"-wal", "-shm"}.issubset(sidecars_before)
+        if observed_mode == "wal" and authority_connection is None:
+            assert not {"-wal", "-shm"}.intersection(sidecars_before)
+        if observed_mode != "wal" and authority_connection is not None:
+            assert "-journal" in sidecars_before
 
         [result] = snapshot.StoreSnapshotService(catalog).create_snapshots("primary")
 
-        mode_after = str(authority_connection.execute("PRAGMA journal_mode").fetchone()[0]).lower()
         sidecars_after = _live_sidecar_inodes(source)
+        if authority_connection is None:
+            mode_after = _read_journal_mode(source)
+        else:
+            mode_after = str(
+                authority_connection.execute("PRAGMA journal_mode").fetchone()[0]
+            ).lower()
     finally:
-        authority_connection.close()
+        if authority_connection is not None:
+            authority_connection.rollback()
+            authority_connection.close()
 
     assert result.verification == "ok"
-    assert set(sidecars_after) == set(sidecars_before)
-    assert sidecars_after == sidecars_before
-    assert mode_before == observed_mode
-    assert mode_after == observed_mode
-    # Deliberately do not compare sidecar bytes or mtimes. A WAL reader's
-    # read-mark bookkeeping may legitimately update -shm bytes in place; inode
-    # stability is what proves there was no unlink-and-recreate cycle.
+    for suffix, identity in sidecars_before.items():
+        assert sidecars_after.get(suffix) == identity
+    if observed_mode == "wal" and authority_connection is None:
+        assert set(sidecars_after) - set(sidecars_before) <= {"-wal", "-shm"}
+    if observed_mode != "wal":
+        assert not {"-wal", "-shm"}.intersection(sidecars_after)
+        assert set(sidecars_after) <= set(sidecars_before)
+    assert mode_after == mode_before
+    # Deliberately do not compare sidecar bytes or mtimes. The daemon-owned
+    # WAL reader may create -wal/-shm for a dormant store and legitimately
+    # update -shm read marks in place. Preserving each preexisting (dev, ino)
+    # is what excludes the #889 unlink-and-recreate orphan vector.
 
 
 @pytest.mark.parametrize("requested_mode", ["delete", "truncate", "wal"])
@@ -493,6 +533,150 @@ def test_missing_registered_store_is_reported_without_sinking_batch(tmp_path: Pa
     assert missing.snapshot_path is None
     assert missing.verification == "skipped"
     assert missing.error == "source_missing"
+
+
+def test_raw_per_store_database_and_os_errors_are_wrapped_and_batch_continues(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    snapshot = _snapshot_module()
+    first = tmp_path / "first.db"
+    second = tmp_path / "second.db"
+    first_connection, first_mode = _create_store(first)
+    second_connection, second_mode = _create_store(second)
+    first_connection.close()
+    second_connection.close()
+    catalog = _catalog_for(
+        tmp_path,
+        first,
+        logical_name="first",
+        journal_mode=first_mode,
+    )
+    catalog.register(
+        "second",
+        second,
+        journal_mode=second_mode,
+        owner="test-owner",
+    )
+    service = snapshot.StoreSnapshotService(catalog)
+    raw_errors = {
+        "first": sqlite3.DatabaseError("file is not a database"),
+        "second": OSError("simulated I/O failure"),
+    }
+
+    def _fail(selected) -> None:
+        raise raw_errors[selected.logical_names[0]]
+
+    monkeypatch.setattr(service, "_snapshot_selected", _fail)
+
+    results = service.create_snapshots()
+
+    assert [result.status for result in results] == ["failed", "failed"]
+    for result in results:
+        assert isinstance(result.error, snapshot.StoreSnapshotError)
+        assert result.error.__cause__ is raw_errors[result.logical_names[0]]
+
+
+def test_snapshot_outcome_is_reported_before_the_next_store_starts(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    snapshot = _snapshot_module()
+    first = tmp_path / "first.db"
+    second = tmp_path / "second.db"
+    first_connection, first_mode = _create_store(first)
+    second_connection, second_mode = _create_store(second)
+    first_connection.close()
+    second_connection.close()
+    catalog = _catalog_for(
+        tmp_path,
+        first,
+        logical_name="first",
+        journal_mode=first_mode,
+    )
+    catalog.register(
+        "second",
+        second,
+        journal_mode=second_mode,
+        owner="test-owner",
+    )
+    service = snapshot.StoreSnapshotService(catalog)
+    snapshot_selected = service._snapshot_selected
+    outcomes = []
+    calls = 0
+
+    def _snapshot_in_order(selected):
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            assert [outcome.logical_names for outcome in outcomes] == [("first",)]
+            raise sqlite3.DatabaseError("file is not a database")
+        return snapshot_selected(selected)
+
+    monkeypatch.setattr(service, "_snapshot_selected", _snapshot_in_order)
+
+    results = service.create_snapshots(on_outcome=outcomes.append)
+
+    assert [result.status for result in results] == ["published", "failed"]
+    assert outcomes == results
+
+
+def test_corrupt_store_returns_audited_partial_success_after_good_publish(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    client = _snapshot_api_client(monkeypatch, tmp_path)
+    service = client.app.state.store_snapshot_service
+    data_root = Path(service._catalog.expected_root)
+    good = data_root / "round2-good.db"
+    corrupt = data_root / "round2-corrupt.db"
+    good_connection, good_mode = _create_store(good)
+    good_connection.close()
+    corrupt.write_bytes(b"this is not a sqlite database")
+    service._catalog.register(
+        "round2_good",
+        good,
+        journal_mode=good_mode,
+        owner="test-owner",
+    )
+    service._catalog.register(
+        "round2_corrupt",
+        corrupt,
+        journal_mode="delete",
+        owner="test-owner",
+    )
+
+    response = client.post(
+        "/internal/stores/snapshot",
+        headers=_signed_snapshot_headers(client, "operator"),
+        json={},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "partial_success"
+    by_name = {item["logical_name"]: item for item in payload["snapshots"]}
+    published = by_name["round2_good"]
+    failed = by_name["round2_corrupt"]
+    assert published["status"] == "published"
+    assert set(published) >= {"logical_name", "status", "path"}
+    assert Path(published["path"]).is_file()
+    assert failed["status"] == "failed"
+    assert set(failed) >= {"logical_name", "status", "error"}
+    assert "DatabaseError" in failed["error"]
+
+    entries = client.app.state.audit.get_log(event="store_snapshot", limit=500)
+    summaries = [json.loads(entry.tool_input_summary) for entry in entries]
+    published_audit = next(
+        item for item in summaries if "round2_good" in item["result_logical_names"]
+    )
+    failed_audit = next(
+        item for item in summaries if "round2_corrupt" in item["result_logical_names"]
+    )
+    assert published_audit["status"] == "published"
+    assert published_audit["path"] == published["path"]
+    assert failed_audit["status"] == "failed"
+    assert "DatabaseError" in failed_audit["error"]
 
 
 def test_snapshot_endpoint_rate_limits_before_third_request_does_work(

--- a/tests/test_store_snapshot.py
+++ b/tests/test_store_snapshot.py
@@ -1,0 +1,424 @@
+"""P0.3 contracts for daemon-owned, catalog-selected SQLite snapshots."""
+
+from __future__ import annotations
+
+import ast
+import importlib
+import json
+import os
+import sqlite3
+import threading
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from pinky_daemon.api import create_api
+from pinky_daemon.auth import build_internal_auth_headers
+from pinky_daemon.store_catalog import StoreCatalog
+
+
+def _snapshot_module():
+    return importlib.import_module("pinky_daemon.store_snapshot")
+
+
+def _create_store(
+    path: Path,
+    *,
+    journal_mode: str = "delete",
+    rows: int = 3,
+) -> tuple[sqlite3.Connection, str]:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    connection = sqlite3.connect(path)
+    observed_mode = str(
+        connection.execute(f"PRAGMA journal_mode={journal_mode}").fetchone()[0]
+    ).lower()
+    connection.execute("CREATE TABLE inventory (id INTEGER PRIMARY KEY, value TEXT NOT NULL)")
+    connection.executemany(
+        "INSERT INTO inventory(value) VALUES (?)",
+        [(f"row-{index}",) for index in range(rows)],
+    )
+    connection.commit()
+    return connection, observed_mode
+
+
+def _catalog_for(
+    root: Path,
+    path: Path,
+    *,
+    logical_name: str = "primary",
+    journal_mode: str = "delete",
+    criticality: str = "authoritative",
+) -> StoreCatalog:
+    catalog = StoreCatalog(expected_root=root, silence_allowlist={})
+    catalog.register(
+        logical_name,
+        path,
+        journal_mode=journal_mode,
+        owner="test-owner",
+        criticality=criticality,
+    )
+    return catalog
+
+
+def _live_sidecars(path: Path) -> set[str]:
+    return {
+        suffix
+        for suffix in ("-wal", "-shm", "-journal")
+        if path.with_name(path.name + suffix).exists()
+    }
+
+
+def test_consistent_copy_reproduces_inventory_and_passes_quick_check(tmp_path: Path) -> None:
+    snapshot = _snapshot_module()
+    source = tmp_path / "primary.db"
+    connection, mode = _create_store(source, rows=7)
+    connection.close()
+    catalog = _catalog_for(tmp_path, source, journal_mode=mode)
+
+    [result] = snapshot.StoreSnapshotService(catalog).create_snapshots("primary")
+
+    assert result.verification == "ok"
+    assert result.error is None
+    assert result.snapshot_path is not None
+    copy = sqlite3.connect(result.snapshot_path)
+    try:
+        assert copy.execute("PRAGMA quick_check").fetchall() == [("ok",)]
+        assert copy.execute("SELECT id, value FROM inventory ORDER BY id").fetchall() == [
+            (index + 1, f"row-{index}") for index in range(7)
+        ]
+    finally:
+        copy.close()
+
+
+def test_external_snapshot_reader_never_touches_live_sidecars(tmp_path: Path) -> None:
+    snapshot = _snapshot_module()
+    source = tmp_path / "rollback.db"
+    authority_connection, mode = _create_store(source, journal_mode="delete")
+    catalog = _catalog_for(tmp_path, source, journal_mode=mode)
+    before = _live_sidecars(source)
+
+    [result] = snapshot.StoreSnapshotService(catalog).create_snapshots("primary")
+    reader = sqlite3.connect(result.snapshot_path)
+    try:
+        assert reader.execute("SELECT COUNT(*) FROM inventory").fetchone() == (3,)
+    finally:
+        reader.close()
+        authority_connection.close()
+
+    assert _live_sidecars(source) == before
+
+
+@pytest.mark.parametrize("requested_mode", ["delete", "truncate", "wal"])
+def test_snapshot_never_mutates_source_journal_mode(
+    tmp_path: Path,
+    requested_mode: str,
+) -> None:
+    snapshot = _snapshot_module()
+    source = tmp_path / f"{requested_mode}.db"
+    authority_connection, observed_mode = _create_store(
+        source,
+        journal_mode=requested_mode,
+    )
+    catalog = _catalog_for(tmp_path, source, journal_mode=observed_mode)
+
+    snapshot.StoreSnapshotService(catalog).create_snapshots("primary")
+
+    try:
+        mode_after = str(authority_connection.execute("PRAGMA journal_mode").fetchone()[0]).lower()
+    finally:
+        authority_connection.close()
+    assert mode_after == observed_mode
+
+
+def test_snapshot_is_a_distinct_inode_not_a_hardlink(tmp_path: Path) -> None:
+    snapshot = _snapshot_module()
+    source = tmp_path / "primary.db"
+    connection, mode = _create_store(source)
+    connection.close()
+    catalog = _catalog_for(tmp_path, source, journal_mode=mode)
+
+    [result] = snapshot.StoreSnapshotService(catalog).create_snapshots("primary")
+
+    source_stat = source.stat()
+    snapshot_stat = Path(result.snapshot_path).stat()
+    assert (snapshot_stat.st_dev, snapshot_stat.st_ino) != (
+        source_stat.st_dev,
+        source_stat.st_ino,
+    )
+
+
+def test_snapshot_directory_stays_clean_under_catalog_reconciliation(tmp_path: Path) -> None:
+    snapshot = _snapshot_module()
+    source = tmp_path / "primary.db"
+    connection, mode = _create_store(source)
+    connection.close()
+    catalog = _catalog_for(tmp_path, source, journal_mode=mode)
+
+    snapshot.StoreSnapshotService(catalog).create_snapshots("primary")
+
+    assert catalog.reconcile_filesystem() == []
+
+
+def test_snapshot_is_consistent_when_source_commit_lands_mid_backup(tmp_path: Path) -> None:
+    snapshot = _snapshot_module()
+    source = tmp_path / "busy.db"
+    authority = sqlite3.connect(source)
+    mode = str(authority.execute("PRAGMA journal_mode=WAL").fetchone()[0]).lower()
+    authority.executescript(
+        """
+        CREATE TABLE left_rows (id INTEGER PRIMARY KEY, payload BLOB NOT NULL);
+        CREATE TABLE right_rows (id INTEGER PRIMARY KEY, payload BLOB NOT NULL);
+        """
+    )
+    payload = b"x" * 4096
+    authority.executemany(
+        "INSERT INTO left_rows(id, payload) VALUES (?, ?)",
+        [(index, payload) for index in range(1, 1501)],
+    )
+    authority.executemany(
+        "INSERT INTO right_rows(id, payload) VALUES (?, ?)",
+        [(index, payload) for index in range(1, 1501)],
+    )
+    authority.commit()
+    catalog = _catalog_for(tmp_path, source, journal_mode=mode)
+    backup_started = threading.Event()
+    writer_committed = threading.Event()
+    writer_errors: list[BaseException] = []
+
+    class CoordinatedSnapshotService(snapshot.StoreSnapshotService):
+        def _backup_progress(self, _status: int, remaining: int, _total: int) -> None:
+            if remaining and not backup_started.is_set():
+                backup_started.set()
+                assert writer_committed.wait(10), "writer did not commit during backup"
+
+    def _write_during_backup() -> None:
+        try:
+            assert backup_started.wait(10), "backup never reached a partial page step"
+            writer = sqlite3.connect(source, timeout=10)
+            try:
+                writer.execute("BEGIN IMMEDIATE")
+                writer.execute(
+                    "INSERT INTO left_rows(id, payload) VALUES (?, ?)",
+                    (1501, payload),
+                )
+                writer.execute(
+                    "INSERT INTO right_rows(id, payload) VALUES (?, ?)",
+                    (1501, payload),
+                )
+                writer.commit()
+            finally:
+                writer.close()
+        except BaseException as exc:  # noqa: BLE001 - re-raised in the test thread
+            writer_errors.append(exc)
+        finally:
+            writer_committed.set()
+
+    writer_thread = threading.Thread(target=_write_during_backup)
+    writer_thread.start()
+    try:
+        [result] = CoordinatedSnapshotService(catalog).create_snapshots("primary")
+    finally:
+        writer_thread.join(timeout=15)
+        authority.close()
+
+    assert not writer_thread.is_alive()
+    assert writer_errors == []
+    copy = sqlite3.connect(result.snapshot_path)
+    try:
+        assert copy.execute("PRAGMA quick_check").fetchall() == [("ok",)]
+        left_ids = copy.execute("SELECT id FROM left_rows ORDER BY id").fetchall()
+        right_ids = copy.execute("SELECT id FROM right_rows ORDER BY id").fetchall()
+    finally:
+        copy.close()
+    assert left_ids == right_ids
+    assert len(left_ids) in {1500, 1501}
+
+
+def test_selection_fails_closed_before_opening_unknown_or_outside_store(
+    tmp_path: Path,
+) -> None:
+    snapshot = _snapshot_module()
+    root = tmp_path / "data"
+    root.mkdir()
+    registered = root / "registered.db"
+    connection, mode = _create_store(registered)
+    connection.close()
+    outside = tmp_path / "outside.db"
+    outside_connection, outside_mode = _create_store(outside)
+    outside_connection.close()
+    catalog = _catalog_for(root, registered, journal_mode=mode)
+    catalog.register(
+        "outside",
+        outside,
+        journal_mode=outside_mode,
+        owner="test-owner",
+    )
+    service = snapshot.StoreSnapshotService(catalog)
+
+    with patch.object(snapshot.sqlite3, "connect") as connect:
+        with pytest.raises(snapshot.StoreSnapshotSelectionError, match="unregistered"):
+            service.create_snapshots("unknown")
+        with pytest.raises(snapshot.StoreSnapshotSelectionError, match="expected root"):
+            service.create_snapshots("outside")
+
+    connect.assert_not_called()
+
+
+def _snapshot_api_client(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> TestClient:
+    monkeypatch.setenv("PINKY_SESSION_SECRET", "snapshot-test-secret")
+    monkeypatch.delenv("PINKY_UI_PASSWORD", raising=False)
+    data_dir = tmp_path / "api-data"
+    app = create_api(
+        max_sessions=10,
+        default_working_dir=str(tmp_path),
+        db_path=str(data_dir / "conversations.db"),
+    )
+    app.state.agents.register(
+        "operator",
+        model="opus",
+        role="operator",
+        working_dir=str(tmp_path / "operator"),
+    )
+    app.state.agents.register(
+        "tenant",
+        model="opus",
+        isolated=True,
+        working_dir=str(tmp_path / "tenant"),
+    )
+    return TestClient(app)
+
+
+def _signed_snapshot_headers(client: TestClient, agent_name: str) -> dict[str, str]:
+    key = client.app.state.agents.get_signing_key(agent_name)
+    return build_internal_auth_headers(
+        key,
+        agent_name=agent_name,
+        method="POST",
+        path="/internal/stores/snapshot",
+    )
+
+
+def test_snapshot_endpoint_denies_unauthenticated_session_only_and_isolated_callers(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    client = _snapshot_api_client(monkeypatch, tmp_path)
+    worker = Mock()
+    client.app.state.store_snapshot_service.create_snapshots = worker
+
+    unauthenticated = client.post("/internal/stores/snapshot", json={})
+    assert unauthenticated.status_code == 401
+
+    client.post("/auth/setup", json={"password": "hunter22", "next": "/"})
+    session_only = client.post("/internal/stores/snapshot", json={})
+    assert session_only.status_code == 403
+
+    isolated = client.post(
+        "/internal/stores/snapshot",
+        headers=_signed_snapshot_headers(client, "tenant"),
+        json={},
+    )
+    assert isolated.status_code == 403
+    worker.assert_not_called()
+
+
+def test_successful_snapshot_request_is_audited_with_caller_selection_and_paths(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    client = _snapshot_api_client(monkeypatch, tmp_path)
+    response = client.post(
+        "/internal/stores/snapshot",
+        headers=_signed_snapshot_headers(client, "operator"),
+        json={"logical_name": "conversations"},
+    )
+
+    assert response.status_code == 200
+    paths = [item["snapshot_path"] for item in response.json()["snapshots"]]
+    entries = client.app.state.audit.get_log(event="store_snapshot", limit=5)
+    assert len(entries) == 1
+    entry = entries[0]
+    assert entry.agent_name == "operator"
+    assert entry.timestamp > 0
+    summary = json.loads(entry.tool_input_summary)
+    assert summary["logical_name"] == "conversations"
+    assert summary["snapshot_paths"] == paths
+
+
+def test_missing_registered_store_is_reported_without_sinking_batch(tmp_path: Path) -> None:
+    snapshot = _snapshot_module()
+    source = tmp_path / "present.db"
+    connection, mode = _create_store(source)
+    connection.close()
+    catalog = _catalog_for(
+        tmp_path,
+        source,
+        logical_name="present",
+        journal_mode=mode,
+    )
+    catalog.register(
+        "missing",
+        tmp_path / "missing.db",
+        journal_mode="delete",
+        owner="test-owner",
+    )
+
+    results = snapshot.StoreSnapshotService(catalog).create_snapshots()
+
+    by_name = {result.logical_names: result for result in results}
+    assert by_name[("present",)].verification == "ok"
+    assert Path(by_name[("present",)].snapshot_path).is_file()
+    missing = by_name[("missing",)]
+    assert missing.snapshot_path is None
+    assert missing.verification == "skipped"
+    assert missing.error == "source_missing"
+
+
+def test_snapshot_endpoint_rate_limits_before_third_request_does_work(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    snapshot = _snapshot_module()
+    client = _snapshot_api_client(monkeypatch, tmp_path)
+    result = snapshot.SnapshotResult(
+        logical_names=("conversations",),
+        snapshot_path=str(tmp_path / "copy.db"),
+        verification="ok",
+        error=None,
+    )
+    worker = Mock(return_value=[result])
+    client.app.state.store_snapshot_service.create_snapshots = worker
+    headers = _signed_snapshot_headers(client, "operator")
+
+    first = client.post("/internal/stores/snapshot", headers=headers, json={})
+    second = client.post("/internal/stores/snapshot", headers=headers, json={})
+    third = client.post("/internal/stores/snapshot", headers=headers, json={})
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert third.status_code == 429
+    assert int(third.headers["Retry-After"]) >= 1
+    assert worker.call_count == 2
+
+
+def test_cli_is_endpoint_only_and_requires_explicit_signing_identity() -> None:
+    script = Path(__file__).resolve().parents[1] / "scripts" / "store_snapshot.py"
+    source = script.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+
+    imported_modules = {
+        alias.name
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Import)
+        for alias in node.names
+    }
+    imported_from = {node.module for node in ast.walk(tree) if isinstance(node, ast.ImportFrom)}
+    assert "sqlite3" not in imported_modules
+    assert "sqlite3" not in imported_from
+    assert "/internal/stores/snapshot" in source
+    assert "--as-agent" in source
+    assert "PINKY_AGENT_NAME" in source
+    assert source.index("PINKY_AGENT_KEY") < source.index("PINKY_SESSION_SECRET")
+    assert not os.path.exists(script.with_name("safe_db_read.py"))

--- a/tests/test_store_snapshot.py
+++ b/tests/test_store_snapshot.py
@@ -517,3 +517,69 @@ def test_cli_is_endpoint_only_and_requires_explicit_signing_identity() -> None:
     assert "PINKY_AGENT_NAME" in source
     assert source.index("PINKY_AGENT_KEY") < source.index("PINKY_SESSION_SECRET")
     assert not os.path.exists(script.with_name("safe_db_read.py"))
+
+
+def test_cli_signs_endpoint_request_and_prints_only_returned_copy_path(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    script = Path(__file__).resolve().parents[1] / "scripts" / "store_snapshot.py"
+    spec = importlib.util.spec_from_file_location("store_snapshot_cli", script)
+    assert spec is not None and spec.loader is not None
+    cli = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(cli)
+    captured_requests = []
+
+    class Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args) -> None:
+            return None
+
+        def read(self) -> bytes:
+            return json.dumps(
+                {
+                    "snapshots": [
+                        {
+                            "logical_names": ["conversations"],
+                            "snapshot_path": "/data/snapshots/conversations-copy.db",
+                            "verification": "ok",
+                            "error": None,
+                        }
+                    ]
+                }
+            ).encode()
+
+    def _urlopen(request, *, timeout: float):
+        captured_requests.append((request, timeout))
+        return Response()
+
+    monkeypatch.setenv("PINKY_AGENT_KEY", "agent-specific-secret")
+    monkeypatch.setenv("PINKY_SESSION_SECRET", "global-secret-must-not-win")
+    monkeypatch.setattr(cli.urllib.request, "urlopen", _urlopen)
+
+    assert (
+        cli.main(
+            [
+                "--as-agent",
+                "operator",
+                "--logical-name",
+                "conversations",
+                "--api-url",
+                "http://127.0.0.1:9999",
+            ]
+        )
+        == 0
+    )
+
+    output = capsys.readouterr()
+    assert output.out == "/data/snapshots/conversations-copy.db\n"
+    assert output.err == ""
+    [(request, timeout)] = captured_requests
+    assert request.full_url == "http://127.0.0.1:9999/internal/stores/snapshot"
+    assert request.get_method() == "POST"
+    assert json.loads(request.data) == {"logical_name": "conversations"}
+    assert request.headers["X-pinky-agent"] == "operator"
+    assert request.headers["X-pinky-signature"]
+    assert timeout == 300.0


### PR DESCRIPTION
## What

Adds an owner-controlled snapshot tool (P0.3, #1112) — a daemon-internal, authenticated mechanism that produces consistent point-in-time copies of registered SQLite stores without any external process opening a live database file.

## Why

The deleted-WAL corruption family (#889) is rooted in external processes opening a live daemon database: their `close()` runs SQLite's checkpoint+unlink through the daemon's held descriptors and orphans them. The prior `scripts/safe_db_read.py` was WAL-shaped and dropped in #1107; operators still need a safe way to read/back up store data. This provides one that never opens a live file from outside the daemon.

## What it does

- A daemon-only `StoreSnapshotService` uses SQLite's Online Backup API (`Connection.backup(pages=64, sleep=.01)`) from a read-only source connection to produce a consistent copy under concurrent writes — same process, so the single storage authority is preserved (the exact distinction from an external reader).
- The source connection runs no SQL and never mutates journal mode. It may create/update the normal WAL reader-coordination sidecars (`-wal`/`-shm`) but never deletes, unlinks, or recreates a preexisting sidecar (the orphan vector). Store inventory comes from the `StoreCatalog` (registered realpath + journal mode); selection is catalog-only and fail-closed.
- Output lands in a `snapshots/` subdirectory (exempt from the boot-time reconciler's unclaimed-file warnings; inode-alias coverage still applies), written to a temp name, `quick_check`-verified, distinct-inode-checked, then atomically renamed. A per-store failure (missing/corrupt source) is recorded under explicit partial-success semantics and audited — a later failure never leaves an earlier published snapshot unaudited, and good snapshots are never rolled back.
- An authenticated signed endpoint (`POST /internal/stores/snapshot`, non-isolated registered caller only; session/isolated/unknown denied) with a per-caller rate limit; a thin `scripts/` CLI wrapper that only calls the endpoint and reads the returned path (opens no database itself).
- Catalog-selection denials and every per-store snapshot outcome are audited.

## Scope / non-goals

No scheduler/cron, no restore path (a later increment), no incremental/dedup. On-demand consistent-copy primitive only. Folds in the backup-API follow-up left open when `safe_db_read.py` was dropped in #1107.
