### PR TITLE
Fail closed on corrupt daemon SQLite stores

### DIFF
--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -195,7 +195,11 @@ from pinky_daemon.shared_mcp import (
 )
 from pinky_daemon.skill_loader import discover_all_skills, register_discovered_skills
 from pinky_daemon.skill_store import SkillStore
-from pinky_daemon.store_catalog import StoreCatalog, StoreCatalogError
+from pinky_daemon.store_catalog import (
+    StoreCatalog,
+    StoreCatalogError,
+    StoreIntegrityTarget,
+)
 from pinky_daemon.store_snapshot import (
     SnapshotResult,
     StoreSnapshotError,
@@ -1693,6 +1697,56 @@ def _frontend_build_status(
 # ── API Server ───────────────────────────────────────────────
 
 
+def _derive_api_store_manifest(
+    db_path: str | os.PathLike[str],
+) -> dict[str, StoreIntegrityTarget]:
+    """Return the single path and recovery manifest for API boot-opened stores."""
+    base = os.path.realpath(os.fspath(db_path))
+    data_dir = Path(base).parent
+
+    def authoritative(logical_name: str, path: str) -> StoreIntegrityTarget:
+        return StoreIntegrityTarget(
+            logical_name=logical_name,
+            path=path,
+            criticality="authoritative",
+            recovery="snapshot",
+        )
+
+    manifest = {
+        "sessions": authoritative("sessions", base.replace(".db", "_sessions.db")),
+        "session_events": authoritative("session_events", base.replace(".db", "_sessions.db")),
+        "conversations": authoritative("conversations", base),
+        "analytics": authoritative("analytics", base.replace(".db", "_analytics.db")),
+        "agents": authoritative("agents", base.replace(".db", "_agents.db")),
+        "audit": authoritative("audit", base.replace(".db", "_audit.db")),
+        "agent_comms": authoritative("agent_comms", base.replace(".db", "_agent_comms.db")),
+        "activity": authoritative("activity", base.replace(".db", "_activity.db")),
+        "message_context": authoritative(
+            "message_context", base.replace(".db", "_message_context.db")
+        ),
+        "dream_state": authoritative("dream_state", base.replace(".db", "_dream_state.db")),
+        "skills": authoritative("skills", base.replace(".db", "_skills.db")),
+        "plugins": authoritative("plugins", base.replace(".db", "_plugins.db")),
+        "outreach_config": authoritative("outreach_config", base.replace(".db", "_outreach.db")),
+        "tasks": authoritative("tasks", base.replace(".db", "_tasks.db")),
+        "research": authoritative("research", base.replace(".db", "_research.db")),
+        "presentations": authoritative("presentations", base.replace(".db", "_presentations.db")),
+        "apps": authoritative("apps", base.replace(".db", "_apps.db")),
+        "triggers": authoritative("triggers", base.replace(".db", "_triggers.db")),
+        "mesh": authoritative("mesh", base.replace(".db", "_mesh.db")),
+        "kb": authoritative("kb", os.fspath(data_dir / "kb" / "kb.db")),
+        "librarian_state": StoreIntegrityTarget(
+            logical_name="librarian_state",
+            path=base.replace(".db", "_librarian_state.db"),
+            criticality="derived",
+            recovery="rebuild",
+        ),
+        "voice": authoritative("voice", os.fspath(data_dir / "voice_calls.db")),
+        "user_profiles": authoritative("user_profiles", os.fspath(data_dir / "user_profiles.db")),
+    }
+    return manifest
+
+
 def create_api(
     *,
     max_sessions: int = 50,
@@ -1704,6 +1758,8 @@ def create_api(
     db_path = os.path.realpath(db_path)
     _data_dir = Path(db_path).parent
     store_catalog = StoreCatalog(expected_root=_data_dir)
+    store_manifest = _derive_api_store_manifest(db_path)
+    store_catalog.preflight_integrity(store_manifest.values())
     store_snapshot_service = StoreSnapshotService(store_catalog)
 
     app = FastAPI(
@@ -1770,24 +1826,16 @@ def create_api(
             response.headers["Strict-Transport-Security"] = "max-age=31536000; includeSubDomains"
         return response
 
-    session_store = SessionStore(
-        db_path=db_path.replace(".db", "_sessions.db"), catalog=store_catalog
-    )
+    session_store = SessionStore(db_path=store_manifest["sessions"].path, catalog=store_catalog)
     session_event_store = SessionEventStore(
-        db_path=db_path.replace(".db", "_sessions.db"), catalog=store_catalog
+        db_path=store_manifest["session_events"].path, catalog=store_catalog
     )
-    store = ConversationStore(db_path=db_path, catalog=store_catalog)
-    analytics = AnalyticsStore(
-        db_path=db_path.replace(".db", "_analytics.db"), catalog=store_catalog
-    )
-    agents = AgentRegistry(
-        db_path=db_path.replace(".db", "_agents.db"), catalog=store_catalog
-    )
+    store = ConversationStore(db_path=store_manifest["conversations"].path, catalog=store_catalog)
+    analytics = AnalyticsStore(db_path=store_manifest["analytics"].path, catalog=store_catalog)
+    agents = AgentRegistry(db_path=store_manifest["agents"].path, catalog=store_catalog)
     _run_grandfather_approved_users_migration(store, agents)
     _refresh_1m_models(agents)
-    audit = AuditStore(
-        db_path=db_path.replace(".db", "_audit.db"), catalog=store_catalog
-    )
+    audit = AuditStore(db_path=store_manifest["audit"].path, catalog=store_catalog)
     app.state.audit = audit
     hooks = HookManager(audit_store=audit)
 
@@ -1811,7 +1859,7 @@ def create_api(
         conversation_store=store, agent_registry=agents,
         hook_manager=hooks,
     )
-    _comms_db = db_path.replace(".db", "_agent_comms.db")
+    _comms_db = store_manifest["agent_comms"].path
     comms = AgentComms(db_path=_comms_db, catalog=store_catalog)
 
     # Auth-failure tracker — counts SDK auth errors across all streaming
@@ -2577,11 +2625,9 @@ def create_api(
         )
         return result
 
-    activity = ActivityStore(
-        db_path=db_path.replace(".db", "_activity.db"), catalog=store_catalog
-    )
+    activity = ActivityStore(db_path=store_manifest["activity"].path, catalog=store_catalog)
     message_context_store = MessageContextStore(
-        db_path=db_path.replace(".db", "_message_context.db"),
+        db_path=store_manifest["message_context"].path,
         catalog=store_catalog,
     )
     app.state.activity = activity
@@ -2730,7 +2776,7 @@ def create_api(
         return [m.to_dict() for m in messages]
 
     dream_runner = DreamRunner(
-        db_path=db_path.replace(".db", "_dream_state.db"),
+        db_path=store_manifest["dream_state"].path,
         history_provider=lambda agent_name, after_ts, limit, role: _resolve_agent_history(
             agent_name,
             after_ts=after_ts,
@@ -4156,9 +4202,7 @@ def create_api(
 
         return closed
 
-    skills = SkillStore(
-        db_path=db_path.replace(".db", "_skills.db"), catalog=store_catalog
-    )
+    skills = SkillStore(db_path=store_manifest["skills"].path, catalog=store_catalog)
     _seed_core_skills(skills)
 
     # Discover SKILL.md files from filesystem and register them
@@ -4169,7 +4213,7 @@ def create_api(
 
     # Initialize plugin manager and discover Python plugins
     plugins = PluginManager(
-        db_path=db_path.replace(".db", "_plugins.db"),
+        db_path=store_manifest["plugins"].path,
         api_url="http://localhost:8888",
         working_dir=default_working_dir,
         catalog=store_catalog,
@@ -4183,26 +4227,16 @@ def create_api(
             plugins.register_in_skill_store(skills, pname)
 
     outreach_config = OutreachConfigStore(
-        db_path=db_path.replace(".db", "_outreach.db"), catalog=store_catalog
+        db_path=store_manifest["outreach_config"].path, catalog=store_catalog
     )
-    tasks = TaskStore(
-        db_path=db_path.replace(".db", "_tasks.db"), catalog=store_catalog
-    )
-    research = ResearchStore(
-        db_path=db_path.replace(".db", "_research.db"), catalog=store_catalog
-    )
+    tasks = TaskStore(db_path=store_manifest["tasks"].path, catalog=store_catalog)
+    research = ResearchStore(db_path=store_manifest["research"].path, catalog=store_catalog)
     presentations = PresentationStore(
-        db_path=db_path.replace(".db", "_presentations.db"), catalog=store_catalog
+        db_path=store_manifest["presentations"].path, catalog=store_catalog
     )
-    app_store = AppStore(
-        db_path=db_path.replace(".db", "_apps.db"), catalog=store_catalog
-    )
-    trigger_store = TriggerStore(
-        db_path=db_path.replace(".db", "_triggers.db"), catalog=store_catalog
-    )
-    mesh_store = MeshStore(
-        db_path=db_path.replace(".db", "_mesh.db"), catalog=store_catalog
-    )
+    app_store = AppStore(db_path=store_manifest["apps"].path, catalog=store_catalog)
+    trigger_store = TriggerStore(db_path=store_manifest["triggers"].path, catalog=store_catalog)
+    mesh_store = MeshStore(db_path=store_manifest["mesh"].path, catalog=store_catalog)
 
     # Ferry host-callback (cross-fleet inbound). Constructed here so it shares
     # the live registry + broker + mesh_store; stashed on app.state for the
@@ -4220,12 +4254,15 @@ def create_api(
     )
 
     # Knowledge Base — project-level, all agents share
-    kb = KBStore(data_dir=_data_dir, catalog=store_catalog)
+    kb = KBStore(
+        data_dir=Path(store_manifest["kb"].path).parent.parent,
+        catalog=store_catalog,
+    )
 
     # KB Librarian runner — curates wiki pages from raw sources
     librarian_runner = LibrarianRunner(
         kb_store=kb,
-        db_path=db_path.replace(".db", "_librarian_state.db"),
+        db_path=store_manifest["librarian_state"].path,
         catalog=store_catalog,
     )
     app.state.librarian_runner = librarian_runner
@@ -4499,9 +4536,7 @@ def create_api(
         from pinky_daemon.voice_routes import set_dependencies as _voice_set_deps
         from pinky_daemon.voice_store import VoiceStore
 
-        _voice_store = VoiceStore(
-            db_path=str(_data_dir / "voice_calls.db"), catalog=store_catalog
-        )
+        _voice_store = VoiceStore(db_path=store_manifest["voice"].path, catalog=store_catalog)
         _voice_base_url = (
             agents.get_setting("PINKY_BASE_URL")
             or os.environ.get("PINKY_BASE_URL", "")
@@ -13532,7 +13567,7 @@ npm run build</pre>
     from pinky_daemon.user_profile_store import UserProfileStore
 
     user_profiles = UserProfileStore(
-        db_path=str(_data_dir / "user_profiles.db"), catalog=store_catalog
+        db_path=store_manifest["user_profiles"].path, catalog=store_catalog
     )
 
     from pinky_daemon.routes.user_profiles import router as _user_profiles_router

--- a/src/pinky_daemon/store_catalog.py
+++ b/src/pinky_daemon/store_catalog.py
@@ -238,6 +238,8 @@ class StoreCatalog:
                 finally:
                     connection.close()
             except (sqlite3.Error, OSError) as exc:
+                if self._path_is_absent(resolved_path):
+                    continue
                 self._raise_integrity_error(matching_targets, resolved_path, exc)
 
             if rows != [("ok",)]:
@@ -365,6 +367,14 @@ class StoreCatalog:
         except OSError:
             return None
         return (stat.st_dev, stat.st_ino)
+
+    @classmethod
+    def _path_is_absent(cls, path: str) -> bool:
+        try:
+            os.stat(path)
+        except OSError as exc:
+            return cls._is_missing_path_error(exc)
+        return False
 
     def _refresh_identities(self) -> None:
         for entry in self._entries:

--- a/src/pinky_daemon/store_catalog.py
+++ b/src/pinky_daemon/store_catalog.py
@@ -7,10 +7,12 @@ import fnmatch
 import logging
 import os
 import re
+import sqlite3
 import stat
 import threading
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
+from pathlib import Path
 from urllib.parse import parse_qsl
 
 logger = logging.getLogger("pinky.store_catalog")
@@ -41,6 +43,16 @@ class StoreRecord:
     criticality: str
     dev_ino: tuple[int, int] | None
     is_memory: bool
+
+
+@dataclass(frozen=True, slots=True)
+class StoreIntegrityTarget:
+    """One API-owned SQLite store that must pass the boot integrity gate."""
+
+    logical_name: str
+    path: str
+    criticality: str = "authoritative"
+    recovery: str = "snapshot"
 
 
 class StoreCatalogError(RuntimeError):
@@ -193,6 +205,78 @@ class StoreCatalog:
             )
 
         return self.reconcile_filesystem()
+
+    def preflight_integrity(self, targets: Iterable[StoreIntegrityTarget]) -> None:
+        """Fail closed when an existing API-owned SQLite file is corrupt.
+
+        Targets that share a physical path are checked once and reported together.
+        Missing and in-memory stores are left for their constructors to create.
+        """
+        targets_by_path: dict[str, list[StoreIntegrityTarget]] = {}
+        for target in targets:
+            raw_path = os.fspath(target.path)
+            if self._is_memory_path(raw_path):
+                continue
+            resolved_path = os.path.realpath(raw_path)
+            targets_by_path.setdefault(resolved_path, []).append(target)
+
+        for resolved_path, matching_targets in targets_by_path.items():
+            try:
+                os.stat(resolved_path)
+            except OSError as exc:
+                if self._is_missing_path_error(exc):
+                    continue
+                self._raise_integrity_error(matching_targets, resolved_path, exc)
+
+            try:
+                connection = sqlite3.connect(
+                    Path(resolved_path).as_uri() + "?mode=ro",
+                    uri=True,
+                )
+                try:
+                    rows = connection.execute("PRAGMA quick_check").fetchall()
+                finally:
+                    connection.close()
+            except (sqlite3.Error, OSError) as exc:
+                self._raise_integrity_error(matching_targets, resolved_path, exc)
+
+            if rows != [("ok",)]:
+                self._raise_integrity_error(
+                    matching_targets,
+                    resolved_path,
+                    f"PRAGMA quick_check returned {rows!r}",
+                )
+
+    @staticmethod
+    def _raise_integrity_error(
+        targets: list[StoreIntegrityTarget],
+        resolved_path: str,
+        detail: BaseException | str,
+    ) -> None:
+        logical_names = ", ".join(target.logical_name for target in targets)
+        if isinstance(detail, BaseException):
+            rendered_detail = f"{type(detail).__name__}: {detail}"
+        else:
+            rendered_detail = detail
+
+        if any(
+            target.criticality == "authoritative" or target.recovery == "snapshot"
+            for target in targets
+        ):
+            recovery = (
+                "Restore the authoritative store from a P0.3 snapshot or backup before restarting."
+            )
+        else:
+            recovery = "Delete the derived store so it can rebuild before restarting."
+
+        error = StoreCatalogError(
+            "Store integrity preflight failed: "
+            f"logical_stores=[{logical_names}] path={resolved_path!r} "
+            f"error={rendered_detail}. {recovery}"
+        )
+        if isinstance(detail, BaseException):
+            raise error from detail
+        raise error
 
     def reconcile_filesystem(self) -> list[str]:
         """Reconcile registered stores with SQLite files found below the data root.

--- a/tests/test_no_direct_db_open.py
+++ b/tests/test_no_direct_db_open.py
@@ -115,6 +115,16 @@ DIRECT_OPEN_ALLOWLIST = {
         ),
     ),
     DirectOpenIdentity(
+        "src/pinky_daemon/store_catalog.py",
+        "StoreCatalog.preflight_integrity",
+    ): AllowlistEntry(
+        expected_count=1,
+        reason=(
+            "Daemon-internal storage authority opens each manifest-selected existing store "
+            "read-only for boot-time PRAGMA quick_check (#1114)."
+        ),
+    ),
+    DirectOpenIdentity(
         "src/pinky_daemon/store_snapshot.py",
         "StoreSnapshotService._backup_and_verify",
     ): AllowlistEntry(

--- a/tests/test_store_integrity.py
+++ b/tests/test_store_integrity.py
@@ -48,9 +48,7 @@ def _manifest(db_path: Path) -> dict[str, Any]:
 def _create_database(path: Path, *, journal_mode: str = "delete") -> sqlite3.Connection:
     path.parent.mkdir(parents=True, exist_ok=True)
     connection = sqlite3.connect(path)
-    observed = str(
-        connection.execute(f"PRAGMA journal_mode={journal_mode}").fetchone()[0]
-    ).lower()
+    observed = str(connection.execute(f"PRAGMA journal_mode={journal_mode}").fetchone()[0]).lower()
     assert observed == journal_mode
     connection.execute("CREATE TABLE inventory (id INTEGER PRIMARY KEY, value TEXT NOT NULL)")
     connection.execute("INSERT INTO inventory(value) VALUES ('seed')")
@@ -160,6 +158,52 @@ def test_absent_store_is_skipped_without_opening(
     catalog = StoreCatalog(expected_root=tmp_path, silence_allowlist={})
 
     _preflight(catalog, [_target("not_created", source)])
+
+
+def test_store_disappearing_during_connect_is_treated_as_absent(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = tmp_path / "raced-away-during-connect.db"
+    connection = _create_database(source)
+    connection.close()
+    real_connect = sqlite3.connect
+
+    def disappear_then_connect(*args: Any, **kwargs: Any) -> sqlite3.Connection:
+        source.unlink()
+        return real_connect(*args, **kwargs)
+
+    monkeypatch.setattr(sqlite3, "connect", disappear_then_connect)
+    catalog = StoreCatalog(expected_root=tmp_path, silence_allowlist={})
+
+    _preflight(catalog, [_target("raced_away_during_connect", source)])
+
+    assert not source.exists()
+
+
+def test_store_disappearing_during_quick_check_is_treated_as_absent(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = tmp_path / "raced-away-during-quick-check.db"
+    connection = _create_database(source)
+    connection.close()
+
+    class DisappearingQuickCheckConnection(_RecordingConnection):
+        def execute(self, statement: str) -> _RecordingConnection:
+            self.statements.append(statement)
+            source.unlink()
+            raise sqlite3.OperationalError("database disappeared during quick_check")
+
+    probe = DisappearingQuickCheckConnection([])
+    monkeypatch.setattr(sqlite3, "connect", lambda *_args, **_kwargs: probe)
+    catalog = StoreCatalog(expected_root=tmp_path, silence_allowlist={})
+
+    _preflight(catalog, [_target("raced_away_during_quick_check", source)])
+
+    assert probe.statements == ["PRAGMA quick_check"]
+    assert probe.closed is True
+    assert not source.exists()
 
 
 def test_memory_store_is_skipped_without_opening(

--- a/tests/test_store_integrity.py
+++ b/tests/test_store_integrity.py
@@ -175,10 +175,14 @@ def test_memory_store_is_skipped_without_opening(
     _preflight(catalog, [_target("memory", ":memory:")])
 
 
-@pytest.mark.parametrize("requested_mode", ["delete", "truncate", "wal"])
+@pytest.mark.parametrize(
+    ("requested_mode", "expected_reopen_mode"),
+    [("delete", "delete"), ("truncate", "delete"), ("wal", "wal")],
+)
 def test_preflight_preserves_sidecar_inodes_and_persisted_journal_mode(
     tmp_path: Path,
     requested_mode: str,
+    expected_reopen_mode: str,
 ) -> None:
     source = tmp_path / f"{requested_mode}.db"
     authority = _create_database(source, journal_mode=requested_mode)
@@ -213,7 +217,9 @@ def test_preflight_preserves_sidecar_inodes_and_persisted_journal_mode(
 
     assert mode_before == requested_mode
     assert mode_after_live == mode_before
-    assert mode_after_reopen == mode_before
+    # SQLite persists only WAL-vs-rollback in the header; TRUNCATE therefore
+    # reopens as DELETE. The probe must preserve that WAL/rollback boundary.
+    assert mode_after_reopen == expected_reopen_mode
     assert sidecars_after == sidecars_before
 
 

--- a/tests/test_store_integrity.py
+++ b/tests/test_store_integrity.py
@@ -1,0 +1,427 @@
+"""P0.4 contracts for fail-closed boot-time SQLite integrity checks."""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from pinky_daemon import api as api_module
+from pinky_daemon import store_catalog as store_catalog_module
+from pinky_daemon.store_catalog import StoreCatalog, StoreCatalogError
+
+
+def _target(
+    logical_name: str,
+    path: str | Path,
+    *,
+    criticality: str = "authoritative",
+    recovery: str = "snapshot",
+) -> Any:
+    target_type = getattr(store_catalog_module, "StoreIntegrityTarget", None)
+    assert target_type is not None, "StoreIntegrityTarget is not implemented"
+    return target_type(
+        logical_name=logical_name,
+        path=os.fspath(path),
+        criticality=criticality,
+        recovery=recovery,
+    )
+
+
+def _preflight(catalog: StoreCatalog, targets: list[Any]) -> None:
+    preflight = getattr(catalog, "preflight_integrity", None)
+    assert preflight is not None, "StoreCatalog.preflight_integrity is not implemented"
+    preflight(targets)
+
+
+def _manifest(db_path: Path) -> dict[str, Any]:
+    derive = getattr(api_module, "_derive_api_store_manifest", None)
+    assert derive is not None, "_derive_api_store_manifest is not implemented"
+    manifest = derive(os.fspath(db_path))
+    assert isinstance(manifest, dict)
+    return manifest
+
+
+def _create_database(path: Path, *, journal_mode: str = "delete") -> sqlite3.Connection:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    connection = sqlite3.connect(path)
+    observed = str(
+        connection.execute(f"PRAGMA journal_mode={journal_mode}").fetchone()[0]
+    ).lower()
+    assert observed == journal_mode
+    connection.execute("CREATE TABLE inventory (id INTEGER PRIMARY KEY, value TEXT NOT NULL)")
+    connection.execute("INSERT INTO inventory(value) VALUES ('seed')")
+    connection.commit()
+    return connection
+
+
+def _sidecar_identities(path: Path) -> dict[str, tuple[int, int]]:
+    identities = {}
+    for suffix in ("-wal", "-shm", "-journal"):
+        sidecar = path.with_name(path.name + suffix)
+        try:
+            sidecar_stat = sidecar.stat()
+        except FileNotFoundError:
+            continue
+        identities[suffix] = (sidecar_stat.st_dev, sidecar_stat.st_ino)
+    return identities
+
+
+class _RecordingConnection:
+    def __init__(self, rows: list[tuple[str]]) -> None:
+        self.rows = rows
+        self.statements: list[str] = []
+        self.closed = False
+
+    def execute(self, statement: str) -> _RecordingConnection:
+        self.statements.append(statement)
+        return self
+
+    def fetchall(self) -> list[tuple[str]]:
+        return self.rows
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def test_corrupt_header_fails_closed_with_store_catalog_error(tmp_path: Path) -> None:
+    source = tmp_path / "user_profiles.db"
+    source.write_bytes(b"\x0d" + b"not-a-sqlite-header" + bytes(4076))
+    catalog = StoreCatalog(expected_root=tmp_path, silence_allowlist={})
+
+    with pytest.raises(StoreCatalogError) as exc_info:
+        _preflight(catalog, [_target("user_profiles", source)])
+
+    message = str(exc_info.value)
+    assert "user_profiles" in message
+    assert os.path.realpath(source) in message
+    assert "file is not a database" in message.lower()
+    assert "P0.3 snapshot" in message
+    assert "before restarting" in message
+
+
+def test_non_ok_quick_check_fails_closed_and_names_all_logical_stores(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = tmp_path / "conversations_sessions.db"
+    source.touch()
+    connection = _RecordingConnection([("*** in database main ***",), ("Page 2 is never used",)])
+    connect_calls: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
+
+    def connect(*args: Any, **kwargs: Any) -> _RecordingConnection:
+        connect_calls.append((args, kwargs))
+        return connection
+
+    monkeypatch.setattr(sqlite3, "connect", connect)
+    catalog = StoreCatalog(expected_root=tmp_path, silence_allowlist={})
+    targets = [
+        _target("sessions", source),
+        _target("session_events", source),
+    ]
+
+    with pytest.raises(StoreCatalogError) as exc_info:
+        _preflight(catalog, targets)
+
+    message = str(exc_info.value)
+    assert "sessions" in message
+    assert "session_events" in message
+    assert os.path.realpath(source) in message
+    assert repr(connection.rows) in message
+    assert connection.statements == ["PRAGMA quick_check"]
+    assert connection.closed is True
+    assert len(connect_calls) == 1
+    assert connect_calls[0][0][0] == source.resolve().as_uri() + "?mode=ro"
+    assert connect_calls[0][1]["uri"] is True
+
+
+def test_clean_store_passes_quick_check_without_false_positive(tmp_path: Path) -> None:
+    source = tmp_path / "tasks.db"
+    connection = _create_database(source)
+    connection.close()
+    catalog = StoreCatalog(expected_root=tmp_path, silence_allowlist={})
+
+    _preflight(catalog, [_target("tasks", source)])
+
+
+def test_absent_store_is_skipped_without_opening(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = tmp_path / "not-created.db"
+
+    def unexpected_connect(*_args: Any, **_kwargs: Any) -> None:
+        pytest.fail("an absent store must not be opened")
+
+    monkeypatch.setattr(sqlite3, "connect", unexpected_connect)
+    catalog = StoreCatalog(expected_root=tmp_path, silence_allowlist={})
+
+    _preflight(catalog, [_target("not_created", source)])
+
+
+def test_memory_store_is_skipped_without_opening(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def unexpected_connect(*_args: Any, **_kwargs: Any) -> None:
+        pytest.fail("an in-memory store must not be opened by the file preflight")
+
+    monkeypatch.setattr(sqlite3, "connect", unexpected_connect)
+    catalog = StoreCatalog(expected_root=tmp_path, silence_allowlist={})
+
+    _preflight(catalog, [_target("memory", ":memory:")])
+
+
+@pytest.mark.parametrize("requested_mode", ["delete", "truncate", "wal"])
+def test_preflight_preserves_sidecar_inodes_and_persisted_journal_mode(
+    tmp_path: Path,
+    requested_mode: str,
+) -> None:
+    source = tmp_path / f"{requested_mode}.db"
+    authority = _create_database(source, journal_mode=requested_mode)
+    try:
+        if requested_mode == "wal":
+            authority.execute("UPDATE inventory SET value = 'wal-live' WHERE id = 1")
+            authority.commit()
+        else:
+            authority.execute("BEGIN IMMEDIATE")
+            authority.execute("UPDATE inventory SET value = 'rollback-live' WHERE id = 1")
+        mode_before = str(authority.execute("PRAGMA journal_mode").fetchone()[0]).lower()
+        sidecars_before = _sidecar_identities(source)
+        if requested_mode == "wal":
+            assert {"-wal", "-shm"}.issubset(sidecars_before)
+        else:
+            assert "-journal" in sidecars_before
+
+        catalog = StoreCatalog(expected_root=tmp_path, silence_allowlist={})
+        _preflight(catalog, [_target("primary", source)])
+
+        mode_after_live = str(authority.execute("PRAGMA journal_mode").fetchone()[0]).lower()
+        sidecars_after = _sidecar_identities(source)
+    finally:
+        authority.rollback()
+        authority.close()
+
+    persisted = sqlite3.connect(source)
+    try:
+        mode_after_reopen = str(persisted.execute("PRAGMA journal_mode").fetchone()[0]).lower()
+    finally:
+        persisted.close()
+
+    assert mode_before == requested_mode
+    assert mode_after_live == mode_before
+    assert mode_after_reopen == mode_before
+    assert sidecars_after == sidecars_before
+
+
+@pytest.mark.parametrize(
+    "open_error",
+    [
+        sqlite3.DatabaseError("file is not a database"),
+        OSError("simulated read failure"),
+    ],
+    ids=["sqlite", "os"],
+)
+def test_open_error_is_actionable_and_preserves_cause(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    open_error: Exception,
+) -> None:
+    source = tmp_path / "audit.db"
+    source.touch()
+
+    def fail_open(*_args: Any, **_kwargs: Any) -> None:
+        raise open_error
+
+    monkeypatch.setattr(sqlite3, "connect", fail_open)
+    catalog = StoreCatalog(expected_root=tmp_path, silence_allowlist={})
+
+    with pytest.raises(StoreCatalogError) as exc_info:
+        _preflight(catalog, [_target("audit", source)])
+
+    message = str(exc_info.value)
+    assert "audit" in message
+    assert os.path.realpath(source) in message
+    assert f"{type(open_error).__name__}: {open_error}" in message
+    assert "restore" in message.lower()
+    assert "P0.3 snapshot" in message
+    assert "before restarting" in message
+    assert exc_info.value.__cause__ is open_error
+
+
+def test_quick_check_error_closes_connection_and_preserves_cause(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = tmp_path / "research.db"
+    source.touch()
+    quick_check_error = sqlite3.DatabaseError("database disk image is malformed")
+
+    class FailingQuickCheckConnection(_RecordingConnection):
+        def execute(self, statement: str) -> _RecordingConnection:
+            self.statements.append(statement)
+            raise quick_check_error
+
+    connection = FailingQuickCheckConnection([])
+    monkeypatch.setattr(sqlite3, "connect", lambda *_args, **_kwargs: connection)
+    catalog = StoreCatalog(expected_root=tmp_path, silence_allowlist={})
+
+    with pytest.raises(StoreCatalogError) as exc_info:
+        _preflight(catalog, [_target("research", source)])
+
+    assert connection.statements == ["PRAGMA quick_check"]
+    assert connection.closed is True
+    assert "database disk image is malformed" in str(exc_info.value)
+    assert exc_info.value.__cause__ is quick_check_error
+
+
+def test_programming_defect_propagates_from_preflight(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = tmp_path / "apps.db"
+    source.touch()
+
+    def programming_bug(*_args: Any, **_kwargs: Any) -> None:
+        raise TypeError("programming bug")
+
+    monkeypatch.setattr(sqlite3, "connect", programming_bug)
+    catalog = StoreCatalog(expected_root=tmp_path, silence_allowlist={})
+
+    with pytest.raises(TypeError, match="programming bug"):
+        _preflight(catalog, [_target("apps", source)])
+
+
+def test_manifest_preserves_every_legacy_inline_path_byte_for_byte(tmp_path: Path) -> None:
+    raw_base = tmp_path / "parent.db.directory" / "fleet.db"
+    base = os.path.realpath(raw_base)
+    manifest = _manifest(raw_base)
+    data_dir = Path(base).parent
+    expected = {
+        "sessions": base.replace(".db", "_sessions.db"),
+        "session_events": base.replace(".db", "_sessions.db"),
+        "conversations": base,
+        "analytics": base.replace(".db", "_analytics.db"),
+        "agents": base.replace(".db", "_agents.db"),
+        "audit": base.replace(".db", "_audit.db"),
+        "agent_comms": base.replace(".db", "_agent_comms.db"),
+        "activity": base.replace(".db", "_activity.db"),
+        "message_context": base.replace(".db", "_message_context.db"),
+        "dream_state": base.replace(".db", "_dream_state.db"),
+        "skills": base.replace(".db", "_skills.db"),
+        "plugins": base.replace(".db", "_plugins.db"),
+        "outreach_config": base.replace(".db", "_outreach.db"),
+        "tasks": base.replace(".db", "_tasks.db"),
+        "research": base.replace(".db", "_research.db"),
+        "presentations": base.replace(".db", "_presentations.db"),
+        "apps": base.replace(".db", "_apps.db"),
+        "triggers": base.replace(".db", "_triggers.db"),
+        "mesh": base.replace(".db", "_mesh.db"),
+        "kb": os.fspath(data_dir / "kb" / "kb.db"),
+        "librarian_state": base.replace(".db", "_librarian_state.db"),
+        "voice": os.fspath(data_dir / "voice_calls.db"),
+        "user_profiles": os.fspath(data_dir / "user_profiles.db"),
+    }
+
+    assert set(manifest) == set(expected)
+    assert {name: target.path for name, target in manifest.items()} == expected
+
+
+def test_manifest_matches_every_boot_opened_catalog_record(tmp_path: Path) -> None:
+    base = tmp_path / "conversations.db"
+    manifest = _manifest(base)
+
+    app = api_module.create_api(db_path=os.fspath(base))
+
+    records = app.state.store_catalog.snapshot()
+    catalog_grouping = {
+        (record.logical_name, record.resolved_path, record.criticality) for record in records
+    }
+    manifest_grouping = {
+        (target.logical_name, os.path.realpath(target.path), target.criticality)
+        for target in manifest.values()
+    }
+    assert manifest_grouping == catalog_grouping
+    authoritative_manifest = {
+        (logical_name, path)
+        for logical_name, path, criticality in manifest_grouping
+        if criticality == "authoritative"
+    }
+    authoritative_catalog = {
+        (logical_name, path)
+        for logical_name, path, criticality in catalog_grouping
+        if criticality == "authoritative"
+    }
+    assert authoritative_manifest == authoritative_catalog
+
+
+def test_clean_preexisting_store_set_boots_normally(tmp_path: Path) -> None:
+    base = tmp_path / "conversations.db"
+    manifest = _manifest(base)
+    seeded_paths: set[str] = set()
+    for target in manifest.values():
+        resolved_path = os.path.realpath(target.path)
+        if resolved_path in seeded_paths:
+            continue
+        seeded_paths.add(resolved_path)
+        connection = _create_database(Path(resolved_path))
+        connection.close()
+
+    app = api_module.create_api(db_path=os.fspath(base))
+
+    assert app.state.store_catalog is not None
+
+
+def test_create_api_preflights_corruption_before_any_store_constructor(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = tmp_path / "conversations.db"
+    source.write_bytes(b"\x0d" + bytes(4095))
+
+    def unexpected_store_construction(*_args: Any, **_kwargs: Any) -> None:
+        pytest.fail("store construction began before the integrity preflight")
+
+    monkeypatch.setattr(api_module, "SessionStore", unexpected_store_construction)
+
+    with pytest.raises(StoreCatalogError) as exc_info:
+        api_module.create_api(db_path=os.fspath(source))
+
+    message = str(exc_info.value)
+    assert "conversations" in message
+    assert os.path.realpath(source) in message
+    assert "file is not a database" in message.lower()
+    assert "P0.3 snapshot" in message
+
+
+def test_corrupt_boot_opened_derived_store_fails_with_rebuild_guidance(
+    tmp_path: Path,
+) -> None:
+    base = tmp_path / "conversations.db"
+    derived = Path(os.path.realpath(base).replace(".db", "_librarian_state.db"))
+    derived.write_bytes(b"\x0d" + bytes(4095))
+
+    with pytest.raises(StoreCatalogError) as exc_info:
+        api_module.create_api(db_path=os.fspath(base))
+
+    message = str(exc_info.value)
+    assert "librarian_state" in message
+    assert os.path.realpath(derived) in message
+    assert "file is not a database" in message.lower()
+    assert "delete" in message.lower()
+    assert "rebuild" in message.lower() or "regenerate" in message.lower()
+    assert "before restarting" in message
+    assert "P0.3 snapshot" not in message
+
+
+def test_unclaimed_corrupt_database_is_not_preflighted(tmp_path: Path) -> None:
+    base = tmp_path / "conversations.db"
+    unclaimed = tmp_path / "unclaimed.db"
+    unclaimed.write_bytes(b"\x0d" + bytes(4095))
+
+    app = api_module.create_api(db_path=os.fspath(base))
+
+    assert app.state.store_catalog is not None


### PR DESCRIPTION
## Summary

- add a centralized, read-only `PRAGMA quick_check` preflight that groups logical stores by physical path and fails with recovery-specific guidance
- define one API-owned manifest for all 23 boot-opened logical stores / 22 physical files and reuse it at every constructor callsite
- run the corruption gate before SnapshotService, FastAPI, or any store construction while retaining final StoreCatalog validation and reconciliation
- register the new read authority in the direct SQLite-open guard

## Verification

- `uv run pytest -q tests/test_store_integrity.py` — 18 passed
- `uv run pytest -q tests/test_store_integrity.py tests/test_store_catalog.py tests/test_no_direct_db_open.py` — 75 passed
- `uv run pytest` — 5,324 passed, 4 skipped (run with an isolated `TMPDIR` because the host shared temp tree contains unrelated database-file pollution)
- `uv run ruff check .` — passed
- changed ranges format-clean; commit diff and secret/path leak scans clean

## SQLite precision correction

The accepted RED originally expected `TRUNCATE` to remain `TRUNCATE` after every connection closed. A no-preflight control proved SQLite persists only WAL-vs-rollback in the database header, so a fresh connection correctly reopens `TRUNCATE` as `DELETE`. The test now expects delete/delete/wal for requested delete/truncate/wal while retaining live-mode equality and exact sidecar-inode equality. No connection wrapper, keeper connection, or writable mutation was introduced.

Closes #1114

🤖 Opened by Kuzya
