### PR TITLE
feat: add storage observability and attended restore drill

### DIFF
--- a/scripts/store_restore.py
+++ b/scripts/store_restore.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Attended local wrapper for daemon-down SQLite store restoration."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+from pinky_daemon.store_restore import StoreRestoreError, restore_store
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Restore one explicit daemon SQLite store from a verified snapshot. "
+            "Stop the daemon before running this command."
+        )
+    )
+    parser.add_argument("--db-path", required=True, help="Canonical conversations DB path.")
+    parser.add_argument("--logical-name", required=True, help="Exact manifest logical name.")
+    parser.add_argument("--snapshot", required=True, help="Static snapshot file to install.")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        result = restore_store(
+            db_path=args.db_path,
+            logical_name=args.logical_name,
+            snapshot_path=args.snapshot,
+        )
+    except StoreRestoreError as exc:
+        print(f"restore refused or failed: {exc}", file=sys.stderr)
+        return 1
+    print(
+        json.dumps(
+            {
+                "logical_names": list(result.logical_names),
+                "corrupt_path": result.corrupt_path,
+                "verification": result.verification,
+            },
+            separators=(",", ":"),
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/pinky_daemon/__main__.py
+++ b/src/pinky_daemon/__main__.py
@@ -109,6 +109,11 @@ def main() -> None:
         default=50,
         help="Max concurrent sessions (api mode)",
     )
+    parser.add_argument(
+        "--db-path",
+        default="data/conversations.db",
+        help="Canonical conversations DB path (api mode)",
+    )
     args = parser.parse_args()
 
     if args.mode == "api":
@@ -118,7 +123,15 @@ def main() -> None:
 
 
 def _run_api(args) -> None:
-    """Start the stateful API server."""
+    """Start the stateful API server under the lifetime store-authority lock."""
+    from pinky_daemon.store_authority import store_authority_lock
+
+    with store_authority_lock(args.db_path):
+        _run_api_with_authority(args)
+
+
+def _run_api_with_authority(args) -> None:
+    """Construct and serve the API while the caller holds store authority."""
     import uvicorn
 
     from pinky_daemon.api import create_api
@@ -136,6 +149,7 @@ def _run_api(args) -> None:
     app = create_api(
         max_sessions=args.max_sessions,
         default_working_dir=working_dir,
+        db_path=args.db_path,
     )
 
     from pinky_daemon.ferry.config import FerryConfig

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -195,6 +195,7 @@ from pinky_daemon.shared_mcp import (
 )
 from pinky_daemon.skill_loader import discover_all_skills, register_discovered_skills
 from pinky_daemon.skill_store import SkillStore
+from pinky_daemon.storage_observability import StorageObservability
 from pinky_daemon.store_catalog import (
     StoreCatalog,
     StoreCatalogError,
@@ -1759,7 +1760,15 @@ def create_api(
     _data_dir = Path(db_path).parent
     store_catalog = StoreCatalog(expected_root=_data_dir)
     store_manifest = _derive_api_store_manifest(db_path)
-    store_catalog.preflight_integrity(store_manifest.values())
+    storage_observability = StorageObservability(store_manifest)
+    try:
+        store_catalog.preflight_integrity(
+            store_manifest.values(),
+            on_outcome=storage_observability.record_preflight,
+        )
+    except StoreCatalogError:
+        storage_observability.record_boot_failure()
+        raise
     store_snapshot_service = StoreSnapshotService(store_catalog)
 
     app = FastAPI(
@@ -1768,6 +1777,7 @@ def create_api(
         version="0.1.0",
     )
     app.state.store_snapshot_service = store_snapshot_service
+    app.state.storage_observability = storage_observability
     app.state.ferry_listener = FerryListenerState.from_config(FerryConfig.from_env())
 
     @app.exception_handler(RequestValidationError)
@@ -5267,6 +5277,14 @@ def create_api(
             return "failed"
         return "partial_success"
 
+    def _record_store_snapshot_outcome(
+        caller: str,
+        logical_name: str | None,
+        result: SnapshotResult,
+    ) -> None:
+        _audit_store_snapshot(caller, logical_name, result)
+        storage_observability.record_snapshot(result)
+
     @app.post("/internal/stores/snapshot")
     async def create_store_snapshot(req: StoreSnapshotRequest, request: Request):
         if not _has_valid_internal_auth(request):
@@ -5290,7 +5308,7 @@ def create_api(
             results = await asyncio.to_thread(
                 store_snapshot_service.create_snapshots,
                 req.logical_name,
-                on_outcome=lambda result: _audit_store_snapshot(
+                on_outcome=lambda result: _record_store_snapshot_outcome(
                     caller,
                     req.logical_name,
                     result,
@@ -12855,6 +12873,7 @@ npm run build</pre>
                 _log(f"admin/watchdog: {et} tracker.status raised: {e}")
                 transport_status[et] = {"status": "unknown", "error": str(e)}
         out["transport_alert_status"] = transport_status
+        out["storage"] = storage_observability.snapshot()
         return out
 
     # ── Admin: Shared MCP Status ─────────────────────────
@@ -14122,9 +14141,11 @@ npm run build</pre>
     # returning the application so an incoherent physical layout cannot serve.
     app.state.store_catalog = store_catalog
     try:
-        store_catalog.validate()
+        warnings = store_catalog.validate() or []
     except StoreCatalogError as exc:
+        storage_observability.record_boot_failure()
         _log(f"ERROR startup: store catalog validation failed: {exc}")
         raise
+    storage_observability.record_boot_success(store_catalog.snapshot(), warnings)
 
     return app

--- a/src/pinky_daemon/storage_observability.py
+++ b/src/pinky_daemon/storage_observability.py
@@ -1,0 +1,145 @@
+"""Bounded, process-local observability for daemon SQLite storage operations."""
+
+from __future__ import annotations
+
+import logging
+import threading
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from pinky_daemon.store_catalog import StoreIntegrityTarget, StoreRecord
+    from pinky_daemon.store_snapshot import SnapshotResult
+
+logger = logging.getLogger("pinky.storage")
+
+
+def _timestamp() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def emit_storage_event(event: str, /, **fields: str | int) -> None:
+    """Write one machine-readable event containing only caller-selected fields."""
+    rendered = ["storage_event", f"event={event}"]
+    rendered.extend(f"{key}={value}" for key, value in fields.items())
+    logger.info(" ".join(rendered))
+
+
+class StorageObservability:
+    """Current-boot metrics exposed through the existing watchdog endpoint."""
+
+    def __init__(self, manifest: dict[str, StoreIntegrityTarget]) -> None:
+        self._lock = threading.RLock()
+        self._manifest = dict(manifest)
+        self._preflight = {logical_name: "pending" for logical_name in self._manifest}
+        self._boot_gate: dict[str, object] = {
+            "outcome": "pending",
+            "warning_count": 0,
+            "timestamp": None,
+        }
+        self._inventory: dict[str, object] = {
+            "logical_count": 0,
+            "physical_count": 0,
+            "stores": {},
+        }
+        self._reconcile_warning_count = 0
+        self._snapshots = {
+            logical_name: {
+                "count": 0,
+                "last_timestamp": None,
+                "last_outcome": None,
+            }
+            for logical_name in self._manifest
+        }
+
+    def record_preflight(self, logical_name: str, outcome: str) -> None:
+        timestamp = _timestamp()
+        with self._lock:
+            self._preflight[logical_name] = outcome
+        emit_storage_event(
+            "boot",
+            phase="preflight",
+            logical_name=logical_name,
+            outcome=outcome,
+            timestamp=timestamp,
+        )
+
+    def record_boot_failure(self) -> None:
+        self._record_boot_gate("fail", 0)
+
+    def record_boot_success(
+        self,
+        records: Iterable[StoreRecord],
+        warnings: list[str],
+    ) -> None:
+        records = list(records)
+        stores: dict[str, dict[str, str]] = {}
+        physical_paths: set[str] = set()
+        for record in records:
+            stores[record.logical_name] = {
+                "criticality": record.criticality,
+                "journal_mode": record.journal_mode,
+            }
+            if not record.is_memory:
+                physical_paths.add(record.resolved_path)
+        with self._lock:
+            self._inventory = {
+                "logical_count": len(stores),
+                "physical_count": len(physical_paths),
+                "stores": stores,
+            }
+            self._reconcile_warning_count = len(warnings)
+        self._record_boot_gate("warn" if warnings else "pass", len(warnings))
+
+    def _record_boot_gate(self, outcome: str, warning_count: int) -> None:
+        timestamp = _timestamp()
+        with self._lock:
+            self._boot_gate = {
+                "outcome": outcome,
+                "warning_count": warning_count,
+                "timestamp": timestamp,
+            }
+        emit_storage_event(
+            "boot",
+            phase="boot_gate",
+            outcome=outcome,
+            warning_count=warning_count,
+            timestamp=timestamp,
+        )
+
+    def record_snapshot(self, result: SnapshotResult) -> None:
+        timestamp = _timestamp()
+        for logical_name in result.logical_names:
+            with self._lock:
+                if logical_name not in self._snapshots:
+                    continue
+                metrics = self._snapshots[logical_name]
+                metrics["count"] = int(metrics["count"]) + 1
+                metrics["last_timestamp"] = timestamp
+                metrics["last_outcome"] = result.status
+            emit_storage_event(
+                "snapshot",
+                logical_name=logical_name,
+                outcome=result.status,
+                timestamp=timestamp,
+            )
+
+    def snapshot(self) -> dict[str, object]:
+        """Return a path-free copy suitable for the admin watchdog response."""
+        with self._lock:
+            return {
+                "boot_gate": dict(self._boot_gate),
+                "preflight": dict(self._preflight),
+                "inventory": {
+                    "logical_count": self._inventory["logical_count"],
+                    "physical_count": self._inventory["physical_count"],
+                    "stores": {
+                        name: dict(details)
+                        for name, details in dict(self._inventory["stores"]).items()
+                    },
+                },
+                "reconcile_warning_count": self._reconcile_warning_count,
+                "snapshots": {name: dict(metrics) for name, metrics in self._snapshots.items()},
+            }

--- a/src/pinky_daemon/store_authority.py
+++ b/src/pinky_daemon/store_authority.py
@@ -1,0 +1,164 @@
+"""Single-writer authority and daemon-down descriptor checks for SQLite stores."""
+
+from __future__ import annotations
+
+import contextlib
+import fcntl
+import os
+import shutil
+import stat
+import subprocess
+from collections.abc import Iterator, Sequence
+from pathlib import Path
+
+_LOCK_FILENAME = ".pinky-store-authority.lock"
+_LSOF_TIMEOUT_SECONDS = 5.0
+
+
+class StoreAuthorityError(RuntimeError):
+    """Raised when exclusive authority over the daemon store root is unavailable."""
+
+
+def store_authority_lock_path(db_path: str | os.PathLike[str]) -> str:
+    """Return the canonical, stable lock inode path for one daemon DB root."""
+    root = Path(os.path.realpath(os.fspath(db_path))).parent
+    return os.fspath(root / _LOCK_FILENAME)
+
+
+@contextlib.contextmanager
+def store_authority_lock(db_path: str | os.PathLike[str]) -> Iterator[None]:
+    """Hold a nonblocking exclusive flock without ever unlinking its inode."""
+    lock_path = Path(store_authority_lock_path(db_path))
+    try:
+        lock_path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+        flags = os.O_RDWR | os.O_CREAT | getattr(os, "O_CLOEXEC", 0)
+        flags |= getattr(os, "O_NOFOLLOW", 0)
+        descriptor = os.open(lock_path, flags, 0o600)
+    except OSError as exc:
+        raise StoreAuthorityError("daemon store authority lock could not be opened") from exc
+    try:
+        try:
+            descriptor_stat = os.fstat(descriptor)
+            path_stat = lock_path.lstat()
+        except OSError as exc:
+            raise StoreAuthorityError("daemon store authority lock could not be verified") from exc
+        if (
+            not stat.S_ISREG(descriptor_stat.st_mode)
+            or stat.S_ISLNK(path_stat.st_mode)
+            or (descriptor_stat.st_dev, descriptor_stat.st_ino)
+            != (path_stat.st_dev, path_stat.st_ino)
+        ):
+            raise StoreAuthorityError("daemon store authority lock path is unsafe")
+        try:
+            fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except (BlockingIOError, PermissionError) as exc:
+            raise StoreAuthorityError("daemon store authority is already held") from exc
+        try:
+            yield
+        finally:
+            fcntl.flock(descriptor, fcntl.LOCK_UN)
+    finally:
+        os.close(descriptor)
+
+
+def _resolve_lsof_binary() -> str | None:
+    binary = shutil.which("lsof")
+    if binary:
+        return binary
+    for candidate in ("/usr/sbin/lsof", "/usr/bin/lsof"):
+        if os.path.isfile(candidate) and os.access(candidate, os.X_OK):
+            return candidate
+    return None
+
+
+def assert_no_open_store_descriptors(paths: Sequence[Path]) -> None:
+    """Fail closed unless lsof proves none of the supplied inodes are open."""
+    identities = {_regular_file_identity(path) for path in paths}
+    lsof = _resolve_lsof_binary()
+    if lsof is None:
+        raise StoreAuthorityError("descriptor scan is unavailable")
+    try:
+        completed = subprocess.run(
+            [lsof, "-nP", "-FpfDi", "--", *(os.fspath(path) for path in paths)],
+            capture_output=True,
+            text=True,
+            timeout=_LSOF_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise StoreAuthorityError("descriptor scan did not complete") from exc
+    if completed.returncode not in (0, 1) or completed.stderr.strip():
+        raise StoreAuthorityError("descriptor scan returned an unusable result")
+    observed = _parse_lsof_identities(completed.stdout)
+    if identities & observed:
+        raise StoreAuthorityError("a daemon store file descriptor is still open")
+
+
+def _regular_file_identity(path: Path) -> tuple[int, int]:
+    path_stat = path.lstat()
+    if stat.S_ISLNK(path_stat.st_mode) or not stat.S_ISREG(path_stat.st_mode):
+        raise StoreAuthorityError("descriptor target is not a regular file")
+    return (path_stat.st_dev, path_stat.st_ino)
+
+
+def _parse_lsof_identities(output: str) -> set[tuple[int, int]]:
+    if not output:
+        return set()
+
+    identities: set[tuple[int, int]] = set()
+    saw_process = False
+    current_descriptor = False
+    device: int | None = None
+    inode: int | None = None
+
+    def finish_descriptor() -> None:
+        nonlocal current_descriptor, device, inode
+        if not current_descriptor or device is None or inode is None:
+            raise StoreAuthorityError("descriptor scan output is malformed")
+        identities.add((device, inode))
+        current_descriptor = False
+        device = None
+        inode = None
+
+    for raw_line in output.splitlines():
+        if not raw_line:
+            continue
+        field, value = raw_line[0], raw_line[1:]
+        if field == "p":
+            if current_descriptor:
+                finish_descriptor()
+            if not value.isdigit():
+                raise StoreAuthorityError("descriptor scan output is malformed")
+            saw_process = True
+        elif field == "f":
+            if not saw_process or not value.isdigit():
+                raise StoreAuthorityError("descriptor scan output is malformed")
+            if current_descriptor:
+                finish_descriptor()
+            current_descriptor = True
+        elif field == "D":
+            if not current_descriptor or device is not None:
+                raise StoreAuthorityError("descriptor scan output is malformed")
+            device = _parse_lsof_integer(value)
+        elif field == "i":
+            if not current_descriptor or inode is not None:
+                raise StoreAuthorityError("descriptor scan output is malformed")
+            inode = _parse_lsof_integer(value)
+        else:
+            raise StoreAuthorityError("descriptor scan output is malformed")
+
+    if current_descriptor:
+        finish_descriptor()
+    if not saw_process:
+        raise StoreAuthorityError("descriptor scan output is malformed")
+    return identities
+
+
+def _parse_lsof_integer(value: str) -> int:
+    try:
+        parsed = int(value, 0)
+    except ValueError as exc:
+        raise StoreAuthorityError("descriptor scan output is malformed") from exc
+    if parsed < 0:
+        raise StoreAuthorityError("descriptor scan output is malformed")
+    return parsed

--- a/src/pinky_daemon/store_catalog.py
+++ b/src/pinky_daemon/store_catalog.py
@@ -10,7 +10,7 @@ import re
 import sqlite3
 import stat
 import threading
-from collections.abc import Iterable, Mapping
+from collections.abc import Callable, Iterable, Mapping
 from dataclasses import dataclass
 from pathlib import Path
 from urllib.parse import parse_qsl
@@ -206,13 +206,19 @@ class StoreCatalog:
 
         return self.reconcile_filesystem()
 
-    def preflight_integrity(self, targets: Iterable[StoreIntegrityTarget]) -> None:
+    def preflight_integrity(
+        self,
+        targets: Iterable[StoreIntegrityTarget],
+        *,
+        on_outcome: Callable[[str, str], None] | None = None,
+    ) -> dict[str, str]:
         """Fail closed when an existing API-owned SQLite file is corrupt.
 
         Targets that share a physical path are checked once and reported together.
         Missing and in-memory stores are left for their constructors to create.
         """
         targets_by_path: dict[str, list[StoreIntegrityTarget]] = {}
+        outcomes: dict[str, str] = {}
         for target in targets:
             raw_path = os.fspath(target.path)
             if self._is_memory_path(raw_path):
@@ -225,7 +231,19 @@ class StoreCatalog:
                 os.stat(resolved_path)
             except OSError as exc:
                 if self._is_missing_path_error(exc):
+                    self._record_integrity_outcomes(
+                        matching_targets,
+                        "skipped-absent",
+                        outcomes,
+                        on_outcome,
+                    )
                     continue
+                self._record_integrity_outcomes(
+                    matching_targets,
+                    "failed-corrupt",
+                    outcomes,
+                    on_outcome,
+                )
                 self._raise_integrity_error(matching_targets, resolved_path, exc)
 
             try:
@@ -239,15 +257,53 @@ class StoreCatalog:
                     connection.close()
             except (sqlite3.Error, OSError) as exc:
                 if self._path_is_absent(resolved_path):
+                    self._record_integrity_outcomes(
+                        matching_targets,
+                        "skipped-absent",
+                        outcomes,
+                        on_outcome,
+                    )
                     continue
+                self._record_integrity_outcomes(
+                    matching_targets,
+                    "failed-corrupt",
+                    outcomes,
+                    on_outcome,
+                )
                 self._raise_integrity_error(matching_targets, resolved_path, exc)
 
             if rows != [("ok",)]:
+                self._record_integrity_outcomes(
+                    matching_targets,
+                    "failed-corrupt",
+                    outcomes,
+                    on_outcome,
+                )
                 self._raise_integrity_error(
                     matching_targets,
                     resolved_path,
                     f"PRAGMA quick_check returned {rows!r}",
                 )
+            self._record_integrity_outcomes(
+                matching_targets,
+                "ok",
+                outcomes,
+                on_outcome,
+            )
+
+        return outcomes
+
+    @staticmethod
+    def _record_integrity_outcomes(
+        targets: list[StoreIntegrityTarget],
+        outcome: str,
+        outcomes: dict[str, str],
+        on_outcome: Callable[[str, str], None] | None,
+    ) -> None:
+        for target in targets:
+            outcomes[target.logical_name] = outcome
+            if on_outcome is not None:
+                on_outcome(target.logical_name, outcome)
 
     @staticmethod
     def _raise_integrity_error(

--- a/src/pinky_daemon/store_restore.py
+++ b/src/pinky_daemon/store_restore.py
@@ -1,0 +1,321 @@
+"""Attended, daemon-down restoration of verified SQLite store snapshots."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import sqlite3
+import stat
+import tempfile
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+from pinky_daemon.storage_observability import emit_storage_event
+from pinky_daemon.store_authority import (
+    StoreAuthorityError,
+    assert_no_open_store_descriptors,
+    store_authority_lock,
+)
+
+_SQLITE_SIDECAR_SUFFIXES = ("-wal", "-shm", "-journal")
+
+STORE_SCHEMA_SENTINELS: dict[str, tuple[str, ...]] = {
+    "sessions": ("sessions",),
+    "session_events": ("session_events",),
+    "conversations": ("messages", "messages_fts"),
+    "analytics": ("analytics_session_facts",),
+    "agents": ("agents",),
+    "audit": ("audit_log",),
+    "agent_comms": ("messages", "inbox"),
+    "activity": ("activity_log",),
+    "message_context": ("message_contexts",),
+    "dream_state": ("dream_state",),
+    "skills": ("skills",),
+    "plugins": ("plugin_state",),
+    "outreach_config": ("platforms",),
+    "tasks": ("projects", "tasks"),
+    "research": ("research_topics", "research_briefs"),
+    "presentations": ("presentations", "presentation_versions"),
+    "apps": ("apps",),
+    "triggers": ("triggers",),
+    "mesh": ("mesh_messages",),
+    "kb": ("raw_sources", "wiki_pages"),
+    "librarian_state": ("librarian_state",),
+    "voice": ("call_request", "voice_call_session"),
+    "user_profiles": ("user_profiles",),
+}
+
+
+class StoreRestoreError(RuntimeError):
+    """Base error for attended store restoration."""
+
+
+class StoreRestoreSelectionError(StoreRestoreError):
+    """Raised when a requested manifest target is absent or unsafe."""
+
+
+class StoreRestoreSafetyError(StoreRestoreError):
+    """Raised when the daemon-down safety proof cannot be established."""
+
+
+class StoreRestoreVerificationError(StoreRestoreError):
+    """Raised when a static restore candidate fails integrity or schema checks."""
+
+
+@dataclass(frozen=True, slots=True)
+class StoreRestoreResult:
+    logical_names: tuple[str, ...]
+    corrupt_path: str
+    verification: str
+
+
+@dataclass(frozen=True, slots=True)
+class _PathIdentity:
+    dev: int
+    ino: int
+    mode: int
+
+
+def restore_store(
+    *,
+    db_path: str | os.PathLike[str],
+    logical_name: str,
+    snapshot_path: str | os.PathLike[str],
+) -> StoreRestoreResult:
+    """Preserve one corrupt manifest target and atomically install a snapshot."""
+    bounded_name = logical_name if logical_name in STORE_SCHEMA_SENTINELS else "unregistered"
+    try:
+        with store_authority_lock(db_path):
+            result = _restore_under_authority(
+                db_path=db_path,
+                logical_name=logical_name,
+                snapshot_path=snapshot_path,
+            )
+    except (StoreRestoreSelectionError, StoreRestoreSafetyError):
+        emit_storage_event(
+            "restore",
+            logical_name=bounded_name,
+            outcome="refused",
+            timestamp=_timestamp(),
+        )
+        raise
+    except StoreRestoreVerificationError:
+        emit_storage_event(
+            "restore",
+            logical_name=bounded_name,
+            outcome="failed",
+            timestamp=_timestamp(),
+        )
+        raise
+    except StoreAuthorityError as exc:
+        emit_storage_event(
+            "restore",
+            logical_name=bounded_name,
+            outcome="refused",
+            timestamp=_timestamp(),
+        )
+        raise StoreRestoreSafetyError("exclusive daemon-store authority is unavailable") from exc
+    except (OSError, sqlite3.Error) as exc:
+        emit_storage_event(
+            "restore",
+            logical_name=bounded_name,
+            outcome="failed",
+            timestamp=_timestamp(),
+        )
+        raise StoreRestoreError("store restoration failed") from exc
+
+    emit_storage_event(
+        "restore",
+        logical_name=bounded_name,
+        outcome="success",
+        timestamp=_timestamp(),
+    )
+    return result
+
+
+def _restore_under_authority(
+    *,
+    db_path: str | os.PathLike[str],
+    logical_name: str,
+    snapshot_path: str | os.PathLike[str],
+) -> StoreRestoreResult:
+    target = _select_target(db_path, logical_name)
+    target_paths = _target_and_sidecars(target)
+    target_identities = _capture_identities(target_paths)
+
+    snapshot = _select_snapshot(Path(snapshot_path))
+    snapshot_identity = _identity(snapshot)
+    if (snapshot_identity.dev, snapshot_identity.ino) in {
+        (identity.dev, identity.ino) for identity in target_identities.values()
+    }:
+        raise StoreRestoreSelectionError("snapshot aliases the selected target")
+    _verify_static_store(snapshot, logical_name)
+
+    try:
+        assert_no_open_store_descriptors(target_paths)
+    except StoreAuthorityError as exc:
+        raise StoreRestoreSafetyError("store descriptor safety proof failed") from exc
+    _assert_unchanged(target, target_identities)
+
+    descriptor, temp_name = tempfile.mkstemp(
+        dir=target.parent,
+        prefix=f".{target.name}.restore-",
+        suffix=".tmp",
+    )
+    os.close(descriptor)
+    temp_path = Path(temp_name)
+    try:
+        shutil.copyfile(snapshot, temp_path)
+        os.chmod(temp_path, stat.S_IMODE(snapshot_identity.mode))
+        _fsync_file(temp_path)
+        if _identity(snapshot) != snapshot_identity:
+            raise StoreRestoreSafetyError("snapshot identity changed during restore")
+        _verify_static_store(temp_path, logical_name)
+        _assert_unchanged(target, target_identities)
+
+        corrupt_path = _next_corrupt_path(target)
+        os.replace(target, corrupt_path)
+        for suffix in _SQLITE_SIDECAR_SUFFIXES:
+            sidecar = Path(os.fspath(target) + suffix)
+            if sidecar in target_identities:
+                os.replace(sidecar, Path(os.fspath(corrupt_path) + suffix))
+        os.replace(temp_path, target)
+        _fsync_directory(target.parent)
+        _verify_static_store(target, logical_name)
+        return StoreRestoreResult(
+            logical_names=(logical_name,),
+            corrupt_path=os.fspath(corrupt_path),
+            verification="ok",
+        )
+    finally:
+        try:
+            temp_path.unlink()
+        except FileNotFoundError:
+            pass
+
+
+def _select_target(
+    db_path: str | os.PathLike[str],
+    logical_name: str,
+) -> Path:
+    from pinky_daemon.api import _derive_api_store_manifest
+
+    manifest = _derive_api_store_manifest(db_path)
+    if logical_name not in manifest or logical_name not in STORE_SCHEMA_SENTINELS:
+        raise StoreRestoreSelectionError("logical store is not registered")
+    target = Path(manifest[logical_name].path)
+    root = Path(os.path.realpath(os.fspath(db_path))).parent
+    if not _is_under_root(root, target):
+        raise StoreRestoreSelectionError("manifest target is outside the daemon store root")
+    try:
+        path_stat = target.lstat()
+    except FileNotFoundError as exc:
+        raise StoreRestoreSelectionError("manifest target is absent") from exc
+    if stat.S_ISLNK(path_stat.st_mode) or not stat.S_ISREG(path_stat.st_mode):
+        raise StoreRestoreSelectionError("manifest target is not a regular file")
+    if os.path.realpath(target) != os.fspath(target):
+        raise StoreRestoreSelectionError("manifest target does not retain its canonical identity")
+    return target
+
+
+def _select_snapshot(snapshot: Path) -> Path:
+    try:
+        snapshot_stat = snapshot.lstat()
+    except FileNotFoundError as exc:
+        raise StoreRestoreSelectionError("snapshot is absent") from exc
+    if stat.S_ISLNK(snapshot_stat.st_mode) or not stat.S_ISREG(snapshot_stat.st_mode):
+        raise StoreRestoreSelectionError("snapshot is not a regular file")
+    if os.path.realpath(snapshot) != os.path.abspath(snapshot):
+        raise StoreRestoreSelectionError("snapshot does not retain its canonical identity")
+    return Path(os.path.realpath(snapshot))
+
+
+def _target_and_sidecars(target: Path) -> list[Path]:
+    paths = [target]
+    for suffix in _SQLITE_SIDECAR_SUFFIXES:
+        sidecar = Path(os.fspath(target) + suffix)
+        try:
+            sidecar_stat = sidecar.lstat()
+        except FileNotFoundError:
+            continue
+        if stat.S_ISLNK(sidecar_stat.st_mode) or not stat.S_ISREG(sidecar_stat.st_mode):
+            raise StoreRestoreSelectionError("SQLite sidecar is not a regular file")
+        paths.append(sidecar)
+    return paths
+
+
+def _capture_identities(paths: list[Path]) -> dict[Path, _PathIdentity]:
+    return {path: _identity(path) for path in paths}
+
+
+def _assert_unchanged(target: Path, expected: dict[Path, _PathIdentity]) -> None:
+    current_paths = _target_and_sidecars(target)
+    if set(current_paths) != set(expected):
+        raise StoreRestoreSafetyError("SQLite sidecar set changed during restore")
+    if any(_identity(path) != identity for path, identity in expected.items()):
+        raise StoreRestoreSafetyError("selected store identity changed during restore")
+
+
+def _identity(path: Path) -> _PathIdentity:
+    path_stat = path.lstat()
+    return _PathIdentity(path_stat.st_dev, path_stat.st_ino, path_stat.st_mode)
+
+
+def _verify_static_store(path: Path, logical_name: str) -> None:
+    uri = path.resolve().as_uri() + "?mode=ro&immutable=1"
+    try:
+        connection = sqlite3.connect(uri, uri=True)
+        try:
+            rows = connection.execute("PRAGMA quick_check").fetchall()
+            if rows != [("ok",)]:
+                raise StoreRestoreVerificationError("snapshot quick_check failed")
+            available = {
+                str(row[0])
+                for row in connection.execute(
+                    "SELECT name FROM sqlite_master WHERE type IN ('table', 'view')"
+                ).fetchall()
+            }
+        finally:
+            connection.close()
+    except (sqlite3.Error, OSError) as exc:
+        raise StoreRestoreVerificationError("snapshot SQLite verification failed") from exc
+    required = set(STORE_SCHEMA_SENTINELS[logical_name])
+    if not required <= available:
+        raise StoreRestoreVerificationError("snapshot does not match the selected store schema")
+
+
+def _next_corrupt_path(target: Path) -> Path:
+    timestamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%S.%fZ")
+    candidate = target.with_name(f"{target.name}.corrupt-{timestamp}")
+    for suffix in ("", *_SQLITE_SIDECAR_SUFFIXES):
+        if os.path.lexists(os.fspath(candidate) + suffix):
+            raise StoreRestoreSafetyError("corrupt preservation path already exists")
+    return candidate
+
+
+def _fsync_file(path: Path) -> None:
+    descriptor = os.open(path, os.O_RDONLY)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _fsync_directory(path: Path) -> None:
+    descriptor = os.open(path, os.O_RDONLY)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _timestamp() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def _is_under_root(root: Path, path: Path) -> bool:
+    try:
+        return os.path.commonpath((os.fspath(root), os.fspath(path))) == os.fspath(root)
+    except ValueError:
+        return False

--- a/src/pinky_daemon/store_restore.py
+++ b/src/pinky_daemon/store_restore.py
@@ -77,6 +77,12 @@ class _PathIdentity:
     mode: int
 
 
+@dataclass(frozen=True, slots=True)
+class _SelectedStore:
+    target: Path
+    logical_names: tuple[str, ...]
+
+
 def restore_store(
     *,
     db_path: str | os.PathLike[str],
@@ -140,7 +146,8 @@ def _restore_under_authority(
     logical_name: str,
     snapshot_path: str | os.PathLike[str],
 ) -> StoreRestoreResult:
-    target = _select_target(db_path, logical_name)
+    selected = _select_target(db_path, logical_name)
+    target = selected.target
     target_paths = _target_and_sidecars(target)
     target_identities = _capture_identities(target_paths)
 
@@ -150,13 +157,7 @@ def _restore_under_authority(
         (identity.dev, identity.ino) for identity in target_identities.values()
     }:
         raise StoreRestoreSelectionError("snapshot aliases the selected target")
-    _verify_static_store(snapshot, logical_name)
-
-    try:
-        assert_no_open_store_descriptors(target_paths)
-    except StoreAuthorityError as exc:
-        raise StoreRestoreSafetyError("store descriptor safety proof failed") from exc
-    _assert_unchanged(target, target_identities)
+    _verify_static_store(snapshot, selected.logical_names)
 
     descriptor, temp_name = tempfile.mkstemp(
         dir=target.parent,
@@ -171,10 +172,14 @@ def _restore_under_authority(
         _fsync_file(temp_path)
         if _identity(snapshot) != snapshot_identity:
             raise StoreRestoreSafetyError("snapshot identity changed during restore")
-        _verify_static_store(temp_path, logical_name)
-        _assert_unchanged(target, target_identities)
+        _verify_static_store(temp_path, selected.logical_names)
 
         corrupt_path = _next_corrupt_path(target)
+        try:
+            assert_no_open_store_descriptors(target_paths)
+        except StoreAuthorityError as exc:
+            raise StoreRestoreSafetyError("store descriptor safety proof failed") from exc
+        _assert_unchanged(target, target_identities)
         os.replace(target, corrupt_path)
         for suffix in _SQLITE_SIDECAR_SUFFIXES:
             sidecar = Path(os.fspath(target) + suffix)
@@ -182,9 +187,9 @@ def _restore_under_authority(
                 os.replace(sidecar, Path(os.fspath(corrupt_path) + suffix))
         os.replace(temp_path, target)
         _fsync_directory(target.parent)
-        _verify_static_store(target, logical_name)
+        _verify_static_store(target, selected.logical_names)
         return StoreRestoreResult(
-            logical_names=(logical_name,),
+            logical_names=selected.logical_names,
             corrupt_path=os.fspath(corrupt_path),
             verification="ok",
         )
@@ -198,13 +203,21 @@ def _restore_under_authority(
 def _select_target(
     db_path: str | os.PathLike[str],
     logical_name: str,
-) -> Path:
+) -> _SelectedStore:
     from pinky_daemon.api import _derive_api_store_manifest
 
     manifest = _derive_api_store_manifest(db_path)
     if logical_name not in manifest or logical_name not in STORE_SCHEMA_SENTINELS:
         raise StoreRestoreSelectionError("logical store is not registered")
     target = Path(manifest[logical_name].path)
+    canonical_target = os.path.realpath(target)
+    logical_names = tuple(
+        candidate_name
+        for candidate_name, candidate in manifest.items()
+        if os.path.realpath(candidate.path) == canonical_target
+    )
+    if not logical_names or any(name not in STORE_SCHEMA_SENTINELS for name in logical_names):
+        raise StoreRestoreSelectionError("manifest store cohort has no schema sentinel")
     root = Path(os.path.realpath(os.fspath(db_path))).parent
     if not _is_under_root(root, target):
         raise StoreRestoreSelectionError("manifest target is outside the daemon store root")
@@ -216,7 +229,7 @@ def _select_target(
         raise StoreRestoreSelectionError("manifest target is not a regular file")
     if os.path.realpath(target) != os.fspath(target):
         raise StoreRestoreSelectionError("manifest target does not retain its canonical identity")
-    return target
+    return _SelectedStore(target=target, logical_names=logical_names)
 
 
 def _select_snapshot(snapshot: Path) -> Path:
@@ -262,7 +275,7 @@ def _identity(path: Path) -> _PathIdentity:
     return _PathIdentity(path_stat.st_dev, path_stat.st_ino, path_stat.st_mode)
 
 
-def _verify_static_store(path: Path, logical_name: str) -> None:
+def _verify_static_store(path: Path, logical_names: tuple[str, ...]) -> None:
     uri = path.resolve().as_uri() + "?mode=ro&immutable=1"
     try:
         connection = sqlite3.connect(uri, uri=True)
@@ -280,7 +293,9 @@ def _verify_static_store(path: Path, logical_name: str) -> None:
             connection.close()
     except (sqlite3.Error, OSError) as exc:
         raise StoreRestoreVerificationError("snapshot SQLite verification failed") from exc
-    required = set(STORE_SCHEMA_SENTINELS[logical_name])
+    required = {
+        table for logical_name in logical_names for table in STORE_SCHEMA_SENTINELS[logical_name]
+    }
     if not required <= available:
         raise StoreRestoreVerificationError("snapshot does not match the selected store schema")
 

--- a/tests/test_no_direct_db_open.py
+++ b/tests/test_no_direct_db_open.py
@@ -134,6 +134,17 @@ DIRECT_OPEN_ALLOWLIST = {
             "fresh destination for SQLite Online Backup API snapshots (#1112)."
         ),
     ),
+    DirectOpenIdentity(
+        "src/pinky_daemon/store_restore.py",
+        "_verify_static_store",
+    ): AllowlistEntry(
+        expected_count=1,
+        reason=(
+            "Attended daemon-down restore opens only static snapshot, temp, and installed "
+            "files read-only with immutable=1 for quick_check and schema verification (#1116); "
+            "it never opens a live P0.4 preflight store."
+        ),
+    ),
 }
 
 

--- a/tests/test_storage_observability.py
+++ b/tests/test_storage_observability.py
@@ -1,0 +1,334 @@
+"""P0.5 contracts for bounded storage-authority observability."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from pinky_daemon import api as api_module
+from pinky_daemon.auth import build_internal_auth_headers
+from pinky_daemon.store_catalog import (
+    DEFAULT_FILESYSTEM_SILENCE_ALLOWLIST,
+    StoreCatalog,
+    StoreCatalogError,
+)
+
+
+def _manifest_names(base: Path) -> set[str]:
+    return set(api_module._derive_api_store_manifest(base))
+
+
+def _register_operator(app, tmp_path: Path) -> str:
+    app.state.agents.register(
+        "storage-operator",
+        model="opus",
+        role="operator",
+        working_dir=str(tmp_path / "operator"),
+    )
+    return app.state.agents.get_signing_key("storage-operator")
+
+
+def _signed_headers(key: str, *, method: str, path: str) -> dict[str, str]:
+    return build_internal_auth_headers(
+        key,
+        agent_name="storage-operator",
+        method=method,
+        path=path,
+    )
+
+
+def _storage_status(client: TestClient, key: str) -> dict:
+    response = client.get(
+        "/admin/watchdog",
+        headers=_signed_headers(key, method="GET", path="/admin/watchdog"),
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert "storage" in body, "/admin/watchdog storage metrics are not implemented"
+    return body["storage"]
+
+
+def _storage_event_lines(
+    caplog: pytest.LogCaptureFixture,
+    capsys: pytest.CaptureFixture[str],
+) -> list[str]:
+    # The daemon's established log channel includes both stdlib logging and
+    # stderr `_log` calls. Accept either transport, but require one bounded
+    # storage-event schema so failed boot attempts remain machine-readable.
+    messages = [record.getMessage() for record in caplog.records]
+    captured = capsys.readouterr()
+    messages.extend(captured.err.splitlines())
+    messages.extend(captured.out.splitlines())
+    return [message for message in messages if message.startswith("storage_event ")]
+
+
+def _assert_no_sensitive_metric_values(
+    storage: dict,
+    *,
+    data_root: Path,
+    secret: str,
+) -> None:
+    encoded = json.dumps(storage, sort_keys=True)
+    assert os.fspath(data_root) not in encoded
+    assert os.path.realpath(data_root) not in encoded
+    assert secret not in encoded
+    assert "storage-operator" not in encoded
+
+    def walk(value: object) -> None:
+        if isinstance(value, dict):
+            for key, child in value.items():
+                lowered = str(key).lower()
+                assert lowered not in {"path", "resolved_path", "snapshot_path", "error"}
+                walk(child)
+        elif isinstance(value, list):
+            for child in value:
+                walk(child)
+
+    walk(storage)
+
+
+def test_admin_watchdog_exposes_bounded_boot_preflight_inventory_and_reconcile_metrics(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    secret = "p0.5-metrics-secret"
+    monkeypatch.setenv("PINKY_SESSION_SECRET", secret)
+    data_root = tmp_path / "data"
+    base = data_root / "conversations.db"
+    manifest_names = _manifest_names(base)
+    assert len(manifest_names) == 23
+
+    app = api_module.create_api(
+        max_sessions=10,
+        default_working_dir=str(tmp_path),
+        db_path=os.fspath(base),
+    )
+    key = _register_operator(app, tmp_path)
+
+    client = TestClient(app)
+    try:
+        storage = _storage_status(client, key)
+    finally:
+        client.close()
+
+    assert set(storage) == {
+        "boot_gate",
+        "preflight",
+        "inventory",
+        "reconcile_warning_count",
+        "snapshots",
+    }
+    assert storage["boot_gate"]["outcome"] == "warn"
+    expected_warning_count = len(DEFAULT_FILESYSTEM_SILENCE_ALLOWLIST)
+    assert storage["boot_gate"]["warning_count"] == expected_warning_count
+    assert storage["boot_gate"]["timestamp"]
+    assert storage["reconcile_warning_count"] == expected_warning_count
+
+    # The preflight runs before constructors: a brand-new data root is absent,
+    # then constructors create all 23 logical / 22 physical stores.
+    assert storage["preflight"] == {
+        logical_name: "skipped-absent" for logical_name in manifest_names
+    }
+    inventory = storage["inventory"]
+    assert inventory["logical_count"] == 23
+    assert inventory["physical_count"] == 22
+    assert set(inventory["stores"]) == manifest_names
+    assert {details["criticality"] for details in inventory["stores"].values()} == {
+        "authoritative",
+        "derived",
+    }
+    assert inventory["stores"]["librarian_state"]["criticality"] == "derived"
+    assert {details["journal_mode"] for details in inventory["stores"].values()} <= {
+        "delete",
+        "truncate",
+        "wal",
+    }
+
+    assert set(storage["snapshots"]) == manifest_names
+    assert all(
+        metrics == {"count": 0, "last_timestamp": None, "last_outcome": None}
+        for metrics in storage["snapshots"].values()
+    )
+    _assert_no_sensitive_metric_values(storage, data_root=data_root, secret=secret)
+
+
+def test_clean_existing_store_records_preflight_ok_and_warning_free_boot_pass(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    data_root = tmp_path / "data"
+    base = data_root / "conversations.db"
+    store = api_module.ConversationStore(db_path=os.fspath(base))
+    store.close()
+
+    class QuietStoreCatalog(StoreCatalog):
+        def __init__(self, expected_root: str | os.PathLike[str]) -> None:
+            super().__init__(expected_root, silence_allowlist={})
+
+    monkeypatch.setattr(api_module, "StoreCatalog", QuietStoreCatalog)
+    app = api_module.create_api(
+        max_sessions=10,
+        default_working_dir=str(tmp_path),
+        db_path=os.fspath(base),
+    )
+    key = _register_operator(app, tmp_path)
+    client = TestClient(app)
+    try:
+        storage = _storage_status(client, key)
+    finally:
+        client.close()
+
+    manifest_names = _manifest_names(base)
+    assert storage["boot_gate"]["outcome"] == "pass"
+    assert storage["boot_gate"]["warning_count"] == 0
+    assert storage["reconcile_warning_count"] == 0
+    assert storage["preflight"]["conversations"] == "ok"
+    assert {
+        logical_name: outcome
+        for logical_name, outcome in storage["preflight"].items()
+        if logical_name != "conversations"
+    } == {
+        logical_name: "skipped-absent"
+        for logical_name in manifest_names
+        if logical_name != "conversations"
+    }
+
+
+def test_snapshot_metrics_count_each_logical_member_without_paths_and_do_not_persist_json(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    secret = "snapshot-metrics-secret"
+    monkeypatch.setenv("PINKY_SESSION_SECRET", secret)
+    caplog.set_level(logging.INFO)
+    data_root = tmp_path / "data"
+    base = data_root / "conversations.db"
+    app = api_module.create_api(
+        max_sessions=10,
+        default_working_dir=str(tmp_path),
+        db_path=os.fspath(base),
+    )
+    key = _register_operator(app, tmp_path)
+
+    client = TestClient(app)
+    try:
+        response = client.post(
+            "/internal/stores/snapshot",
+            headers=_signed_headers(
+                key,
+                method="POST",
+                path="/internal/stores/snapshot",
+            ),
+            json={"logical_name": "sessions"},
+        )
+        assert response.status_code == 200
+        assert response.json()["status"] == "success"
+        [published] = response.json()["snapshots"]
+        snapshot_path = published["path"]
+
+        def fail_snapshot(_selected: Any) -> None:
+            raise sqlite3.DatabaseError("simulated snapshot corruption")
+
+        monkeypatch.setattr(
+            app.state.store_snapshot_service,
+            "_snapshot_selected",
+            fail_snapshot,
+        )
+        failed_response = client.post(
+            "/internal/stores/snapshot",
+            headers=_signed_headers(
+                key,
+                method="POST",
+                path="/internal/stores/snapshot",
+            ),
+            json={"logical_name": "conversations"},
+        )
+        assert failed_response.status_code == 200
+        assert failed_response.json()["status"] == "failed"
+        storage = _storage_status(client, key)
+    finally:
+        client.close()
+
+    for logical_name in ("sessions", "session_events"):
+        metrics = storage["snapshots"][logical_name]
+        assert metrics["count"] == 1
+        assert metrics["last_timestamp"]
+        assert metrics["last_outcome"] == "published"
+    assert storage["snapshots"]["conversations"]["count"] == 1
+    assert storage["snapshots"]["conversations"]["last_timestamp"]
+    assert storage["snapshots"]["conversations"]["last_outcome"] == "failed"
+    _assert_no_sensitive_metric_values(storage, data_root=data_root, secret=secret)
+
+    events = _storage_event_lines(caplog, capsys)
+    snapshot_events = [event for event in events if "event=snapshot" in event]
+    assert snapshot_events
+    assert any("logical_name=sessions" in event for event in snapshot_events)
+    assert any("logical_name=session_events" in event for event in snapshot_events)
+    for event in snapshot_events:
+        assert snapshot_path not in event
+        assert os.fspath(data_root) not in event
+        assert secret not in event
+        assert "storage-operator" not in event
+        assert "simulated snapshot corruption" not in event
+
+    # Barsik ruling: current-process counters only. Durable history stays in
+    # structured logs + P0.3 audit; P0.5 must not add a JSON persistence surface.
+    assert list(data_root.rglob("*.json")) == []
+
+
+def test_corrupt_preflight_logs_bounded_failure_before_create_api_raises(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    base = tmp_path / "conversations.db"
+    base.write_bytes(b"\x0d" + bytes(4095))
+    caplog.set_level(logging.INFO)
+
+    with pytest.raises(StoreCatalogError):
+        api_module.create_api(db_path=os.fspath(base))
+
+    events = _storage_event_lines(caplog, capsys)
+    preflight = [event for event in events if "phase=preflight" in event]
+    boot = [event for event in events if "phase=boot_gate" in event]
+    assert any(
+        "logical_name=conversations" in event and "outcome=failed-corrupt" in event
+        for event in preflight
+    )
+    assert any("outcome=fail" in event for event in boot)
+    for event in preflight + boot:
+        assert os.path.realpath(base) not in event
+        assert "file is not a database" not in event.lower()
+
+
+def test_final_catalog_failure_logs_bounded_boot_gate_failure_before_raise(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    caplog.set_level(logging.INFO)
+    forbidden = os.fspath(tmp_path / "secret-layout.db")
+
+    def fail_validation(_catalog: StoreCatalog) -> list[str]:
+        raise StoreCatalogError(f"unsafe layout at {forbidden}")
+
+    monkeypatch.setattr(StoreCatalog, "validate", fail_validation)
+
+    with pytest.raises(StoreCatalogError, match="unsafe layout"):
+        api_module.create_api(db_path=os.fspath(tmp_path / "conversations.db"))
+
+    events = _storage_event_lines(caplog, capsys)
+    boot = [event for event in events if "phase=boot_gate" in event]
+    assert any("outcome=fail" in event for event in boot)
+    assert all(forbidden not in event for event in boot)
+    assert all("unsafe layout" not in event for event in boot)

--- a/tests/test_store_restore.py
+++ b/tests/test_store_restore.py
@@ -21,6 +21,7 @@ from pinky_daemon import api as api_module
 from pinky_daemon import store_snapshot
 from pinky_daemon.agent_comms import AgentComms
 from pinky_daemon.conversation_store import ConversationStore
+from pinky_daemon.session_store import SessionEventStore, SessionStore
 from pinky_daemon.store_catalog import StoreCatalog
 from pinky_daemon.task_store import TaskStore
 
@@ -329,6 +330,78 @@ def test_restore_refuses_foreign_descriptor_on_target_or_sidecar_inode(
     assert _corrupt_artifacts(base) == []
 
 
+@pytest.mark.parametrize("held_suffix", ["", "-wal"], ids=["main", "wal-sidecar"])
+def test_restore_boundary_scan_refuses_descriptor_opened_after_candidate_verification(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    held_suffix: str,
+) -> None:
+    authority = _authority_module()
+    restore = _restore_module()
+    safety_error = getattr(restore, "StoreRestoreSafetyError", None)
+    assert safety_error is not None
+    base = tmp_path / "data" / "conversations.db"
+    snapshot_path = _snapshot_conversations(base)
+    corrupt_bytes = _write_corrupt_target(base)
+    before_identity = (base.stat().st_dev, base.stat().st_ino)
+    held_path = Path(os.fspath(base) + held_suffix)
+    held_bytes = corrupt_bytes
+    if held_suffix:
+        held_bytes = b"late legacy wal holder"
+        held_path.write_bytes(held_bytes)
+
+    resolver = getattr(authority, "_resolve_lsof_binary", None)
+    assert resolver is not None
+    monkeypatch.setattr(authority, "_resolve_lsof_binary", lambda: "/fake/lsof")
+    holder: Any | None = None
+    descriptor_scans = 0
+
+    def dynamic_lsof(*_args: Any, **_kwargs: Any) -> SimpleNamespace:
+        nonlocal descriptor_scans
+        descriptor_scans += 1
+        if holder is None:
+            stdout = "p999999\nf7\nD0x7fffffff\ni9223372036854775806\n"
+        else:
+            held_stat = held_path.stat()
+            stdout = (
+                f"p{os.getpid()}\n"
+                f"f{holder.fileno()}\n"
+                f"D0x{held_stat.st_dev:x}\n"
+                f"i{held_stat.st_ino}\n"
+            )
+        return SimpleNamespace(stdout=stdout, stderr="", returncode=0)
+
+    monkeypatch.setattr(authority.subprocess, "run", dynamic_lsof)
+    real_verify = restore._verify_static_store
+    verification_count = 0
+
+    def verify_then_open(
+        path: Path,
+        logical_names: tuple[str, ...],
+    ) -> None:
+        nonlocal holder, verification_count
+        real_verify(path, logical_names)
+        verification_count += 1
+        if verification_count == 2:
+            holder = held_path.open("rb")
+
+    monkeypatch.setattr(restore, "_verify_static_store", verify_then_open)
+    try:
+        with pytest.raises(safety_error):
+            _restore(base, "conversations", snapshot_path)
+    finally:
+        if holder is not None:
+            holder.close()
+
+    assert verification_count == 2
+    assert descriptor_scans == 1
+    assert base.read_bytes() == corrupt_bytes
+    assert (base.stat().st_dev, base.stat().st_ino) == before_identity
+    if held_suffix:
+        assert held_path.read_bytes() == held_bytes
+    assert _corrupt_artifacts(base) == []
+
+
 @pytest.mark.parametrize("race", ["target-identity", "sidecar-set"])
 def test_restore_refuses_identity_or_sidecar_change_after_descriptor_scan(
     monkeypatch: pytest.MonkeyPatch,
@@ -475,6 +548,48 @@ def test_restore_rejects_quick_check_ok_snapshot_of_wrong_store_schema(
 
     assert base.read_bytes() == corrupt_bytes
     assert _corrupt_artifacts(base) == []
+
+
+def test_restore_shared_physical_cohort_requires_union_schema_and_reports_all_names(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    restore = _restore_module()
+    verification_error = getattr(restore, "StoreRestoreVerificationError", None)
+    assert verification_error is not None
+    base = tmp_path / "target" / "conversations.db"
+    target = Path(api_module._derive_api_store_manifest(base)["sessions"].path)
+    target.parent.mkdir(parents=True)
+    target_store = SessionStore(db_path=os.fspath(target))
+    target_events = SessionEventStore(db_path=os.fspath(target))
+    target_store.close()
+    target_events.close()
+    corrupt_bytes = _write_corrupt_target(target)
+    before_identity = (target.stat().st_dev, target.stat().st_ino)
+
+    incomplete_snapshot = tmp_path / "snapshot-only-sessions.db"
+    incomplete_store = SessionStore(db_path=os.fspath(incomplete_snapshot))
+    incomplete_store.close()
+    assert _quick_check(incomplete_snapshot) == [("ok",)]
+    _configure_lsof(monkeypatch)
+
+    with pytest.raises(verification_error, match="store|schema|table"):
+        _restore(base, "sessions", incomplete_snapshot)
+
+    assert target.read_bytes() == corrupt_bytes
+    assert (target.stat().st_dev, target.stat().st_ino) == before_identity
+    assert _corrupt_artifacts(target) == []
+
+    complete_snapshot = tmp_path / "snapshot-session-cohort.db"
+    complete_store = SessionStore(db_path=os.fspath(complete_snapshot))
+    complete_events = SessionEventStore(db_path=os.fspath(complete_snapshot))
+    complete_store.close()
+    complete_events.close()
+
+    result = _restore(base, "sessions", complete_snapshot)
+
+    assert result.logical_names == ("sessions", "session_events")
+    assert _quick_check(target) == [("ok",)]
 
 
 def test_schema_sentinel_inventory_is_complete_for_every_manifest_logical_store(

--- a/tests/test_store_restore.py
+++ b/tests/test_store_restore.py
@@ -1,0 +1,696 @@
+"""P0.5 contracts for attended, daemon-down SQLite store restoration."""
+
+from __future__ import annotations
+
+import ast
+import importlib
+import importlib.util
+import logging
+import os
+import re
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from pinky_daemon import api as api_module
+from pinky_daemon import store_snapshot
+from pinky_daemon.agent_comms import AgentComms
+from pinky_daemon.conversation_store import ConversationStore
+from pinky_daemon.store_catalog import StoreCatalog
+from pinky_daemon.task_store import TaskStore
+
+
+def _authority_module():
+    spec = importlib.util.find_spec("pinky_daemon.store_authority")
+    assert spec is not None, "pinky_daemon.store_authority is not implemented"
+    return importlib.import_module("pinky_daemon.store_authority")
+
+
+def _restore_module():
+    spec = importlib.util.find_spec("pinky_daemon.store_restore")
+    assert spec is not None, "pinky_daemon.store_restore is not implemented"
+    return importlib.import_module("pinky_daemon.store_restore")
+
+
+def _restore(
+    base: Path,
+    logical_name: str,
+    snapshot_path: Path,
+) -> Any:
+    module = _restore_module()
+    restore = getattr(module, "restore_store", None)
+    assert restore is not None, "restore_store is not implemented"
+    return restore(
+        db_path=os.fspath(base),
+        logical_name=logical_name,
+        snapshot_path=os.fspath(snapshot_path),
+    )
+
+
+def _snapshot_conversations(
+    base: Path,
+    *,
+    session_id: str = "restore-drill",
+    messages: tuple[str, ...] = ("alpha", "beta"),
+) -> Path:
+    catalog = StoreCatalog(expected_root=base.parent, silence_allowlist={})
+    store = ConversationStore(db_path=os.fspath(base), catalog=catalog)
+    try:
+        for index, message in enumerate(messages):
+            store.append(
+                session_id,
+                "user" if index % 2 == 0 else "assistant",
+                message,
+                timestamp=1_700_000_000.0 + index,
+            )
+    finally:
+        store.close()
+    [result] = store_snapshot.StoreSnapshotService(catalog).create_snapshots("conversations")
+    assert result.verification == "ok"
+    assert result.snapshot_path is not None
+    return Path(result.snapshot_path)
+
+
+def _snapshot_tasks(base: Path) -> tuple[Path, Path]:
+    tasks_path = Path(api_module._derive_api_store_manifest(base)["tasks"].path)
+    catalog = StoreCatalog(expected_root=base.parent, silence_allowlist={})
+    store = TaskStore(db_path=os.fspath(tasks_path), catalog=catalog)
+    store.close()
+    [result] = store_snapshot.StoreSnapshotService(catalog).create_snapshots("tasks")
+    assert result.verification == "ok"
+    assert result.snapshot_path is not None
+    return tasks_path, Path(result.snapshot_path)
+
+
+def _write_corrupt_target(path: Path) -> bytes:
+    prefix = b"\x0d" + b"p0.5-corrupt-store"
+    corrupt = prefix + bytes(4096 - len(prefix))
+    assert len(corrupt) == 4096
+    path.write_bytes(corrupt)
+    return corrupt
+
+
+def _immutable_connection(path: Path) -> sqlite3.Connection:
+    return sqlite3.connect(path.resolve().as_uri() + "?mode=ro&immutable=1", uri=True)
+
+
+def _quick_check(path: Path) -> list[tuple[str]]:
+    connection = _immutable_connection(path)
+    try:
+        return connection.execute("PRAGMA quick_check").fetchall()
+    finally:
+        connection.close()
+
+
+def _journal_mode(path: Path) -> str:
+    connection = _immutable_connection(path)
+    try:
+        return str(connection.execute("PRAGMA journal_mode").fetchone()[0]).lower()
+    finally:
+        connection.close()
+
+
+def _messages(path: Path, session_id: str = "restore-drill") -> list[str]:
+    connection = _immutable_connection(path)
+    try:
+        rows = connection.execute(
+            "SELECT content FROM messages WHERE session_id = ? ORDER BY id",
+            (session_id,),
+        ).fetchall()
+        return [str(row[0]) for row in rows]
+    finally:
+        connection.close()
+
+
+def _corrupt_artifacts(target: Path) -> list[Path]:
+    return sorted(target.parent.glob(target.name + ".corrupt-*"))
+
+
+def _configure_lsof(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    stdout: str = "p999999\nf7\nD0x7fffffff\ni9223372036854775806\n",
+    stderr: str = "",
+    returncode: int = 0,
+    error: BaseException | None = None,
+    on_run: Any | None = None,
+) -> None:
+    authority = _authority_module()
+    resolver = getattr(authority, "_resolve_lsof_binary", None)
+    assert resolver is not None, "store authority lsof resolver is not implemented"
+    monkeypatch.setattr(authority, "_resolve_lsof_binary", lambda: "/fake/lsof")
+
+    def run(*_args: Any, **_kwargs: Any) -> SimpleNamespace:
+        if error is not None:
+            raise error
+        if on_run is not None:
+            on_run()
+        return SimpleNamespace(stdout=stdout, stderr=stderr, returncode=returncode)
+
+    monkeypatch.setattr(authority.subprocess, "run", run)
+
+
+def _configure_lsof_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
+    authority = _authority_module()
+    resolver = getattr(authority, "_resolve_lsof_binary", None)
+    assert resolver is not None, "store authority lsof resolver is not implemented"
+    monkeypatch.setattr(authority, "_resolve_lsof_binary", lambda: None)
+
+
+def _storage_event_lines(
+    caplog: pytest.LogCaptureFixture,
+    capsys: pytest.CaptureFixture[str],
+) -> list[str]:
+    messages = [record.getMessage() for record in caplog.records]
+    captured = capsys.readouterr()
+    messages.extend(captured.err.splitlines())
+    messages.extend(captured.out.splitlines())
+    return [message for message in messages if message.startswith("storage_event ")]
+
+
+def test_store_authority_lock_is_canonical_nonblocking_and_never_unlinked(
+    tmp_path: Path,
+) -> None:
+    authority = _authority_module()
+    lock = getattr(authority, "store_authority_lock", None)
+    lock_path_for = getattr(authority, "store_authority_lock_path", None)
+    error_type = getattr(authority, "StoreAuthorityError", None)
+    assert lock is not None, "store_authority_lock is not implemented"
+    assert lock_path_for is not None, "store_authority_lock_path is not implemented"
+    assert error_type is not None, "StoreAuthorityError is not implemented"
+    raw_base = tmp_path / "nested" / ".." / "data" / "conversations.db"
+    expected_root = Path(os.path.realpath(raw_base)).parent
+
+    with lock(raw_base):
+        lock_path = Path(lock_path_for(raw_base))
+        assert lock_path.parent == expected_root
+        assert lock_path.is_file()
+        with pytest.raises(error_type):
+            with lock(raw_base):
+                pytest.fail("a second daemon/restore acquired the authority lock")
+
+    assert lock_path.is_file(), "the stable lock inode must never be unlinked"
+    with lock(raw_base):
+        assert lock_path.is_file()
+
+
+def test_supported_daemon_entrypoint_holds_authority_lock_before_create_api_and_uvicorn(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from pinky_daemon import __main__ as daemon_main
+
+    authority = _authority_module()
+    lock = getattr(authority, "store_authority_lock", None)
+    error_type = getattr(authority, "StoreAuthorityError", None)
+    assert lock is not None and error_type is not None
+    base = tmp_path / "data" / "conversations.db"
+    observations: list[str] = []
+
+    def assert_lock_held(phase: str) -> None:
+        with pytest.raises(error_type):
+            with lock(base):
+                pytest.fail(f"authority lock was not held during {phase}")
+        observations.append(phase)
+
+    def fake_create_api(**kwargs: Any) -> SimpleNamespace:
+        assert kwargs["db_path"] == os.fspath(base)
+        assert_lock_held("create_api")
+        return SimpleNamespace(state=SimpleNamespace(ferry_listener=None))
+
+    def fake_uvicorn_run(_app: Any, **_kwargs: Any) -> None:
+        assert_lock_held("uvicorn")
+
+    monkeypatch.delenv("PINKYBOT_FERRY_ENABLED", raising=False)
+    monkeypatch.setattr(api_module, "create_api", fake_create_api)
+    uvicorn = importlib.import_module("uvicorn")
+    monkeypatch.setattr(uvicorn, "run", fake_uvicorn_run)
+    args = SimpleNamespace(
+        host="127.0.0.1",
+        port=8888,
+        working_dir=os.fspath(tmp_path),
+        max_sessions=3,
+        db_path=os.fspath(base),
+    )
+
+    daemon_main._run_api(args)
+
+    assert observations == ["create_api", "uvicorn"]
+    with lock(base):
+        pass
+
+
+def test_daemon_cli_accepts_nonbreaking_db_path_and_passes_it_to_api_mode(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from pinky_daemon import __main__ as daemon_main
+
+    base = tmp_path / "custom" / "conversations.db"
+    received: list[Any] = []
+    monkeypatch.setattr(daemon_main, "_run_api", received.append)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "pinky_daemon",
+            "--mode",
+            "api",
+            "--db-path",
+            os.fspath(base),
+        ],
+    )
+
+    daemon_main.main()
+
+    assert len(received) == 1
+    assert received[0].db_path == os.fspath(base)
+
+
+def test_restore_refuses_while_daemon_authority_lock_is_held(
+    tmp_path: Path,
+) -> None:
+    authority = _authority_module()
+    restore = _restore_module()
+    safety_error = getattr(restore, "StoreRestoreSafetyError", None)
+    assert safety_error is not None, "StoreRestoreSafetyError is not implemented"
+    base = tmp_path / "data" / "conversations.db"
+    snapshot_path = _snapshot_conversations(base)
+    corrupt_bytes = _write_corrupt_target(base)
+    before_identity = (base.stat().st_dev, base.stat().st_ino)
+
+    with authority.store_authority_lock(base):
+        with pytest.raises(safety_error):
+            _restore(base, "conversations", snapshot_path)
+
+    assert base.read_bytes() == corrupt_bytes
+    assert (base.stat().st_dev, base.stat().st_ino) == before_identity
+    assert _corrupt_artifacts(base) == []
+
+
+@pytest.mark.parametrize("held_suffix", ["", "-wal"], ids=["main", "wal-sidecar"])
+def test_restore_refuses_foreign_descriptor_on_target_or_sidecar_inode(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    held_suffix: str,
+) -> None:
+    restore = _restore_module()
+    safety_error = getattr(restore, "StoreRestoreSafetyError", None)
+    assert safety_error is not None
+    base = tmp_path / "data" / "conversations.db"
+    snapshot_path = _snapshot_conversations(base)
+    corrupt_bytes = _write_corrupt_target(base)
+    held_path = Path(os.fspath(base) + held_suffix)
+    if held_suffix:
+        held_path.write_bytes(b"held-forensic-sidecar")
+    held_stat = held_path.stat()
+
+    with held_path.open("rb") as foreign_holder:
+        _configure_lsof(
+            monkeypatch,
+            stdout=(
+                f"p{os.getpid()}\n"
+                f"f{foreign_holder.fileno()}\n"
+                f"D0x{held_stat.st_dev:x}\n"
+                f"i{held_stat.st_ino}\n"
+            ),
+        )
+        with pytest.raises(safety_error):
+            _restore(base, "conversations", snapshot_path)
+
+    assert base.read_bytes() == corrupt_bytes
+    if held_suffix:
+        assert held_path.read_bytes() == b"held-forensic-sidecar"
+    assert _corrupt_artifacts(base) == []
+
+
+@pytest.mark.parametrize("race", ["target-identity", "sidecar-set"])
+def test_restore_refuses_identity_or_sidecar_change_after_descriptor_scan(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    race: str,
+) -> None:
+    restore = _restore_module()
+    safety_error = getattr(restore, "StoreRestoreSafetyError", None)
+    assert safety_error is not None
+    base = tmp_path / "data" / "conversations.db"
+    snapshot_path = _snapshot_conversations(base)
+    corrupt_bytes = _write_corrupt_target(base)
+    before_identity = (base.stat().st_dev, base.stat().st_ino)
+    raced_bytes = b"raced replacement must not be preserved as the selected target"
+
+    def mutate_after_scan() -> None:
+        if race == "target-identity":
+            replacement = base.with_name("raced-replacement.tmp")
+            replacement.write_bytes(raced_bytes)
+            os.replace(replacement, base)
+        else:
+            Path(os.fspath(base) + "-wal").write_bytes(b"late-sidecar")
+
+    _configure_lsof(monkeypatch, on_run=mutate_after_scan)
+
+    with pytest.raises(safety_error):
+        _restore(base, "conversations", snapshot_path)
+
+    if race == "target-identity":
+        assert base.read_bytes() == raced_bytes
+        assert (base.stat().st_dev, base.stat().st_ino) != before_identity
+    else:
+        assert base.read_bytes() == corrupt_bytes
+        assert Path(os.fspath(base) + "-wal").read_bytes() == b"late-sidecar"
+    assert _corrupt_artifacts(base) == []
+
+
+@pytest.mark.parametrize("failure", ["unavailable", "timeout", "malformed"])
+def test_restore_fails_closed_when_descriptor_scan_cannot_prove_store_closed(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    failure: str,
+    caplog: pytest.LogCaptureFixture,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    restore = _restore_module()
+    safety_error = getattr(restore, "StoreRestoreSafetyError", None)
+    assert safety_error is not None
+    caplog.set_level(logging.INFO)
+    base = tmp_path / "data" / "conversations.db"
+    snapshot_path = _snapshot_conversations(base)
+    corrupt_bytes = _write_corrupt_target(base)
+    target_stat = base.stat()
+
+    if failure == "unavailable":
+        _configure_lsof_unavailable(monkeypatch)
+    elif failure == "timeout":
+        _configure_lsof(
+            monkeypatch,
+            error=subprocess.TimeoutExpired("lsof", 5),
+        )
+    else:
+        _configure_lsof(
+            monkeypatch,
+            stdout=f"pnot-a-pid\nfwat\nDgarbage\ni{target_stat.st_ino}\n",
+        )
+
+    with pytest.raises(safety_error):
+        _restore(base, "conversations", snapshot_path)
+
+    assert base.read_bytes() == corrupt_bytes
+    assert _corrupt_artifacts(base) == []
+    events = _storage_event_lines(caplog, capsys)
+    restore_events = [event for event in events if "event=restore" in event]
+    assert any(
+        "logical_name=conversations" in event and "outcome=refused" in event
+        for event in restore_events
+    )
+    assert all(os.fspath(base.parent) not in event for event in restore_events)
+    assert all("/fake/lsof" not in event for event in restore_events)
+    assert all("TimeoutExpired" not in event for event in restore_events)
+    assert all("not-a-pid" not in event for event in restore_events)
+
+
+def test_restore_rejects_bad_snapshot_before_mutating_target_or_sidecars(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    restore = _restore_module()
+    verification_error = getattr(restore, "StoreRestoreVerificationError", None)
+    assert verification_error is not None, "StoreRestoreVerificationError is not implemented"
+    caplog.set_level(logging.INFO)
+    base = tmp_path / "data" / "conversations.db"
+    good_snapshot = _snapshot_conversations(base)
+    bad_snapshot = good_snapshot.with_name("bad-snapshot.db")
+    bad_snapshot.write_bytes(b"\x0d" + bytes(4095))
+    corrupt_bytes = _write_corrupt_target(base)
+    sidecar = Path(os.fspath(base) + "-journal")
+    sidecar.write_bytes(b"forensic-journal")
+    before = {
+        base: ((base.stat().st_dev, base.stat().st_ino), base.read_bytes()),
+        sidecar: ((sidecar.stat().st_dev, sidecar.stat().st_ino), sidecar.read_bytes()),
+    }
+    _configure_lsof(monkeypatch)
+
+    with pytest.raises(verification_error):
+        _restore(base, "conversations", bad_snapshot)
+
+    for path, (identity, content) in before.items():
+        assert (path.stat().st_dev, path.stat().st_ino) == identity
+        assert path.read_bytes() == content
+    assert base.read_bytes() == corrupt_bytes
+    assert _corrupt_artifacts(base) == []
+    events = _storage_event_lines(caplog, capsys)
+    restore_events = [event for event in events if "event=restore" in event]
+    assert any(
+        "logical_name=conversations" in event and "outcome=failed" in event
+        for event in restore_events
+    )
+    assert all(os.fspath(base.parent) not in event for event in restore_events)
+    assert all(os.fspath(bad_snapshot) not in event for event in restore_events)
+
+
+def test_restore_rejects_quick_check_ok_snapshot_of_wrong_store_schema(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    restore = _restore_module()
+    verification_error = getattr(restore, "StoreRestoreVerificationError", None)
+    assert verification_error is not None
+    base = tmp_path / "data" / "conversations.db"
+    expected_snapshot = _snapshot_conversations(base)
+    wrong_snapshot = expected_snapshot.with_name("healthy-wrong-store.db")
+    wrong_store = AgentComms(db_path=os.fspath(wrong_snapshot))
+    wrong_store.close()
+    assert _quick_check(wrong_snapshot) == [("ok",)]
+    corrupt_bytes = _write_corrupt_target(base)
+    _configure_lsof(monkeypatch)
+
+    with pytest.raises(verification_error, match="store|schema|table"):
+        _restore(base, "conversations", wrong_snapshot)
+
+    assert base.read_bytes() == corrupt_bytes
+    assert _corrupt_artifacts(base) == []
+
+
+def test_schema_sentinel_inventory_is_complete_for_every_manifest_logical_store(
+    tmp_path: Path,
+) -> None:
+    restore = _restore_module()
+    sentinels = getattr(restore, "STORE_SCHEMA_SENTINELS", None)
+    assert sentinels is not None, "STORE_SCHEMA_SENTINELS is not implemented"
+    manifest = api_module._derive_api_store_manifest(tmp_path / "conversations.db")
+
+    assert set(sentinels) == set(manifest)
+    for logical_name, required_tables in sentinels.items():
+        assert isinstance(required_tables, tuple), logical_name
+        assert required_tables, logical_name
+        assert all(re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", table) for table in required_tables)
+    assert "sessions" in sentinels["sessions"]
+    assert "session_events" in sentinels["session_events"]
+    assert "messages" in sentinels["conversations"]
+    assert "messages_fts" in sentinels["conversations"]
+
+
+@pytest.mark.parametrize("selection", ["unregistered", "absent", "nonregular", "symlink"])
+def test_restore_refuses_unregistered_absent_or_unsafe_manifest_target(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    selection: str,
+) -> None:
+    restore = _restore_module()
+    selection_error = getattr(restore, "StoreRestoreSelectionError", None)
+    assert selection_error is not None, "StoreRestoreSelectionError is not implemented"
+    source_base = tmp_path / "source" / "conversations.db"
+    conversation_snapshot = _snapshot_conversations(source_base)
+    target_base = tmp_path / "target" / "conversations.db"
+    logical_name = "conversations"
+    snapshot_path = conversation_snapshot
+    selected_target = target_base
+
+    if selection == "unregistered":
+        logical_name = "not_in_manifest"
+    elif selection == "nonregular":
+        target_base.mkdir(parents=True)
+    elif selection == "symlink":
+        logical_name = "tasks"
+        real_base = tmp_path / "tasks-source" / "conversations.db"
+        real_tasks, snapshot_path = _snapshot_tasks(real_base)
+        manifest_target = Path(api_module._derive_api_store_manifest(target_base)["tasks"].path)
+        manifest_target.parent.mkdir(parents=True, exist_ok=True)
+        manifest_target.symlink_to(real_tasks)
+        selected_target = manifest_target
+
+    before_lstat = selected_target.lstat() if selected_target.exists() else None
+
+    _configure_lsof(monkeypatch)
+
+    with pytest.raises(selection_error):
+        _restore(target_base, logical_name, snapshot_path)
+
+    assert _corrupt_artifacts(selected_target) == []
+    if before_lstat is not None:
+        after_lstat = selected_target.lstat()
+        assert (after_lstat.st_dev, after_lstat.st_ino, after_lstat.st_mode) == (
+            before_lstat.st_dev,
+            before_lstat.st_ino,
+            before_lstat.st_mode,
+        )
+
+
+def test_restore_preserves_corrupt_main_and_sidecars_and_atomically_installs_snapshot(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    restore = _restore_module()
+    caplog.set_level(logging.INFO)
+    base = tmp_path / "data" / "conversations.db"
+    snapshot_path = _snapshot_conversations(base, messages=("known-one", "known-two"))
+    snapshot_mode = _journal_mode(snapshot_path)
+    snapshot_bytes = snapshot_path.read_bytes()
+    corrupt_bytes = _write_corrupt_target(base)
+    sidecar_bytes = {
+        "-wal": b"forensic-wal",
+        "-shm": b"forensic-shm",
+        "-journal": b"forensic-journal",
+    }
+    for suffix, content in sidecar_bytes.items():
+        Path(os.fspath(base) + suffix).write_bytes(content)
+    replace_calls: list[tuple[Path, Path]] = []
+    real_replace = os.replace
+
+    def recording_replace(source: str | os.PathLike[str], target: str | os.PathLike[str]) -> None:
+        source_path = Path(source)
+        target_path = Path(target)
+        if target_path == base:
+            assert source_path.parent == base.parent
+            assert source_path.is_file()
+            replace_calls.append((source_path, target_path))
+        real_replace(source, target)
+
+    monkeypatch.setattr(restore.os, "replace", recording_replace)
+    _configure_lsof(monkeypatch)
+
+    result = _restore(base, "conversations", snapshot_path)
+
+    assert result.logical_names == ("conversations",)
+    assert result.verification == "ok"
+    corrupt_path = Path(result.corrupt_path)
+    assert corrupt_path in _corrupt_artifacts(base)
+    assert corrupt_path.read_bytes() == corrupt_bytes
+    for suffix, content in sidecar_bytes.items():
+        assert Path(os.fspath(corrupt_path) + suffix).read_bytes() == content
+        assert not Path(os.fspath(base) + suffix).exists()
+    assert _quick_check(base) == [("ok",)]
+    assert _messages(base) == ["known-one", "known-two"]
+    assert base.read_bytes() == snapshot_bytes
+    assert snapshot_path.read_bytes() == snapshot_bytes
+    assert _journal_mode(base) == snapshot_mode
+    assert (base.stat().st_dev, base.stat().st_ino) != (
+        snapshot_path.stat().st_dev,
+        snapshot_path.stat().st_ino,
+    )
+    assert len(replace_calls) == 1
+    assert replace_calls[0][1] == base
+    assert list(base.parent.glob("*.tmp")) == []
+
+    events = _storage_event_lines(caplog, capsys)
+    restore_events = [event for event in events if "event=restore" in event]
+    assert any(
+        "logical_name=conversations" in event and "outcome=success" in event
+        for event in restore_events
+    )
+    assert all(os.fspath(base.parent) not in event for event in restore_events)
+    assert all(os.fspath(snapshot_path) not in event for event in restore_events)
+
+
+def test_restore_verification_is_static_immutable_and_never_reads_or_sets_journal_mode(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    restore = _restore_module()
+    base = tmp_path / "data" / "conversations.db"
+    snapshot_path = _snapshot_conversations(base)
+    _write_corrupt_target(base)
+    real_connect = sqlite3.connect
+    opens: list[tuple[str, dict[str, Any]]] = []
+    statements: list[str] = []
+
+    def recording_connect(database: Any, *args: Any, **kwargs: Any) -> sqlite3.Connection:
+        rendered = os.fspath(database)
+        opens.append((rendered, dict(kwargs)))
+        connection = real_connect(database, *args, **kwargs)
+        connection.set_trace_callback(statements.append)
+        return connection
+
+    monkeypatch.setattr(restore.sqlite3, "connect", recording_connect)
+    _configure_lsof(monkeypatch)
+
+    _restore(base, "conversations", snapshot_path)
+
+    assert len(opens) >= 2
+    for database, kwargs in opens:
+        assert "mode=ro" in database
+        assert "immutable=1" in database
+        assert kwargs.get("uri") is True
+    normalized = [statement.upper() for statement in statements]
+    assert any("PRAGMA QUICK_CHECK" in statement for statement in normalized)
+    assert any("SQLITE_MASTER" in statement for statement in normalized)
+    assert all("JOURNAL_MODE" not in statement for statement in normalized)
+
+
+def test_full_p03_snapshot_corrupt_restore_p04_clean_boot_drill(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    base = tmp_path / "data" / "conversations.db"
+    known_messages = ("before-corruption", "survives-restore")
+    snapshot_path = _snapshot_conversations(base, messages=known_messages)
+    corrupt_bytes = _write_corrupt_target(base)
+    _configure_lsof(monkeypatch)
+
+    result = _restore(base, "conversations", snapshot_path)
+
+    corrupt_path = Path(result.corrupt_path)
+    assert corrupt_path.read_bytes() == corrupt_bytes
+    assert _quick_check(base) == [("ok",)]
+    assert _messages(base) == list(known_messages)
+
+    # Load-bearing recovery proof: the installed P0.3 copy clears P0.4's
+    # pre-constructor integrity gate and the complete boot gate returns an app.
+    fresh_app = api_module.create_api(
+        default_working_dir=os.fspath(tmp_path),
+        db_path=os.fspath(base),
+    )
+    assert fresh_app.state.store_catalog is not None
+    assert [
+        message.content
+        for message in fresh_app.state.conversation_store.get_history("restore-drill")
+    ] == list(known_messages)
+
+
+def test_restore_cli_is_local_attended_wrapper_with_explicit_selection() -> None:
+    script = Path(__file__).resolve().parents[1] / "scripts" / "store_restore.py"
+    assert script.is_file(), "scripts/store_restore.py is not implemented"
+    source = script.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    imported_modules = {
+        alias.name
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Import)
+        for alias in node.names
+    }
+    imported_from = {node.module for node in ast.walk(tree) if isinstance(node, ast.ImportFrom)}
+
+    assert "--db-path" in source
+    assert "--logical-name" in source
+    assert "--snapshot" in source
+    assert "restore_store" in source
+    assert not any(name and name.startswith("urllib") for name in imported_modules | imported_from)
+    assert "/internal/" not in source


### PR DESCRIPTION
## Summary

- expose bounded current-boot storage health and snapshot counters through /admin/watchdog, with structured storage events and no JSON persistence
- hold a stable lifetime store-authority flock around API daemon startup and serving, with fail-closed lsof inode and race checks for attended restore
- add 23-store schema sentinels, immutable static verification, forensic corrupt-file preservation, atomic restore install, and an explicit local CLI

## Verification

- focused P0.5 contracts: 27 passed
- combined P0.3/P0.4/P0.5 storage gate: 127 passed
- isolated full CI-relevant lane: 5372 passed, 1 skipped, 1 deselected (local Camoufox live-browser test; clean CI omits the web extra and skips it through the import guard)
- ruff check, formatter checks, diff check, direct-open guard, real lsof shape probe, and leak scan passed

## Safety

- no persistent metrics JSON
- immutable mode is limited to static snapshot, temp, and installed restore verification; never the live P0.4 preflight
- no deployment or production restart performed

Closes #1116

🤖 Opened by Kuzya