### PR TITLE
chore(#405): ignora i file operativi de-tracciati da #423/#424

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,42 @@ docs/
 heartbeat.log
 .coverage
 output/
+
+# ─────────────────────────────────────────────────────────────────────
+# Protezione del de-track di #423/#424 (aggiunto 18/08, #405)
+# Quei task hanno de-tracciato ~340 file operativi, ma NESSUNO era
+# ignorato: un solo `git add -A` ne rimetteva dentro 332, segreti
+# compresi, annullando #423 e ricreando #425. Qui NON si cambia cosa e'
+# versionato: i file gia' tracciati restano tracciati (.gitignore non
+# de-traccia). Si chiude solo il rientro accidentale.
+# ─────────────────────────────────────────────────────────────────────
+
+# config/ — in origin/main NON c'e' nessun file tracciato: si puo'
+# ignorare in blocco. I .template restano ammessi: sono documentazione
+# di configurazione, non dati operativi.
+config/*
+!config/*.template
+
+# scripts/ — ATTENZIONE: qui ci sono 15 file sorgente legittimi
+# versionati in origin/main. Si usa `scripts/*` (non `scripts/`) perche'
+# altrimenti git non scende nella directory e le eccezioni sotto non
+# funzionerebbero. Ogni nuovo script che deve essere versionato va
+# aggiunto a questo elenco.
+scripts/*
+!scripts/audit_route_auth_coverage.py
+!scripts/backfill_codex_runtime.py
+!scripts/backfill_embeddings.py
+!scripts/claude_account.py
+!scripts/demo_containerize.py
+!scripts/install-service.sh
+!scripts/kg_ephemeral_sweep.py
+!scripts/rollback_codex_home.py
+!scripts/store_restore.py
+!scripts/store_snapshot.py
+!scripts/v3_export.py
+!scripts/restart.sh
+!scripts/launchctl/
+!scripts/systemd/
+
+# Token in chiaro nella root
+openclaw_token.txt

--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,7 @@ scripts/*
 
 # Token in chiaro nella root
 openclaw_token.txt
+
+# Artefatto orfano da 0 byte nella root (creato il 22/07, mai tracciato,
+# 0 tabelle). Ignorato per non farlo rientrare con un `git add -A`.
+db.sqlite3


### PR DESCRIPTION
## Il problema

#423/#424 hanno **de-tracciato ~340 file operativi** (script cron, config) per evitare che un `git checkout` del tag di deploy li cancellasse. Ma nessuno di quei file è mai finito in `.gitignore`: sono de-tracciati e **non protetti**.

Conseguenza misurata sul checkout di produzione: **un solo `git add -A` ne rimetteva dentro 332**, segreti compresi — annullando il lavoro di #423 e ricreando la regressione di #425. È esattamente il meccanismo con cui i segreti ci erano finiti la prima volta (commit catch-all `6d50c86a`).

## Misura prima / dopo

| | file che `git add -A` stagerebbe |
|---|---|
| prima | **332** |
| dopo | **5** |

I 5 residui sono innocui: `.gitignore` stesso, due `.md` di analisi, il template di configurazione e un `db.sqlite3` (segnalato a parte, fuori dallo scopo di questa PR).

File con segreti ora coperti, verificati uno per uno con `git add -An`:

- `config/gsc_oauth_credentials.json`
- `config/gsc_service_account.json`
- `config/substack_config.json`
- `scripts/.aiena_secrets`
- `openclaw_token.txt`

## Cosa questa PR NON fa

- **Non cambia cosa è versionato.** `.gitignore` non de-traccia: i file già tracciati restano tracciati. Verificato che `git status` non mostri alcuna rimozione.
- **Non revoca i segreti e non ripulisce la storia git.** Quelle due parti di #405 restano aperte e richiedono una decisione dell'owner. Questa PR è solo la parte difensiva e reversibile.

## Scelte di progetto

- **`config/*`** ignorato in blocco: in `origin/main` quella directory **non ha alcun file tracciato**, quindi non c'è nulla da preservare. `!config/*.template` mantiene ammessi i template, che sono documentazione di configurazione e non dati operativi.
- **`scripts/*`** (non `scripts/`) con **eccezioni esplicite**: la directory contiene **15 sorgenti legittimi** versionati in `origin/main` — unit systemd, `install-service.sh`, script di audit. La forma `scripts/*` è necessaria perché con `scripts/` git non scende nella directory e le negazioni non verrebbero applicate. Ho verificato **uno per uno** che tutti e 15 restino non ignorati.
- Ogni nuovo script che deve essere versionato va aggiunto all'elenco delle eccezioni: è il costo di questa forma, ed è annotato nel commento dentro `.gitignore`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🤖 Opened by Engineer
