### PR TITLE
fix(#445): tetto e log sull'attesa dello slot di delivery dello scheduler

### DIFF
--- a/src/pinky_daemon/codex_tmux_session.py
+++ b/src/pinky_daemon/codex_tmux_session.py
@@ -58,6 +58,8 @@ from pinky_daemon.codex_home import (
     prepare_agent_codex_home,
     validate_agent_codex_home,
 )
+
+from pinky_daemon import tmux_session
 from pinky_daemon.codex_tmux_transcript import (
     CodexTmuxTranscriptTailer,
     _discover_codex_rollout,
@@ -489,10 +491,41 @@ class CodexTmuxSession(TmuxSession):
         """Wait for Codex work, with a literal idle-pane stale-meta exit."""
         if not turn.scheduler_serialized:
             return
+        if turn.scheduler_slot_wait_started_at is None:
+            turn.scheduler_slot_wait_started_at = time.monotonic()
+        anchor = turn.scheduler_slot_wait_started_at
+        next_log_at = anchor + tmux_session._SCHEDULER_SLOT_WAIT_LOG_INTERVAL_SEC
         while self._scheduler_pane_busy(turn):
             delivery = turn.scheduler_delivery
             if delivery is not None and delivery.cancelled():
                 raise _SchedulerDeliveryCancelled
+            # #445 — same bounded, logged wait as the base class. The codex
+            # gate has extra stale-meta recovery below, but nothing here
+            # guarantees the pane ever frees: without a cap the wait holds
+            # ``_scheduler_delivery_lock`` forever and starves later wakes.
+            now = time.monotonic()
+            waited = now - anchor
+            if waited >= tmux_session._SCHEDULER_SLOT_WAIT_TIMEOUT_SEC:
+                raise tmux_session._SchedulerDeliverySlotTimeout(
+                    f"no codex scheduler delivery slot after {waited:.0f}s "
+                    f"(cap "
+                    f"{tmux_session._SCHEDULER_SLOT_WAIT_TIMEOUT_SEC:.0f}s, "
+                    f"reason={turn.reason}, "
+                    f"busy={self._scheduler_busy_reason(turn)}) — "
+                    f"leaving the wake undelivered for replay"
+                )
+            if now >= next_log_at:
+                _log(
+                    f"tmux[{self.agent_name}]: SCHEDULER_SLOT_WAIT "
+                    f"reason={turn.reason} waited={waited:.0f}s "
+                    f"cap="
+                    f"{tmux_session._SCHEDULER_SLOT_WAIT_TIMEOUT_SEC:.0f}s "
+                    f"busy={self._scheduler_busy_reason(turn)}"
+                )
+                while next_log_at <= now:
+                    next_log_at += (
+                        tmux_session._SCHEDULER_SLOT_WAIT_LOG_INTERVAL_SEC
+                    )
             if self._codex_gate_blocked_only_by_metas(turn):
                 first_idle = await self._codex_capture_explicit_idle()
                 if first_idle:
@@ -506,7 +539,12 @@ class CodexTmuxSession(TmuxSession):
                             reason="explicit_idle_pane",
                         )
                         continue
-            await asyncio.sleep(0.25)
+            await asyncio.sleep(
+                min(
+                    0.25,
+                    tmux_session._SCHEDULER_SLOT_WAIT_LOG_INTERVAL_SEC / 2,
+                )
+            )
         delivery = turn.scheduler_delivery
         if delivery is not None and delivery.cancelled():
             raise _SchedulerDeliveryCancelled

--- a/src/pinky_daemon/codex_tmux_session.py
+++ b/src/pinky_daemon/codex_tmux_session.py
@@ -51,6 +51,7 @@ import shlex
 import time
 from pathlib import Path
 
+from pinky_daemon import tmux_session
 from pinky_daemon.codex_home import (
     MANAGED_CONFIG_SENTINEL,
     codex_home_for,
@@ -58,8 +59,6 @@ from pinky_daemon.codex_home import (
     prepare_agent_codex_home,
     validate_agent_codex_home,
 )
-
-from pinky_daemon import tmux_session
 from pinky_daemon.codex_tmux_transcript import (
     CodexTmuxTranscriptTailer,
     _discover_codex_rollout,

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -538,6 +538,27 @@ class _WakeSubmissionLateDetected(Exception):  # noqa: N818
 class _WakeSubmissionRecoveryScheduled(Exception):  # noqa: N818
     """The failed wake scheduled transport recovery; stop the old worker."""
 
+class _SchedulerDeliverySlotTimeout(RuntimeError):  # noqa: N818
+    """The pane never freed a delivery slot within the #445 cap.
+
+    Raised out of ``_wait_for_scheduler_delivery_slot`` so the ordinary
+    ``except Exception`` arm of ``_deliver_scheduler_turn`` resolves the
+    receipt False (wake stays undelivered → replayed on the next
+    scheduler pass) and releases ``_scheduler_delivery_lock``, instead of
+    holding it forever behind an invisible spin.
+    """
+
+
+# #445 — the busy-wait before a scheduler paste used to be unbounded and
+# silent. When ``live_status`` latches on "working" (a wake prompt typed
+# but never submitted) ``_scheduler_pane_busy`` stays True forever, so the
+# wait spun with zero log lines while holding ``_scheduler_delivery_lock``
+# — starving every later wake for the same agent. The cap sits below the
+# scheduler's own 600 s receipt expiry so the receipt resolves False (and
+# the wake is re-queued) before the scheduler gives up on it.
+_SCHEDULER_SLOT_WAIT_TIMEOUT_SEC = 300.0
+_SCHEDULER_SLOT_WAIT_LOG_INTERVAL_SEC = 30.0
+
 
 @dataclass
 class TmuxCommandResult:
@@ -1433,6 +1454,12 @@ class _QueuedTurn:
     # the only positive evidence and replay work that already entered the pane.
     scheduler_accept: object = None  # Callable() -> bool
     scheduler_serialized: bool = False
+    # #445 — monotonic anchor for the delivery-slot wait budget. Set on the
+    # first wait for this turn and never reset: ``_deliver_turn`` re-enters
+    # the wait every time the under-lock recheck loses the pane, and a
+    # per-call budget would restart from zero each lap (the unbounded spin
+    # this cap exists to stop). Same anchor discipline as #832/#445-bis.
+    scheduler_slot_wait_started_at: float | None = None
     pane_delivery_started: bool = False
     pane_queue_enqueued: bool = False
     transport_accepted: bool = False
@@ -8693,13 +8720,87 @@ class TmuxSession(TransportReplacementMixin):
 
         if self._scheduler_receipt_terminal(turn):
             raise _SchedulerDeliveryCancelled
+
+        if turn.scheduler_slot_wait_started_at is None:
+            turn.scheduler_slot_wait_started_at = time.monotonic()
+        anchor = turn.scheduler_slot_wait_started_at
+        next_log_at = anchor + _SCHEDULER_SLOT_WAIT_LOG_INTERVAL_SEC
+
         while self._scheduler_pane_busy(turn):
             if self._scheduler_receipt_terminal(turn):
                 raise _SchedulerDeliveryCancelled
-            await asyncio.sleep(0.25)
+            now = time.monotonic()
+            waited = now - anchor
+            if waited >= _SCHEDULER_SLOT_WAIT_TIMEOUT_SEC:
+                raise _SchedulerDeliverySlotTimeout(
+                    f"no scheduler delivery slot after {waited:.0f}s "
+                    f"(cap {_SCHEDULER_SLOT_WAIT_TIMEOUT_SEC:.0f}s, "
+                    f"reason={turn.reason}, "
+                    f"busy={self._scheduler_busy_reason(turn)}) — "
+                    f"leaving the wake undelivered for replay"
+                )
+            if now >= next_log_at:
+                _log(
+                    f"tmux[{self.agent_name}]: SCHEDULER_SLOT_WAIT "
+                    f"reason={turn.reason} waited={waited:.0f}s "
+                    f"cap={_SCHEDULER_SLOT_WAIT_TIMEOUT_SEC:.0f}s "
+                    f"busy={self._scheduler_busy_reason(turn)}"
+                )
+                while next_log_at <= now:
+                    next_log_at += _SCHEDULER_SLOT_WAIT_LOG_INTERVAL_SEC
+            await asyncio.sleep(
+                min(0.25, _SCHEDULER_SLOT_WAIT_LOG_INTERVAL_SEC / 2)
+            )
 
         if self._scheduler_receipt_terminal(turn):
             raise _SchedulerDeliveryCancelled
+
+    def _scheduler_busy_reason(
+        self, candidate: _QueuedTurn | None = None
+    ) -> str:
+        """Short diagnostic for why the pane refuses a scheduler paste.
+
+        Logging-only (#445): the historical wait printed nothing, so a
+        latched ``live_status`` was indistinguishable from a genuinely
+        busy pane. Never raises — a broken ``live_status_fn`` must not
+        take down the log line that reports it.
+        """
+        candidate_in_worker = (
+            candidate is not None and self._inflight_turn is candidate
+        )
+        if self._inflight_tool_calls:
+            return f"tool_calls={len(self._inflight_tool_calls)}"
+        if self._inflight_turn is not None and not candidate_in_worker:
+            return "inflight_turn"
+        if not self._message_queue.empty() and not candidate_in_worker:
+            return f"queue={self._message_queue.qsize()}"
+        live_status_fn = getattr(self._config, "live_status_fn", None)
+        if live_status_fn is None:
+            return "no_live_status_fn"
+        try:
+            live = live_status_fn() or {}
+        except Exception as exc:
+            return f"live_status_error={type(exc).__name__}"
+        status = live.get("status")
+        if status != "idle":
+            return f"live_status={status!r}"
+        last_updated = live.get("last_updated")
+        if not (
+            isinstance(last_updated, (int, float))
+            and not isinstance(last_updated, bool)
+            and last_updated > 0
+        ):
+            return "live_status_no_timestamp"
+        for entry in self._inflight_metas:
+            dispatched_at = getattr(entry, "dispatched_at", None)
+            if not (
+                isinstance(dispatched_at, (int, float))
+                and not isinstance(dispatched_at, bool)
+                and dispatched_at > 0
+                and last_updated >= dispatched_at
+            ):
+                return "idle_older_than_inflight_meta"
+        return "free"
 
     def _scheduler_pane_busy(
         self, candidate: _QueuedTurn | None = None

--- a/tests/test_codex_tmux_session.py
+++ b/tests/test_codex_tmux_session.py
@@ -949,3 +949,38 @@ async def test_integration_codex_tmux_roundtrip(tmp_path):
         assert "PONG" in captured[-1].text.upper()
     finally:
         await ss.disconnect()
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# #445 — the codex override needs the same bounded, visible slot wait
+# ──────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_codex_scheduler_slot_wait_gives_up_after_cap(monkeypatch) -> None:
+    """The codex override must inherit the #445 cap, not spin forever."""
+    from pinky_daemon import codex_tmux_session
+    from pinky_daemon import tmux_session as _ts
+
+    monkeypatch.setattr(_ts, "_SCHEDULER_SLOT_WAIT_TIMEOUT_SEC", 0.20)
+    monkeypatch.setattr(_ts, "_SCHEDULER_SLOT_WAIT_LOG_INTERVAL_SEC", 0.05)
+    lines: list[str] = []
+    monkeypatch.setattr(codex_tmux_session, "_log", lines.append)
+
+    ss = _session()
+    # Precondition, not the behavior under test: a pane that never frees a
+    # slot (the latched-live_status signature of #445).
+    ss._scheduler_pane_busy = lambda candidate=None: True
+    turn = _QueuedTurn(
+        prompt="wake",
+        internal=True,
+        reason="wake_scheduled",
+        scheduler_serialized=True,
+        scheduler_delivery=asyncio.get_event_loop().create_future(),
+    )
+
+    with pytest.raises(_ts._SchedulerDeliverySlotTimeout):
+        await asyncio.wait_for(
+            ss._wait_for_scheduler_delivery_slot(turn), timeout=5
+        )
+    assert any("SCHEDULER_SLOT_WAIT" in ln for ln in lines), lines

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -12581,3 +12581,97 @@ def test_scheduler_drain_busy_unstamped_spawn_keeps_fail_closed() -> None:
     }
 
     assert ss.scheduler_drain_busy() is True
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# #445 — scheduler delivery slot: bounded wait + visible progress
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def _scheduler_turn() -> _QueuedTurn:
+    """A serialized scheduler turn with a live delivery receipt."""
+    return _QueuedTurn(
+        prompt="wake",
+        platform="",
+        chat_id="",
+        message_id="",
+        internal=True,
+        reason="wake_scheduled",
+        scheduler_serialized=True,
+        scheduler_delivery=asyncio.get_event_loop().create_future(),
+    )
+
+
+@pytest.fixture
+def _tiny_slot_budget(monkeypatch):
+    """Shrink the #445 cap/log cadence so tests run in milliseconds."""
+    monkeypatch.setattr(
+        tmux_session, "_SCHEDULER_SLOT_WAIT_TIMEOUT_SEC", 0.20
+    )
+    monkeypatch.setattr(
+        tmux_session, "_SCHEDULER_SLOT_WAIT_LOG_INTERVAL_SEC", 0.05
+    )
+
+
+@pytest.mark.asyncio
+async def test_scheduler_slot_wait_gives_up_after_cap(_tiny_slot_budget) -> None:
+    """A permanently busy pane must not spin the wait forever."""
+    ss, _ = _make_session()
+    turn = _scheduler_turn()
+
+    with pytest.raises(tmux_session._SchedulerDeliverySlotTimeout):
+        await asyncio.wait_for(
+            ss._wait_for_scheduler_delivery_slot(turn), timeout=5
+        )
+
+
+@pytest.mark.asyncio
+async def test_scheduler_slot_wait_logs_progress_while_blocked(
+    _tiny_slot_budget, monkeypatch
+) -> None:
+    """The wait must be visible in the log, not a silent spin."""
+    lines: list[str] = []
+    monkeypatch.setattr(tmux_session, "_log", lines.append)
+    ss, _ = _make_session()
+    turn = _scheduler_turn()
+
+    with pytest.raises(tmux_session._SchedulerDeliverySlotTimeout):
+        await ss._wait_for_scheduler_delivery_slot(turn)
+
+    waiting = [ln for ln in lines if "SCHEDULER_SLOT_WAIT" in ln]
+    assert waiting, f"no progress log emitted; got {lines}"
+    assert any("wake_scheduled" in ln for ln in waiting)
+
+
+@pytest.mark.asyncio
+async def test_scheduler_slot_wait_budget_survives_retry_gate(
+    _tiny_slot_budget,
+) -> None:
+    """The cap is anchored on the turn, so the retry gate can't reset it.
+
+    ``_deliver_turn`` re-enters the wait each time the under-lock recheck
+    loses the pane; a per-call budget would restart from zero every lap
+    and reproduce the unbounded #445 spin.
+    """
+    ss, _ = _make_session()
+    turn = _scheduler_turn()
+    turn.scheduler_slot_wait_started_at = _time.monotonic() - 1000
+
+    started = _time.monotonic()
+    with pytest.raises(tmux_session._SchedulerDeliverySlotTimeout):
+        await ss._wait_for_scheduler_delivery_slot(turn)
+    assert _time.monotonic() - started < 0.15
+
+
+@pytest.mark.asyncio
+async def test_scheduler_slot_timeout_resolves_receipt_false(
+    _tiny_slot_budget,
+) -> None:
+    """A capped-out slot wait must mark the wake undelivered, not vanish."""
+    ss, _ = _make_session(state=SessionState.CONNECTED)
+    turn = _scheduler_turn()
+
+    await ss._deliver_scheduler_turn(turn)
+
+    assert turn.scheduler_delivery.done()
+    assert turn.scheduler_delivery.result() is False


### PR DESCRIPTION
## Problema (#445)

`_wait_for_scheduler_delivery_slot` attendeva **illimitato e senza una riga di log**.

Quando `live_status` resta latchato su `"working"` (prompt di wake digitato ma mai submittato), `_scheduler_pane_busy` resta `True` per sempre: l'attesa gira a vuoto **tenendo `_scheduler_delivery_lock`**, e ogni wake successivo dello stesso agente muore in coda. Dall'esterno si vede solo `wake undelivered` ripetuto e zero log dal transport — cioè il sintomo è visibile ma la causa è muta.

## Modifiche

- **`_SCHEDULER_SLOT_WAIT_TIMEOUT_SEC = 300s`**, deliberatamente sotto la scadenza a 600s della ricevuta. Allo scadere si alza `_SchedulerDeliverySlotTimeout`, che il ramo generico di `_deliver_scheduler_turn` traduce in receipt `False` (wake **non** consegnato → riaccodato al giro dopo) e **rilascia il lock**, invece di trattenerlo su uno spin invisibile.
- **`_SCHEDULER_SLOT_WAIT_LOG_INTERVAL_SEC = 30s`**: riga `SCHEDULER_SLOT_WAIT` con reason, attesa accumulata, tetto e motivo del blocco.
- **`_scheduler_busy_reason()`**: diagnostica solo-log del motivo (tool in volo / turno inflight / coda / `live_status` latchato / idle più vecchio di un meta). Non solleva mai.
- **`turn.scheduler_slot_wait_started_at`**: anchor monotonico fissato **una volta per turno**. `_deliver_turn` rientra nell'attesa a ogni giro del retry gate sotto lock: un budget per-chiamata ripartirebbe da zero ogni volta e riprodurrebbe esattamente lo spin illimitato. Stessa disciplina di #832 / #445-bis.
- Stesso trattamento all'override di `CodexTmuxSession`, che duplica il ciclo e aveva lo stesso difetto.

## Test

Aggiunti `tests/test_tmux_session.py` (+94) e `tests/test_codex_tmux_session.py` (+35).

## Note per chi rivede

- **Rebasato su `origin/main` (8bd484dc) il 18/08.** La prima apertura risultava `mergeable: false / dirty`: i 25 commit intercorsi confliggevano. I 3 conflitti erano tutti **additivi** (blocchi aggiunti da entrambe le parti nello stesso punto: classi di eccezione, un import, test in coda) e sono stati risolti **tenendo entrambe le parti**, non scegliendone una.
- Verificato che il fix **non sia già arrivato in main per altra via**: in `origin/main` `_wait_for_scheduler_delivery_slot` è tuttora un `while` illimitato con `asyncio.sleep(0.25)`, senza tetto né log — il difetto è ancora presente e la patch non è ridondante.
- **Test dopo il rebase**, eseguiti da worktree isolato (mai dal checkout live, che toccherebbe i DB di produzione): `tests/test_tmux_session.py` + `tests/test_codex_tmux_session.py` → **469 passed, 1 skipped**, exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🤖 Opened by Engineer
