### PR TITLE
Log an unconditional receipt for every webhook delivery attempt

### DIFF
--- a/src/pinky_daemon/__main__.py
+++ b/src/pinky_daemon/__main__.py
@@ -135,6 +135,11 @@ def _run_api_with_authority(args) -> None:
     import uvicorn
 
     from pinky_daemon.api import create_api
+    from pinky_daemon.routes.triggers import uvicorn_log_config
+
+    # The access log prints raw request paths; /hooks/<token> carries a
+    # credential in the path, so every server start gets the redacting config.
+    log_config = uvicorn_log_config()
 
     working_dir = os.path.abspath(args.working_dir)
 
@@ -183,7 +188,7 @@ def _run_api_with_authority(args) -> None:
         )
         if enabled_requested:
             print(f"[pinky] Ferry disabled: {ferry_cfg.why_disabled()}", file=sys.stderr)
-        uvicorn.run(app, host=args.host, port=args.port)
+        uvicorn.run(app, host=args.host, port=args.port, log_config=log_config)
         return
 
     # Ferry enabled: run the main API + a dedicated ferry listener bound to the
@@ -204,7 +209,7 @@ def _run_api_with_authority(args) -> None:
             "[pinky] ferry enabled but host_pinky missing — starting API only",
             file=sys.stderr,
         )
-        uvicorn.run(app, host=args.host, port=args.port)
+        uvicorn.run(app, host=args.host, port=args.port, log_config=log_config)
         return
 
     ferry_app = build_ferry_app(host_pinky=host_pinky, config=ferry_cfg)
@@ -214,9 +219,16 @@ def _run_api_with_authority(args) -> None:
         file=sys.stderr,
     )
 
-    main_server = uvicorn.Server(uvicorn.Config(app, host=args.host, port=args.port))
+    main_server = uvicorn.Server(
+        uvicorn.Config(app, host=args.host, port=args.port, log_config=log_config)
+    )
     ferry_server = uvicorn.Server(
-        uvicorn.Config(ferry_app, host=ferry_cfg.bind_host, port=ferry_cfg.bind_port)
+        uvicorn.Config(
+            ferry_app,
+            host=ferry_cfg.bind_host,
+            port=ferry_cfg.bind_port,
+            log_config=log_config,
+        )
     )
     # uvicorn's serve() does `with self.capture_signals():` — a context manager
     # that installs signal.signal(...) handlers. With two servers on one loop the

--- a/src/pinky_daemon/routes/triggers.py
+++ b/src/pinky_daemon/routes/triggers.py
@@ -11,6 +11,7 @@ process-local in api.py too — a server restart resets them.
 from __future__ import annotations
 
 import json
+import logging
 import re as _re2
 import time
 from datetime import datetime
@@ -56,6 +57,53 @@ _hook_ip_buckets: dict[str, list[float]] = {}
 
 _HOOK_IP_RATE_LIMIT = 20
 _HOOK_IP_RATE_WINDOW = 60.0
+
+
+_HOOKS_PATH_RE = _re2.compile(r"(/hooks/)([^/\s\"?]+)")
+
+
+def _redact_hook_path(value: str) -> str:
+    """Replace the token segment of a /hooks/<token> path with its 8-char prefix."""
+    return _HOOKS_PATH_RE.sub(lambda m: f"{m.group(1)}{m.group(2)[:8]}*", value)
+
+
+class HookTokenRedactionFilter(logging.Filter):
+    """Redact webhook tokens from uvicorn access-log request lines.
+
+    The handler-level receipt log already truncates the token, but uvicorn's
+    access log prints the raw request path — including the full /hooks/<token>
+    credential — so the token must also be redacted at this boundary.
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        if isinstance(record.args, tuple):
+            record.args = tuple(
+                _redact_hook_path(arg) if isinstance(arg, str) else arg
+                for arg in record.args
+            )
+        if isinstance(record.msg, str) and "/hooks/" in record.msg:
+            record.msg = _redact_hook_path(record.msg)
+        return True
+
+
+def uvicorn_log_config() -> dict:
+    """uvicorn's default logging config with token redaction on the access handler.
+
+    A logger-level addFilter() does not survive uvicorn's dictConfig (each
+    Config load resets the access logger, and ferry mode loads two Configs),
+    so the filter must ship inside the config that every load re-applies.
+    """
+    import copy
+
+    import uvicorn.config
+
+    config = copy.deepcopy(uvicorn.config.LOGGING_CONFIG)
+    config.setdefault("filters", {})["hook_token_redaction"] = {
+        "()": "pinky_daemon.routes.triggers.HookTokenRedactionFilter",
+    }
+    access_handler = config["handlers"]["access"]
+    access_handler.setdefault("filters", []).append("hook_token_redaction")
+    return config
 
 
 def _client_ip(request: Request) -> str:

--- a/src/pinky_daemon/routes/triggers.py
+++ b/src/pinky_daemon/routes/triggers.py
@@ -58,12 +58,17 @@ _HOOK_IP_RATE_LIMIT = 20
 _HOOK_IP_RATE_WINDOW = 60.0
 
 
-def _check_hook_ip_rate_limit(request: Request, now: float) -> bool:
-    """Return True if the client IP is within the webhook rate limit."""
-    ip = (
+def _client_ip(request: Request) -> str:
+    """Best-effort client IP: first X-Forwarded-For hop, else socket peer."""
+    return (
         request.headers.get("x-forwarded-for", "").split(",")[0].strip()
         or (request.client.host if request.client else "unknown")
     )
+
+
+def _check_hook_ip_rate_limit(request: Request, now: float) -> bool:
+    """Return True if the client IP is within the webhook rate limit."""
+    ip = _client_ip(request)
     timestamps = _hook_ip_buckets.get(ip, [])
     timestamps = [t for t in timestamps if now - t < _HOOK_IP_RATE_WINDOW]
     if len(timestamps) >= _HOOK_IP_RATE_LIMIT:
@@ -258,6 +263,14 @@ async def test_agent_trigger(agent_name: str, trigger_id: int):
 @router.post("/hooks/{token}")
 async def receive_webhook(token: str, request: Request):
     """Receive an inbound webhook and wake the associated agent."""
+    # Receipt log — must stay the first statement so every delivery attempt
+    # is visible even when a later check drops the request (unknown-token 404,
+    # rate-limit 429, oversized 413). The token is a credential: prefix only.
+    _log(
+        f"hooks: receipt token={token[:8]}* ip={_client_ip(request)}"
+        f" len={request.headers.get('content-length', '?')}"
+        f" type={request.headers.get('content-type', '-')}"
+    )
     now = time.time()
 
     # IP rate limit (anti-enumeration — runs before token lookup)

--- a/src/pinky_daemon/shared_mcp.py
+++ b/src/pinky_daemon/shared_mcp.py
@@ -766,16 +766,22 @@ class SharedMcpManager:
         """Run the shared MCP server in a dedicated thread with supervisor loop."""
         import uvicorn
 
+        from pinky_daemon.routes.triggers import uvicorn_log_config
+
         backoff = 1
         max_backoff = 60
 
         while self._running:
             app = self._create_app()
+            # log_config: this Config load (and every supervisor restart)
+            # re-runs dictConfig process-wide; without the patched config it
+            # would strip the /hooks token redaction off the access handler.
             config = uvicorn.Config(
                 app,
                 host=self._host,
                 port=self._port,
                 log_level="warning",
+                log_config=uvicorn_log_config(),
             )
             self._server = uvicorn.Server(config)
             try:

--- a/tests/test_webhook_receipt_log.py
+++ b/tests/test_webhook_receipt_log.py
@@ -9,6 +9,8 @@ logged; only its prefix may appear.
 
 from __future__ import annotations
 
+import logging
+import time
 from dataclasses import dataclass
 
 import pytest
@@ -40,8 +42,7 @@ class _Store:
         self.fired.append(trigger_id)
 
 
-@pytest.fixture()
-def rig(monkeypatch):
+def _wire(monkeypatch) -> tuple[FastAPI, list[str]]:
     monkeypatch.setattr(triggers_module, "_hook_rate_buckets", {})
     monkeypatch.setattr(triggers_module, "_hook_ip_buckets", {})
     logs: list[str] = []
@@ -57,6 +58,12 @@ def rig(monkeypatch):
     )
     app = FastAPI()
     app.include_router(triggers_module.router)
+    return app, logs
+
+
+@pytest.fixture()
+def rig(monkeypatch):
+    app, logs = _wire(monkeypatch)
     return TestClient(app), logs
 
 
@@ -129,3 +136,119 @@ class TestWebhookReceiptLog:
         client.post(f"/hooks/{UNKNOWN_TOKEN}", json={})
         client.post(f"/hooks/{TOKEN}", json={})
         assert len(_receipts(logs)) == 3
+
+
+class _CaptureHandler(logging.Handler):
+    def __init__(self, sink: list[str]):
+        super().__init__()
+        self.sink = sink
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.sink.append(self.format(record))
+
+
+@pytest.fixture()
+def access_capture():
+    """Capture formatted uvicorn.access records with redaction installed."""
+    access_logger = logging.getLogger("uvicorn.access")
+    redaction_filter = triggers_module.HookTokenRedactionFilter()
+    access_logger.addFilter(redaction_filter)
+    records: list[str] = []
+    handler = _CaptureHandler(records)
+    previous_level = access_logger.level
+    access_logger.addHandler(handler)
+    access_logger.setLevel(logging.INFO)
+    yield records
+    access_logger.removeHandler(handler)
+    access_logger.setLevel(previous_level)
+    access_logger.removeFilter(redaction_filter)
+
+
+class TestAccessLogTokenRedaction:
+    def test_request_line_args_are_redacted(self, access_capture):
+        # Exact record shape uvicorn's protocol emits for an access line.
+        logging.getLogger("uvicorn.access").info(
+            '%s - "%s %s HTTP/%s" %d',
+            "127.0.0.1:12345",
+            "POST",
+            f"/hooks/{TOKEN}",
+            "1.1",
+            404,
+        )
+        assert len(access_capture) == 1
+        assert TOKEN not in access_capture[0]
+        assert f"/hooks/{TOKEN[:8]}*" in access_capture[0]
+
+    def test_non_hook_paths_pass_through_unchanged(self, access_capture):
+        logging.getLogger("uvicorn.access").info(
+            '%s - "%s %s HTTP/%s" %d',
+            "127.0.0.1:12345",
+            "GET",
+            "/agents/barsik/status",
+            "1.1",
+            200,
+        )
+        assert access_capture == [
+            '127.0.0.1:12345 - "GET /agents/barsik/status HTTP/1.1" 200'
+        ]
+
+    def test_uvicorn_log_config_wires_redaction_into_access_handler(self):
+        import uvicorn.config
+
+        config = triggers_module.uvicorn_log_config()
+        assert config["filters"]["hook_token_redaction"]["()"] == (
+            "pinky_daemon.routes.triggers.HookTokenRedactionFilter"
+        )
+        assert "hook_token_redaction" in config["handlers"]["access"]["filters"]
+        # The patched dict must be a copy, not a mutation of uvicorn's default.
+        assert "hook_token_redaction" not in (
+            uvicorn.config.LOGGING_CONFIG.get("filters") or {}
+        )
+
+    def test_live_uvicorn_access_log_never_emits_full_token(
+        self, monkeypatch, capfd
+    ):
+        """End-to-end with the production log config: the emitted access
+        record must carry the token prefix, never the full credential."""
+        import threading
+        import urllib.request
+
+        import uvicorn
+
+        app, _ = _wire(monkeypatch)
+        config = uvicorn.Config(
+            app,
+            host="127.0.0.1",
+            port=0,
+            access_log=True,
+            log_config=triggers_module.uvicorn_log_config(),
+        )
+        server = uvicorn.Server(config)
+        thread = threading.Thread(target=server.run, daemon=True)
+        thread.start()
+        try:
+            deadline = time.time() + 15
+            while not server.started and time.time() < deadline:
+                time.sleep(0.05)
+            assert server.started, "uvicorn did not start in time"
+            port = server.servers[0].sockets[0].getsockname()[1]
+            request = urllib.request.Request(
+                f"http://127.0.0.1:{port}/hooks/{TOKEN}",
+                data=b"{}",
+                headers={"content-type": "application/json"},
+                method="POST",
+            )
+            with urllib.request.urlopen(request, timeout=10) as response:
+                assert response.status == 200
+            deadline = time.time() + 10
+            emitted = ""
+            while "/hooks/" not in emitted and time.time() < deadline:
+                time.sleep(0.05)
+                captured = capfd.readouterr()
+                emitted += captured.out + captured.err
+        finally:
+            server.should_exit = True
+            thread.join(timeout=15)
+        assert "/hooks/" in emitted, "no access-log line observed"
+        assert TOKEN not in emitted
+        assert f"/hooks/{TOKEN[:8]}*" in emitted

--- a/tests/test_webhook_receipt_log.py
+++ b/tests/test_webhook_receipt_log.py
@@ -1,0 +1,131 @@
+"""Tests for the /hooks/{token} unconditional receipt log.
+
+Every delivery attempt must leave a receipt line, including the early-drop
+paths (unknown-token 404, IP/per-token 429, oversized 413) that previously
+exited with no log at all — making a dropped delivery indistinguishable from
+a sender that never sent. The full token is a credential and must never be
+logged; only its prefix may appear.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from pinky_daemon.routes import triggers as triggers_module
+
+TOKEN = "whk_valid_token_abcdef1234567890"
+UNKNOWN_TOKEN = "whk_unknown_token_0987654321fedc"
+
+
+@dataclass
+class _Trigger:
+    id: int = 1
+    name: str = "t1"
+    agent_name: str = "agent-a"
+    prompt_template: str = "fired: {{body_raw}}"
+
+
+class _Store:
+    def __init__(self):
+        self.fired: list[int] = []
+
+    def get_by_token(self, token: str):
+        return _Trigger() if token == TOKEN else None
+
+    def record_fire(self, trigger_id: int) -> None:
+        self.fired.append(trigger_id)
+
+
+@pytest.fixture()
+def rig(monkeypatch):
+    monkeypatch.setattr(triggers_module, "_hook_rate_buckets", {})
+    monkeypatch.setattr(triggers_module, "_hook_ip_buckets", {})
+    logs: list[str] = []
+
+    async def wake(agent_name: str, session_id: str, prompt: str) -> None:
+        return None
+
+    triggers_module.set_dependencies(
+        trigger_store=_Store(),
+        agents=None,
+        log=logs.append,
+        wake_callback=wake,
+    )
+    app = FastAPI()
+    app.include_router(triggers_module.router)
+    return TestClient(app), logs
+
+
+def _receipts(logs: list[str]) -> list[str]:
+    return [line for line in logs if line.startswith("hooks: receipt ")]
+
+
+def _assert_token_never_logged(logs: list[str], token: str) -> None:
+    assert all(token not in line for line in logs), "full token leaked into logs"
+
+
+class TestWebhookReceiptLog:
+    def test_success_path_logs_receipt_with_prefix_only(self, rig):
+        client, logs = rig
+        response = client.post(
+            f"/hooks/{TOKEN}", json={"k": "v"},
+        )
+        assert response.status_code == 200
+        receipts = _receipts(logs)
+        assert len(receipts) == 1
+        assert f"token={TOKEN[:8]}*" in receipts[0]
+        assert "ip=" in receipts[0]
+        assert "len=" in receipts[0]
+        assert "type=application/json" in receipts[0]
+        _assert_token_never_logged(logs, TOKEN)
+
+    def test_unknown_token_404_still_logs_receipt(self, rig):
+        client, logs = rig
+        response = client.post(f"/hooks/{UNKNOWN_TOKEN}", json={})
+        assert response.status_code == 404
+        receipts = _receipts(logs)
+        assert len(receipts) == 1
+        assert f"token={UNKNOWN_TOKEN[:8]}*" in receipts[0]
+        _assert_token_never_logged(logs, UNKNOWN_TOKEN)
+
+    def test_oversized_413_still_logs_receipt(self, rig):
+        client, logs = rig
+        response = client.post(
+            f"/hooks/{TOKEN}", content=b"x" * 1_048_577,
+        )
+        assert response.status_code == 413
+        assert len(_receipts(logs)) == 1
+        _assert_token_never_logged(logs, TOKEN)
+
+    def test_token_rate_limited_429_still_logs_receipt(self, rig):
+        client, logs = rig
+        import time as time_module
+
+        now = time_module.time()
+        triggers_module._hook_rate_buckets[TOKEN] = [now] * 60
+        response = client.post(f"/hooks/{TOKEN}", json={})
+        assert response.status_code == 429
+        assert len(_receipts(logs)) == 1
+        _assert_token_never_logged(logs, TOKEN)
+
+    def test_ip_rate_limited_429_still_logs_receipt(self, rig):
+        client, logs = rig
+        import time as time_module
+
+        now = time_module.time()
+        triggers_module._hook_ip_buckets["testclient"] = [now] * 20
+        response = client.post(f"/hooks/{TOKEN}", json={})
+        assert response.status_code == 429
+        assert len(_receipts(logs)) == 1
+        _assert_token_never_logged(logs, TOKEN)
+
+    def test_every_attempt_gets_its_own_receipt(self, rig):
+        client, logs = rig
+        client.post(f"/hooks/{TOKEN}", json={})
+        client.post(f"/hooks/{UNKNOWN_TOKEN}", json={})
+        client.post(f"/hooks/{TOKEN}", json={})
+        assert len(_receipts(logs)) == 3

--- a/tests/test_webhook_receipt_log.py
+++ b/tests/test_webhook_receipt_log.py
@@ -252,3 +252,50 @@ class TestAccessLogTokenRedaction:
         assert "/hooks/" in emitted, "no access-log line observed"
         assert TOKEN not in emitted
         assert f"/hooks/{TOKEN[:8]}*" in emitted
+
+
+def _balanced_call(text: str, open_paren_index: int) -> str:
+    depth = 0
+    for end in range(open_paren_index, len(text)):
+        char = text[end]
+        if char == "(":
+            depth += 1
+        elif char == ")":
+            depth -= 1
+            if depth == 0:
+                return text[open_paren_index : end + 1]
+    return text[open_paren_index:]
+
+
+def test_every_daemon_uvicorn_site_passes_the_redacting_log_config():
+    """Any uvicorn Config/run in the daemon process re-runs dictConfig
+    process-wide; an unpatched site would strip the token redaction off the
+    access handler (the shared-MCP supervisor restarts uvicorn at arbitrary
+    times). Every in-process site must pass log_config explicitly.
+
+    Scope is the pinky_daemon package only: pinky_hub runs as its own
+    process, so its logging config cannot strip this daemon's filter.
+    """
+    from pathlib import Path
+
+    package_root = Path(triggers_module.__file__).resolve().parents[1]
+    violations = []
+    for source_path in sorted(package_root.rglob("*.py")):
+        text = source_path.read_text(encoding="utf-8")
+        for pattern in ("uvicorn.run(", "uvicorn.Config("):
+            start = 0
+            while True:
+                index = text.find(pattern, start)
+                if index == -1:
+                    break
+                call_text = _balanced_call(text, index + len(pattern) - 1)
+                if "log_config" not in call_text:
+                    line_number = text.count("\n", 0, index) + 1
+                    violations.append(
+                        f"{source_path.relative_to(package_root)}:{line_number}"
+                    )
+                start = index + len(pattern)
+    assert violations == [], (
+        "uvicorn started without the redacting log_config at: "
+        + ", ".join(violations)
+    )


### PR DESCRIPTION
## Problem

`POST /hooks/{token}` logs only after a successful wake (`hooks: trigger fired`). The three early-exit paths — unknown-token 404, rate-limit 429 (the per-token limiter logged nothing; only the IP limiter logged), oversized 413 — drop the request with no trace. Operationally that means a dropped webhook is indistinguishable from an upstream sender that never sent, which turns every delivery gap into an unanswerable investigation.

Additionally (review finding, round 2): uvicorn's access log printed the raw request path, so the full `/hooks/<token>` credential reached the logs on every request regardless of handler-level care.

## Fix

1. **Unconditional receipt log** as the first statement of `receive_webhook`, before any check can drop the request: `hooks: receipt token=<8-char prefix>* ip=<client> len=<content-length> type=<content-type>`. Client-IP extraction factored into a shared `_client_ip()` helper.
2. **Access-log redaction at the uvicorn boundary**: `uvicorn_log_config()` returns uvicorn's default `LOGGING_CONFIG` with a `HookTokenRedactionFilter` wired onto the access handler, and all four server start sites pass it. The filter ships inside the dict config (not a logger-level `addFilter`) because every uvicorn Config load re-applies `dictConfig` and wipes logger-level filters — the ferry two-server path loads two Configs.

The full token is a credential and never enters logs on either boundary — prefix only.

## Tests

`tests/test_webhook_receipt_log.py` (10 tests): receipt present on the success path and all four drop paths (unknown-token 404, per-token 429, IP 429, oversized 413), one receipt per attempt, full token absent from handler logs; access-log filter redacts the exact uvicorn record shape, passes non-hook paths through byte-identical, config-shape test proves the filter is wired into a copy (not uvicorn's module default); and a **live uvicorn round-trip** with the production log config observing the actually emitted access record via capfd — full token absent, prefix present.

No screenshot: log-line observability change, no UI surface.

🤖 Opened by barsik

🤖 Generated with [Claude Code](https://claude.com/claude-code)