### PR TITLE
Stop the wake drain terminalizing deliverable work

### DIFF
--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -742,6 +742,11 @@ class AgentSchedule:
     direct_send: bool = False  # If true, prompt is sent directly as a message (not as agent input)
     target_channel: str = ""  # Chat ID or channel for direct_send routing
     one_shot: bool = False  # If true, auto-disable after first firing
+    # Newest ACCEPTED exact-fire timestamp (fire identity, not receipt
+    # wall-clock). Durable supersession authority: it outlives the reapable
+    # accepted receipt rows, so replay's floor never loses ordering evidence
+    # to retention configuration (#635).
+    last_accepted_fired_at: float = 0.0
 
     def to_dict(self) -> dict:
         return {
@@ -754,6 +759,7 @@ class AgentSchedule:
             "enabled": self.enabled,
             "last_run": self.last_run,
             "last_delivered": self.last_delivered,
+            "last_accepted_fired_at": self.last_accepted_fired_at,
             "next_run": _cron_next_run(self.cron, self.timezone),
             "created_at": self.created_at,
             "direct_send": self.direct_send,
@@ -785,6 +791,11 @@ class PendingScheduleWake:
     last_error: str = ""
     abandoned_at: float = 0.0
     drain_parked_at: float = 0.0
+    # Structural release provenance (#635): stamped by the release
+    # transition itself — the only creator of released rows — so replay's
+    # supersession floor cannot be dodged by any park-reason text. Cleared
+    # when the row is parked again.
+    released_at: float = 0.0
 
     @property
     def name(self) -> str:
@@ -826,6 +837,7 @@ class PendingScheduleWake:
             "last_error": self.last_error,
             "abandoned_at": self.abandoned_at,
             "drain_parked_at": self.drain_parked_at,
+            "released_at": self.released_at,
             "state": self.ledger_state,
         }
 
@@ -1507,6 +1519,7 @@ class AgentRegistry:
                 enabled INTEGER NOT NULL DEFAULT 1,
                 last_run REAL NOT NULL DEFAULT 0,
                 last_delivered REAL NOT NULL DEFAULT 0,
+                last_accepted_fired_at REAL NOT NULL DEFAULT 0,
                 created_at REAL NOT NULL,
                 FOREIGN KEY (agent_name) REFERENCES agents(name) ON DELETE CASCADE
             );
@@ -1526,6 +1539,7 @@ class AgentRegistry:
                 last_error TEXT NOT NULL DEFAULT '',
                 abandoned_at REAL NOT NULL DEFAULT 0,
                 drain_parked_at REAL NOT NULL DEFAULT 0,
+                released_at REAL NOT NULL DEFAULT 0,
                 FOREIGN KEY (agent_name) REFERENCES agents(name) ON DELETE CASCADE,
                 UNIQUE(schedule_id, fired_at)
             );
@@ -1997,6 +2011,7 @@ class AgentRegistry:
             ("target_channel", "TEXT NOT NULL DEFAULT ''"),
             ("one_shot", "INTEGER NOT NULL DEFAULT 0"),
             ("last_delivered", "REAL NOT NULL DEFAULT 0"),
+            ("last_accepted_fired_at", "REAL NOT NULL DEFAULT 0"),
         ]
         for col, typedef in sched_migrations:
             if col not in sched_existing:
@@ -2018,6 +2033,7 @@ class AgentRegistry:
             ("last_error", "TEXT NOT NULL DEFAULT ''"),
             ("abandoned_at", "REAL NOT NULL DEFAULT 0"),
             ("drain_parked_at", "REAL NOT NULL DEFAULT 0"),
+            ("released_at", "REAL NOT NULL DEFAULT 0"),
         ]
         for col, typedef in wake_migrations:
             if col not in wake_existing:
@@ -4960,11 +4976,12 @@ except Exception as exc:
             direct_send=bool(r[10]) if len(r) > 10 else False,
             target_channel=r[11] if len(r) > 11 else "",
             one_shot=bool(r[12]) if len(r) > 12 else False,
+            last_accepted_fired_at=float(r[13]) if len(r) > 13 else 0.0,
         )
 
     def get_schedules(self, agent_name: str, *, enabled_only: bool = True) -> list[AgentSchedule]:
         """Get all schedules for an agent."""
-        sql = "SELECT id, agent_name, name, cron, prompt, timezone, enabled, last_run, last_delivered, created_at, direct_send, target_channel, one_shot FROM agent_schedules WHERE agent_name=?"
+        sql = "SELECT id, agent_name, name, cron, prompt, timezone, enabled, last_run, last_delivered, created_at, direct_send, target_channel, one_shot, last_accepted_fired_at FROM agent_schedules WHERE agent_name=?"
         params: list = [agent_name]
         if enabled_only:
             sql += " AND enabled=1"
@@ -4974,7 +4991,7 @@ except Exception as exc:
 
     def get_all_schedules(self, *, enabled_only: bool = True) -> list[AgentSchedule]:
         """Get all schedules across all agents."""
-        sql = "SELECT id, agent_name, name, cron, prompt, timezone, enabled, last_run, last_delivered, created_at, direct_send, target_channel, one_shot FROM agent_schedules"
+        sql = "SELECT id, agent_name, name, cron, prompt, timezone, enabled, last_run, last_delivered, created_at, direct_send, target_channel, one_shot, last_accepted_fired_at FROM agent_schedules"
         if enabled_only:
             sql += " WHERE enabled=1"
         sql += " ORDER BY agent_name, created_at ASC"
@@ -5010,7 +5027,7 @@ except Exception as exc:
         row = self._db.execute(
             """SELECT id, agent_name, name, cron, prompt, timezone, enabled,
                       last_run, last_delivered, created_at, direct_send,
-                      target_channel, one_shot
+                      target_channel, one_shot, last_accepted_fired_at
                FROM agent_schedules WHERE id=?""",
             (schedule_id,),
         ).fetchone()
@@ -5071,7 +5088,8 @@ except Exception as exc:
                 return None
             row = self._db.execute(
                 """SELECT id, agent_name, name, cron, prompt, timezone, enabled, last_run,
-                          last_delivered, created_at, direct_send, target_channel, one_shot
+                          last_delivered, created_at, direct_send, target_channel, one_shot,
+                          last_accepted_fired_at
                    FROM agent_schedules WHERE id=?""",
                 (schedule_id,),
             ).fetchone()
@@ -5327,7 +5345,7 @@ except Exception as exc:
         return self._db.execute(
             """SELECT id, schedule_id, agent_name, schedule_name, prompt,
                       fired_at, created_at, attempts, parked_at, accepted_at,
-                      failed_at, last_error, abandoned_at, drain_parked_at
+                      failed_at, last_error, abandoned_at, drain_parked_at, released_at
                FROM pending_schedule_wakes
                WHERE schedule_id=? AND fired_at=?""",
             (schedule_id, fired_at),
@@ -5371,7 +5389,7 @@ except Exception as exc:
             row = self._db.execute(
                 """SELECT id, schedule_id, agent_name, schedule_name, prompt,
                           fired_at, created_at, attempts, parked_at, accepted_at,
-                          failed_at, last_error, abandoned_at, drain_parked_at
+                          failed_at, last_error, abandoned_at, drain_parked_at, released_at
                    FROM pending_schedule_wakes
                    WHERE schedule_id=? AND fired_at=?""",
                 (schedule_id, fired_at),
@@ -5394,7 +5412,7 @@ except Exception as exc:
         """
         sql = """SELECT id, schedule_id, agent_name, schedule_name, prompt,
                         fired_at, created_at, attempts, parked_at, accepted_at,
-                        failed_at, last_error, abandoned_at, drain_parked_at
+                        failed_at, last_error, abandoned_at, drain_parked_at, released_at
                  FROM pending_schedule_wakes"""
         conditions: list[str] = []
         params: list = []
@@ -5484,7 +5502,7 @@ except Exception as exc:
             raise ValueError(f"invalid scheduler wake ledger state: {state}")
         sql = """SELECT id, schedule_id, agent_name, schedule_name, prompt,
                         fired_at, created_at, attempts, parked_at, accepted_at,
-                        failed_at, last_error, abandoned_at, drain_parked_at
+                        failed_at, last_error, abandoned_at, drain_parked_at, released_at
                  FROM pending_schedule_wakes"""
         conditions: list[str] = []
         params: list = []
@@ -5640,6 +5658,7 @@ except Exception as exc:
             cursor = self._db.execute(
                 """UPDATE pending_schedule_wakes
                    SET drain_parked_at=?,
+                       released_at=0,
                        failed_at=CASE WHEN failed_at=0 THEN ? ELSE failed_at END,
                        last_error=?
                    WHERE id=? AND drain_parked_at=0 AND parked_at=0
@@ -5657,42 +5676,23 @@ except Exception as exc:
         replay policy, so the #1102 staleness and zombie rules still bound
         what actually replays. Terminal rows are never resurrected.
 
-        The release stamps ``OUTBOX_DRAIN_RELEASED`` provenance onto
-        ``last_error``: this transition is the ONLY creator of released rows,
-        so replay's recurrence-supersession floor can key on it without
-        depending on what reason string the park was originally given.
+        The release stamps STRUCTURAL provenance (``released_at``): this
+        transition is the ONLY creator of released rows, so replay's
+        recurrence-supersession floor keys on the column and no park-reason
+        text — any case, any content — can dodge it.
         """
+        timestamp = time.time()
         with self._rmw_lock:
             cursor = self._db.execute(
                 """UPDATE pending_schedule_wakes
                    SET drain_parked_at=0,
-                       last_error=CASE
-                           WHEN last_error LIKE 'OUTBOX_DRAIN_RELEASED:%'
-                           THEN last_error
-                           ELSE 'OUTBOX_DRAIN_RELEASED: ' || last_error END
+                       released_at=?
                    WHERE agent_name=? AND drain_parked_at>0
                      AND accepted_at=0 AND parked_at=0 AND abandoned_at=0""",
-                (agent_name,),
+                (timestamp, agent_name),
             )
             self._db.commit()
         return cursor.rowcount
-
-    def get_max_accepted_fired_at(self, schedule_id: int) -> float:
-        """Return the newest ACCEPTED exact-fire timestamp for one schedule.
-
-        This is the exact-fire high-water mark replay's supersession floor
-        compares against — receipt wall-clock time (``last_delivered``) is
-        NOT ordering evidence, because an older fire can be accepted after a
-        newer one fired. Returns 0.0 when no accepted receipt is retained
-        (including after the reaper prunes old accepted rows — parked debt
-        hits the reaper's own fired-at ceiling long before that window).
-        """
-        row = self._db.execute(
-            """SELECT MAX(fired_at) FROM pending_schedule_wakes
-               WHERE schedule_id=? AND accepted_at>0""",
-            (schedule_id,),
-        ).fetchone()
-        return float(row[0]) if row and row[0] is not None else 0.0
 
     def list_drain_parked_agent_names(self) -> list[str]:
         """Name every agent holding recoverable drain-parked wake debt."""
@@ -5766,7 +5766,7 @@ except Exception as exc:
         timestamp = delivered_at or time.time()
         with self._rmw_lock:
             row = self._db.execute(
-                """SELECT schedule_id, accepted_at
+                """SELECT schedule_id, accepted_at, fired_at
                    FROM pending_schedule_wakes WHERE id=?""",
                 (pending_id,),
             ).fetchone()
@@ -5774,9 +5774,10 @@ except Exception as exc:
                 return False
             self._db.execute(
                 """UPDATE agent_schedules
-                   SET last_delivered=MAX(last_delivered, ?)
+                   SET last_delivered=MAX(last_delivered, ?),
+                       last_accepted_fired_at=MAX(last_accepted_fired_at, ?)
                    WHERE id=?""",
-                (timestamp, row[0]),
+                (timestamp, float(row[2]), row[0]),
             )
             self._db.execute(
                 """UPDATE pending_schedule_wakes
@@ -5811,9 +5812,10 @@ except Exception as exc:
                 return False
             self._db.execute(
                 """UPDATE agent_schedules
-                   SET last_delivered=MAX(last_delivered, ?)
+                   SET last_delivered=MAX(last_delivered, ?),
+                       last_accepted_fired_at=MAX(last_accepted_fired_at, ?)
                    WHERE id=?""",
-                (timestamp, schedule_id),
+                (timestamp, fired_at, schedule_id),
             )
             self._db.execute(
                 """UPDATE pending_schedule_wakes

--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -2017,24 +2017,13 @@ class AgentRegistry:
             if col not in sched_existing:
                 self._db.execute(f"ALTER TABLE agent_schedules ADD COLUMN {col} {typedef}")
                 _log(f"agent_registry: migrated — added {col} to agent_schedules")
-        if "last_accepted_fired_at" not in sched_existing:
-            # Backfill the supersession authority from retained accepted wake
-            # rows: that evidence is provable at upgrade time, and discarding
-            # it would let an already-superseded old occurrence replay after
-            # the upgrade. Schedules whose receipts were already reaped keep
-            # the conservative zero (floor inert until the next accept).
-            self._db.execute(
-                """UPDATE agent_schedules
-                   SET last_accepted_fired_at=COALESCE(
-                       (SELECT MAX(w.fired_at) FROM pending_schedule_wakes w
-                        WHERE w.schedule_id=agent_schedules.id
-                          AND w.accepted_at>0),
-                       0)"""
-            )
-            _log(
-                "agent_registry: migrated — backfilled "
-                "last_accepted_fired_at from retained accepted wakes"
-            )
+        # The last_accepted_fired_at backfill reads pending_schedule_wakes
+        # columns, so it MUST run after the wake-table migration below —
+        # released upgrade sources have the wake table without accepted_at,
+        # and reading it here would abort the reopen (boot-brick).
+        backfill_accepted_authority = (
+            "last_accepted_fired_at" not in sched_existing
+        )
 
         # Migrate pending_schedule_wakes table
         wake_existing = {
@@ -2074,6 +2063,27 @@ class AgentRegistry:
                    accepted_at, parked_at, abandoned_at, fired_at
                )"""
         )
+        if backfill_accepted_authority:
+            # Backfill the supersession authority from retained accepted wake
+            # rows: that evidence is provable at upgrade time, and discarding
+            # it would let an already-superseded old occurrence replay after
+            # the upgrade. Runs after the wake migration so accepted_at is
+            # guaranteed to exist; schedules whose receipts were already
+            # reaped (or upgrade sources that never had accepted stamps)
+            # keep the conservative zero — the floor stays inert until the
+            # next accept, which fails safe toward delivering.
+            self._db.execute(
+                """UPDATE agent_schedules
+                   SET last_accepted_fired_at=COALESCE(
+                       (SELECT MAX(w.fired_at) FROM pending_schedule_wakes w
+                        WHERE w.schedule_id=agent_schedules.id
+                          AND w.accepted_at>0),
+                       0)"""
+            )
+            _log(
+                "agent_registry: migrated — backfilled "
+                "last_accepted_fired_at from retained accepted wakes"
+            )
         self._db.commit()
 
         # Migrate agent_heartbeats table
@@ -5709,17 +5719,31 @@ except Exception as exc:
         recurrence-supersession floor keys on the column and no park-reason
         text — any case, any content — can dodge it.
         """
-        timestamp = time.time()
         with self._rmw_lock:
-            cursor = self._db.execute(
-                """UPDATE pending_schedule_wakes
-                   SET drain_parked_at=0,
-                       released_at=?
-                   WHERE agent_name=? AND drain_parked_at>0
-                     AND accepted_at=0 AND parked_at=0 AND abandoned_at=0""",
-                (timestamp, agent_name),
+            released = self._release_drain_parked_locked(
+                agent_name, time.time()
             )
             self._db.commit()
+        return released
+
+    def _release_drain_parked_locked(
+        self, agent_name: str, timestamp: float
+    ) -> int:
+        """Release one agent's drain-parked rows; caller holds the rmw lock.
+
+        Shared by the public release and both durable confirm transitions:
+        a positive receipt is release evidence AT THE DURABLE EDGE, so a
+        process crash between the durable accept and any in-process
+        confirmed-handling can never strand recoverable debt (#991 seam).
+        """
+        cursor = self._db.execute(
+            """UPDATE pending_schedule_wakes
+               SET drain_parked_at=0,
+                   released_at=?
+               WHERE agent_name=? AND drain_parked_at>0
+                 AND accepted_at=0 AND parked_at=0 AND abandoned_at=0""",
+            (timestamp, agent_name),
+        )
         return cursor.rowcount
 
     def list_drain_parked_agent_names(self) -> list[str]:
@@ -5794,7 +5818,7 @@ except Exception as exc:
         timestamp = delivered_at or time.time()
         with self._rmw_lock:
             row = self._db.execute(
-                """SELECT schedule_id, accepted_at, fired_at
+                """SELECT schedule_id, accepted_at, fired_at, agent_name
                    FROM pending_schedule_wakes WHERE id=?""",
                 (pending_id,),
             ).fetchone()
@@ -5818,6 +5842,9 @@ except Exception as exc:
                    WHERE id=?""",
                 (timestamp, pending_id),
             )
+            # A durable positive receipt is release evidence for every
+            # other drain-parked row this agent holds (#635, #991 seam).
+            self._release_drain_parked_locked(str(row[3]), timestamp)
             self._db.commit()
         return True
 
@@ -5832,7 +5859,8 @@ except Exception as exc:
         timestamp = delivered_at or time.time()
         with self._rmw_lock:
             row = self._db.execute(
-                """SELECT id, accepted_at FROM pending_schedule_wakes
+                """SELECT id, accepted_at, agent_name
+                   FROM pending_schedule_wakes
                    WHERE schedule_id=? AND fired_at=?""",
                 (schedule_id, fired_at),
             ).fetchone()
@@ -5856,6 +5884,9 @@ except Exception as exc:
                    WHERE schedule_id=? AND fired_at=?""",
                 (timestamp, schedule_id, fired_at),
             )
+            # A durable positive receipt is release evidence for every
+            # other drain-parked row this agent holds (#635, #991 seam).
+            self._release_drain_parked_locked(str(row[2]), timestamp)
             self._db.commit()
         newly_receipted = float(row[1]) == 0
         if newly_receipted:

--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -2017,6 +2017,24 @@ class AgentRegistry:
             if col not in sched_existing:
                 self._db.execute(f"ALTER TABLE agent_schedules ADD COLUMN {col} {typedef}")
                 _log(f"agent_registry: migrated — added {col} to agent_schedules")
+        if "last_accepted_fired_at" not in sched_existing:
+            # Backfill the supersession authority from retained accepted wake
+            # rows: that evidence is provable at upgrade time, and discarding
+            # it would let an already-superseded old occurrence replay after
+            # the upgrade. Schedules whose receipts were already reaped keep
+            # the conservative zero (floor inert until the next accept).
+            self._db.execute(
+                """UPDATE agent_schedules
+                   SET last_accepted_fired_at=COALESCE(
+                       (SELECT MAX(w.fired_at) FROM pending_schedule_wakes w
+                        WHERE w.schedule_id=agent_schedules.id
+                          AND w.accepted_at>0),
+                       0)"""
+            )
+            _log(
+                "agent_registry: migrated — backfilled "
+                "last_accepted_fired_at from retained accepted wakes"
+            )
 
         # Migrate pending_schedule_wakes table
         wake_existing = {
@@ -5152,13 +5170,23 @@ except Exception as exc:
         return cursor.rowcount > 0
 
     def update_schedule_last_delivered(
-        self, schedule_id: int, timestamp: float = 0.0
+        self, schedule_id: int, timestamp: float = 0.0,
+        *, accepted_fired_at: float = 0.0,
     ) -> None:
-        """Record when the session confirmed acceptance of a fired prompt."""
+        """Record when the session confirmed acceptance of a fired prompt.
+
+        ``accepted_fired_at`` carries the exact fire identity for ledgerless
+        confirmations (direct-send fires have no wake row): the durable
+        supersession floor must advance on EVERY confirmed occurrence, not
+        only receipted ones.
+        """
         ts = timestamp or time.time()
         self._db.execute(
-            "UPDATE agent_schedules SET last_delivered=? WHERE id=?",
-            (ts, schedule_id),
+            """UPDATE agent_schedules
+               SET last_delivered=?,
+                   last_accepted_fired_at=MAX(last_accepted_fired_at, ?)
+               WHERE id=?""",
+            (ts, max(0.0, accepted_fired_at), schedule_id),
         )
         self._db.commit()
 

--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -5656,17 +5656,43 @@ except Exception as exc:
         confirmed delivery to this agent). Released rows re-enter the normal
         replay policy, so the #1102 staleness and zombie rules still bound
         what actually replays. Terminal rows are never resurrected.
+
+        The release stamps ``OUTBOX_DRAIN_RELEASED`` provenance onto
+        ``last_error``: this transition is the ONLY creator of released rows,
+        so replay's recurrence-supersession floor can key on it without
+        depending on what reason string the park was originally given.
         """
         with self._rmw_lock:
             cursor = self._db.execute(
                 """UPDATE pending_schedule_wakes
-                   SET drain_parked_at=0
+                   SET drain_parked_at=0,
+                       last_error=CASE
+                           WHEN last_error LIKE 'OUTBOX_DRAIN_RELEASED:%'
+                           THEN last_error
+                           ELSE 'OUTBOX_DRAIN_RELEASED: ' || last_error END
                    WHERE agent_name=? AND drain_parked_at>0
                      AND accepted_at=0 AND parked_at=0 AND abandoned_at=0""",
                 (agent_name,),
             )
             self._db.commit()
         return cursor.rowcount
+
+    def get_max_accepted_fired_at(self, schedule_id: int) -> float:
+        """Return the newest ACCEPTED exact-fire timestamp for one schedule.
+
+        This is the exact-fire high-water mark replay's supersession floor
+        compares against — receipt wall-clock time (``last_delivered``) is
+        NOT ordering evidence, because an older fire can be accepted after a
+        newer one fired. Returns 0.0 when no accepted receipt is retained
+        (including after the reaper prunes old accepted rows — parked debt
+        hits the reaper's own fired-at ceiling long before that window).
+        """
+        row = self._db.execute(
+            """SELECT MAX(fired_at) FROM pending_schedule_wakes
+               WHERE schedule_id=? AND accepted_at>0""",
+            (schedule_id,),
+        ).fetchone()
+        return float(row[0]) if row and row[0] is not None else 0.0
 
     def list_drain_parked_agent_names(self) -> list[str]:
         """Name every agent holding recoverable drain-parked wake debt."""

--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -5746,6 +5746,23 @@ except Exception as exc:
         )
         return cursor.rowcount
 
+    def has_released_pending_wakes(self, agent_name: str) -> bool:
+        """Whether this agent holds active rows released from drain parking.
+
+        Replay triggers on confirm evidence key on THIS, not on any active
+        row: ordinary next-session backlog (never parked) must keep its
+        documented turn-idle/drain boundary, and a transiently failed FIFO
+        row must keep its attempt cadence.
+        """
+        row = self._db.execute(
+            """SELECT 1 FROM pending_schedule_wakes
+               WHERE agent_name=? AND released_at>0 AND accepted_at=0
+                 AND parked_at=0 AND abandoned_at=0 AND drain_parked_at=0
+               LIMIT 1""",
+            (agent_name,),
+        ).fetchone()
+        return row is not None
+
     def list_drain_parked_agent_names(self) -> list[str]:
         """Name every agent holding recoverable drain-parked wake debt."""
         rows = self._db.execute(

--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -784,6 +784,7 @@ class PendingScheduleWake:
     failed_at: float = 0.0
     last_error: str = ""
     abandoned_at: float = 0.0
+    drain_parked_at: float = 0.0
 
     @property
     def name(self) -> str:
@@ -792,13 +793,21 @@ class PendingScheduleWake:
 
     @property
     def ledger_state(self) -> str:
-        """Return the exact operational outcome used by fleet health."""
+        """Return the exact operational outcome used by fleet health.
+
+        ``drain-parked`` is the one NON-terminal marker here: the row is
+        excluded from drain retry pressure but remains owed work until a
+        release, a late receipt, an explicit terminal transition, or the
+        reaper's fired-at ceiling resolves it.
+        """
         if self.accepted_at > 0:
             return "receipted-ran-once"
         if self.abandoned_at > 0:
             return "abandoned"
         if self.parked_at > 0:
             return "quarantined"
+        if self.drain_parked_at > 0:
+            return "drain-parked"
         return "pending"
 
     def to_dict(self) -> dict:
@@ -816,6 +825,7 @@ class PendingScheduleWake:
             "failed_at": self.failed_at,
             "last_error": self.last_error,
             "abandoned_at": self.abandoned_at,
+            "drain_parked_at": self.drain_parked_at,
             "state": self.ledger_state,
         }
 
@@ -1515,6 +1525,7 @@ class AgentRegistry:
                 failed_at REAL NOT NULL DEFAULT 0,
                 last_error TEXT NOT NULL DEFAULT '',
                 abandoned_at REAL NOT NULL DEFAULT 0,
+                drain_parked_at REAL NOT NULL DEFAULT 0,
                 FOREIGN KEY (agent_name) REFERENCES agents(name) ON DELETE CASCADE,
                 UNIQUE(schedule_id, fired_at)
             );
@@ -2006,6 +2017,7 @@ class AgentRegistry:
             ("failed_at", "REAL NOT NULL DEFAULT 0"),
             ("last_error", "TEXT NOT NULL DEFAULT ''"),
             ("abandoned_at", "REAL NOT NULL DEFAULT 0"),
+            ("drain_parked_at", "REAL NOT NULL DEFAULT 0"),
         ]
         for col, typedef in wake_migrations:
             if col not in wake_existing:
@@ -5315,7 +5327,7 @@ except Exception as exc:
         return self._db.execute(
             """SELECT id, schedule_id, agent_name, schedule_name, prompt,
                       fired_at, created_at, attempts, parked_at, accepted_at,
-                      failed_at, last_error, abandoned_at
+                      failed_at, last_error, abandoned_at, drain_parked_at
                FROM pending_schedule_wakes
                WHERE schedule_id=? AND fired_at=?""",
             (schedule_id, fired_at),
@@ -5359,7 +5371,7 @@ except Exception as exc:
             row = self._db.execute(
                 """SELECT id, schedule_id, agent_name, schedule_name, prompt,
                           fired_at, created_at, attempts, parked_at, accepted_at,
-                          failed_at, last_error, abandoned_at
+                          failed_at, last_error, abandoned_at, drain_parked_at
                    FROM pending_schedule_wakes
                    WHERE schedule_id=? AND fired_at=?""",
                 (schedule_id, fired_at),
@@ -5375,13 +5387,14 @@ except Exception as exc:
     ) -> list[PendingScheduleWake]:
         """Return pending scheduler wakes oldest-first.
 
-        Accepted receipts are always excluded. Quarantined and abandoned rows
-        are excluded by default; pass ``include_parked=True`` to inspect those
-        terminal records alongside the active replay outbox.
+        Accepted receipts are always excluded. Quarantined, abandoned, and
+        drain-parked rows are excluded by default; pass ``include_parked=True``
+        to inspect those records alongside the active replay outbox
+        (drain-parked rows are non-terminal but carry no retry pressure).
         """
         sql = """SELECT id, schedule_id, agent_name, schedule_name, prompt,
                         fired_at, created_at, attempts, parked_at, accepted_at,
-                        failed_at, last_error, abandoned_at
+                        failed_at, last_error, abandoned_at, drain_parked_at
                  FROM pending_schedule_wakes"""
         conditions: list[str] = []
         params: list = []
@@ -5390,7 +5403,9 @@ except Exception as exc:
             params.append(agent_name)
         conditions.append("accepted_at=0")
         if not include_parked:
-            conditions.extend(("parked_at=0", "abandoned_at=0"))
+            conditions.extend(
+                ("parked_at=0", "abandoned_at=0", "drain_parked_at=0")
+            )
         if conditions:
             sql += " WHERE " + " AND ".join(conditions)
         sql += " ORDER BY fired_at ASC, id ASC"
@@ -5410,10 +5425,15 @@ except Exception as exc:
         never as active replay debt.
         """
         sql = """SELECT agent_name,
-                        SUM(CASE WHEN abandoned_at=0 THEN 1 ELSE 0 END),
-                        MIN(CASE WHEN abandoned_at=0 THEN fired_at END),
-                        MAX(CASE WHEN abandoned_at=0 THEN fired_at END),
-                        SUM(CASE WHEN abandoned_at>0 THEN 1 ELSE 0 END)
+                        SUM(CASE WHEN abandoned_at=0 AND drain_parked_at=0
+                            THEN 1 ELSE 0 END),
+                        MIN(CASE WHEN abandoned_at=0 AND drain_parked_at=0
+                            THEN fired_at END),
+                        MAX(CASE WHEN abandoned_at=0 AND drain_parked_at=0
+                            THEN fired_at END),
+                        SUM(CASE WHEN abandoned_at>0 THEN 1 ELSE 0 END),
+                        SUM(CASE WHEN abandoned_at=0 AND drain_parked_at>0
+                            THEN 1 ELSE 0 END)
                  FROM pending_schedule_wakes
                  WHERE accepted_at=0 AND parked_at=0"""
         params: list = []
@@ -5430,8 +5450,9 @@ except Exception as exc:
             result.append(
                 {
                     "agent_name": str(row[0]),
-                    "count": int(row[1]),
+                    "count": int(row[1] or 0),
                     "abandoned_count": int(row[4]),
+                    "drain_parked_count": int(row[5]),
                     "oldest_fired_at": oldest_fired_at,
                     "newest_fired_at": newest_fired_at,
                     "oldest_age_seconds": (
@@ -5458,11 +5479,12 @@ except Exception as exc:
             "receipted-ran-once",
             "quarantined",
             "abandoned",
+            "drain-parked",
         }:
             raise ValueError(f"invalid scheduler wake ledger state: {state}")
         sql = """SELECT id, schedule_id, agent_name, schedule_name, prompt,
                         fired_at, created_at, attempts, parked_at, accepted_at,
-                        failed_at, last_error, abandoned_at
+                        failed_at, last_error, abandoned_at, drain_parked_at
                  FROM pending_schedule_wakes"""
         conditions: list[str] = []
         params: list = []
@@ -5474,7 +5496,12 @@ except Exception as exc:
             params.append(fired_after)
         if state == "pending":
             conditions.extend(
-                ("accepted_at=0", "parked_at=0", "abandoned_at=0")
+                (
+                    "accepted_at=0",
+                    "parked_at=0",
+                    "abandoned_at=0",
+                    "drain_parked_at=0",
+                )
             )
         elif state == "receipted-ran-once":
             conditions.append("accepted_at>0")
@@ -5485,6 +5512,15 @@ except Exception as exc:
         elif state == "abandoned":
             conditions.extend(
                 ("accepted_at=0", "parked_at=0", "abandoned_at>0")
+            )
+        elif state == "drain-parked":
+            conditions.extend(
+                (
+                    "accepted_at=0",
+                    "parked_at=0",
+                    "abandoned_at=0",
+                    "drain_parked_at>0",
+                )
             )
         if conditions:
             sql += " WHERE " + " AND ".join(conditions)
@@ -5518,6 +5554,7 @@ except Exception as exc:
                 current.accepted_at > 0
                 or current.parked_at > 0
                 or current.abandoned_at > 0
+                or current.drain_parked_at > 0
             ):
                 return current, False
             first_failure = current.failed_at == 0
@@ -5526,7 +5563,7 @@ except Exception as exc:
                    SET failed_at=CASE WHEN failed_at=0 THEN ? ELSE failed_at END,
                        last_error=?
                    WHERE id=? AND accepted_at=0 AND parked_at=0
-                     AND abandoned_at=0""",
+                     AND abandoned_at=0 AND drain_parked_at=0""",
                 (timestamp, reason, current.id),
             )
             row = self._select_schedule_wake_by_fire(schedule_id, fired_at)
@@ -5542,7 +5579,7 @@ except Exception as exc:
                 """UPDATE pending_schedule_wakes
                    SET attempts=attempts + 1
                    WHERE id=? AND accepted_at=0 AND parked_at=0
-                     AND abandoned_at=0""",
+                     AND abandoned_at=0 AND drain_parked_at=0""",
                 (pending_id,),
             )
             if cursor.rowcount == 0:
@@ -5576,6 +5613,65 @@ except Exception as exc:
             )
             self._db.commit()
         return cursor.rowcount > 0
+
+    def drain_park_pending_schedule_wake(
+        self,
+        pending_id: int,
+        *,
+        drain_parked_at: float = 0.0,
+        reason: str = "drain-extension budget expired",
+    ) -> bool:
+        """Move one active wake into recoverable drain parking once (#635).
+
+        Unlike quarantine or abandonment this is NOT terminal: the row keeps
+        its prompt and exact-fire identity, drops out of drain retry pressure,
+        and returns to the active outbox via
+        ``release_drain_parked_schedule_wakes`` (or a late positive receipt).
+        The outbox reaper's fired-at ceiling remains the ultimate terminal
+        bound for a row that never becomes deliverable again.
+        """
+        timestamp = drain_parked_at or time.time()
+        with self._rmw_lock:
+            cursor = self._db.execute(
+                """UPDATE pending_schedule_wakes
+                   SET drain_parked_at=?,
+                       failed_at=CASE WHEN failed_at=0 THEN ? ELSE failed_at END,
+                       last_error=?
+                   WHERE id=? AND drain_parked_at=0 AND parked_at=0
+                     AND accepted_at=0 AND abandoned_at=0""",
+                (timestamp, timestamp, reason, pending_id),
+            )
+            self._db.commit()
+        return cursor.rowcount > 0
+
+    def release_drain_parked_schedule_wakes(self, agent_name: str) -> int:
+        """Return an agent's drain-parked wakes to the active outbox.
+
+        Callers hold delivery evidence (a verified-idle transport probe or a
+        confirmed delivery to this agent). Released rows re-enter the normal
+        replay policy, so the #1102 staleness and zombie rules still bound
+        what actually replays. Terminal rows are never resurrected.
+        """
+        with self._rmw_lock:
+            cursor = self._db.execute(
+                """UPDATE pending_schedule_wakes
+                   SET drain_parked_at=0
+                   WHERE agent_name=? AND drain_parked_at>0
+                     AND accepted_at=0 AND parked_at=0 AND abandoned_at=0""",
+                (agent_name,),
+            )
+            self._db.commit()
+        return cursor.rowcount
+
+    def list_drain_parked_agent_names(self) -> list[str]:
+        """Name every agent holding recoverable drain-parked wake debt."""
+        rows = self._db.execute(
+            """SELECT DISTINCT agent_name FROM pending_schedule_wakes
+               WHERE drain_parked_at>0 AND accepted_at=0 AND parked_at=0
+                 AND abandoned_at=0
+               ORDER BY agent_name"""
+        ).fetchall()
+        return [str(row[0]) for row in rows]
 
     def abandon_pending_schedule_wake(
         self,
@@ -5655,6 +5751,7 @@ except Exception as exc:
                            WHEN accepted_at=0 THEN ? ELSE accepted_at END,
                        parked_at=0,
                        abandoned_at=0,
+                       drain_parked_at=0,
                        last_error=''
                    WHERE id=?""",
                 (timestamp, pending_id),
@@ -5691,6 +5788,7 @@ except Exception as exc:
                            WHEN accepted_at=0 THEN ? ELSE accepted_at END,
                        parked_at=0,
                        abandoned_at=0,
+                       drain_parked_at=0,
                        last_error=''
                    WHERE schedule_id=? AND fired_at=?""",
                 (timestamp, schedule_id, fired_at),
@@ -5783,6 +5881,12 @@ except Exception as exc:
         so every newly backfilled abandonment survives its full forensic window.
         Large populations are committed in bounded chunks while the registry's
         mutation lock prevents in-process replay races.
+
+        Drain-parked rows (#635) deliberately share the active fired-at
+        ceiling: a recoverable park whose agent never becomes deliverable
+        again crosses into explicit abandonment here — the ultimate terminal
+        bound that keeps parked debt from becoming immortal. Their prompt
+        payloads are never trimmed while the row is still recoverable.
         """
         observed_at = float(now)
         windows = {
@@ -5846,6 +5950,7 @@ except Exception as exc:
                 """SELECT agent_name, COUNT(*)
                    FROM pending_schedule_wakes
                    WHERE accepted_at=0 AND parked_at=0 AND abandoned_at=0
+                     AND drain_parked_at=0
                    GROUP BY agent_name"""
             ).fetchall()
             for agent_name, count in active_rows:

--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -5599,12 +5599,17 @@ except Exception as exc:
         parked_at: float = 0.0,
         reason: str = "delivery attempts exhausted",
     ) -> bool:
-        """Atomically move an active wake to terminal quarantine once."""
+        """Atomically move an active wake to terminal quarantine once.
+
+        Terminal transitions clear ``drain_parked_at``: no row may carry the
+        recoverable marker and a terminal marker simultaneously.
+        """
         timestamp = parked_at or time.time()
         with self._rmw_lock:
             cursor = self._db.execute(
                 """UPDATE pending_schedule_wakes
                    SET parked_at=?,
+                       drain_parked_at=0,
                        failed_at=CASE WHEN failed_at=0 THEN ? ELSE failed_at END,
                        last_error=?
                    WHERE id=? AND parked_at=0 AND accepted_at=0
@@ -5691,6 +5696,7 @@ except Exception as exc:
             cursor = self._db.execute(
                 """UPDATE pending_schedule_wakes
                    SET abandoned_at=?,
+                       drain_parked_at=0,
                        failed_at=CASE WHEN failed_at=0 THEN ? ELSE failed_at END,
                        last_error=?
                    WHERE id=? AND parked_at=0 AND accepted_at=0
@@ -5717,6 +5723,7 @@ except Exception as exc:
             cursor = self._db.execute(
                 """UPDATE pending_schedule_wakes
                    SET parked_at=?,
+                       drain_parked_at=0,
                        failed_at=CASE WHEN failed_at=0 THEN ? ELSE failed_at END,
                        last_error=?
                    WHERE id=? AND parked_at=0 AND accepted_at=0
@@ -5829,7 +5836,7 @@ except Exception as exc:
         (tracked separately; accepted rows already accumulate the same way).
         """
         sql = """UPDATE pending_schedule_wakes
-                 SET parked_at=?, last_error=?
+                 SET parked_at=?, drain_parked_at=0, last_error=?
                  WHERE id=? AND accepted_at=0 AND parked_at=0
                    AND abandoned_at=0"""
         params: list = [time.time(), "retired via discard", pending_id]
@@ -5849,13 +5856,15 @@ except Exception as exc:
         rows unboundedly without a reaper. Deliberate/manual retirement uses
         ``discard_pending_schedule_wake`` (which tombstones) so a retired fire
         cannot be re-created by a later reconciliation. Accepted, parked, or
-        abandoned rows are terminal and are left as-is.
+        abandoned rows are terminal and are left as-is; drain-parked rows are
+        recoverable debt and equally must not be erased by a stale replay
+        object or a second writer.
         """
         with self._rmw_lock:
             cursor = self._db.execute(
                 """DELETE FROM pending_schedule_wakes
                    WHERE id=? AND accepted_at=0 AND parked_at=0
-                     AND abandoned_at=0""",
+                     AND abandoned_at=0 AND drain_parked_at=0""",
                 (pending_id,),
             )
             self._db.commit()
@@ -6025,7 +6034,7 @@ except Exception as exc:
                 failed_phase = "abandon"
                 _apply_batched(
                     """UPDATE pending_schedule_wakes
-                       SET abandoned_at=?, parked_at=0
+                       SET abandoned_at=?, parked_at=0, drain_parked_at=0
                        WHERE id IN (
                            SELECT id FROM pending_schedule_wakes
                            WHERE accepted_at=0 AND abandoned_at=0

--- a/src/pinky_daemon/scheduler.py
+++ b/src/pinky_daemon/scheduler.py
@@ -114,6 +114,11 @@ class _OutboxDrainExtensionState:
     # #635 A1: deferrals whose busy verdict came from an indeterminate probe
     # (timeout/exception after one retry), not a positive transport signal.
     unverified_checks: int = 0
+    # #635 review round 4: set when the post-park durable re-list failed, so
+    # this episode's identity could not be re-keyed. The next health sample
+    # ADOPTS its new oldest fire into this state (keeping alert dedup and
+    # attempt history) instead of starting a fresh un-alerted episode.
+    rekey_pending: bool = False
 
 
 def _retrieve_probe_outcome(future: "asyncio.Future") -> None:
@@ -2039,7 +2044,16 @@ class AgentScheduler:
         """Bound consecutive drain deferrals by count and oldest-fire age."""
         oldest_fired_at = float(summary["oldest_fired_at"])
         state = self._outbox_drain_extensions.get(agent_name)
-        if state is None or state.oldest_fired_at != oldest_fired_at:
+        if state is not None and state.oldest_fired_at != oldest_fired_at:
+            if state.rekey_pending:
+                # The prior cycle parked rows but could not re-list the
+                # remaining cohort; this sample supplies the re-key. Same
+                # episode: alert dedup and attempt history survive.
+                state.oldest_fired_at = oldest_fired_at
+                state.rekey_pending = False
+            else:
+                state = None
+        if state is None:
             state = _OutboxDrainExtensionState(oldest_fired_at)
             self._outbox_drain_extensions[agent_name] = state
         state.attempts += 1
@@ -2152,10 +2166,14 @@ class AgentScheduler:
             remaining = self._registry.list_pending_schedule_wakes(agent_name)
         except Exception as exc:
             remaining = None
+            # Episode identity must survive this transient read failure:
+            # the next health sample's changed oldest fire will be ADOPTED
+            # into this state instead of starting a fresh un-alerted one.
+            state.rekey_pending = True
             _log(
                 "scheduler: OUTBOX_DRAIN_PARK_FAILURE re-listing active "
                 f"rows for '{agent_name}': {type(exc).__name__}: {exc}; "
-                "keeping the budget state as-is"
+                "deferring the episode re-key to the next health sample"
             )
         if remaining is not None:
             if not remaining:
@@ -2166,6 +2184,7 @@ class AgentScheduler:
                 # One partial-park episode: keep alert dedup and attempt
                 # history, keyed to the oldest row that is REALLY active.
                 state.oldest_fired_at = remaining[0].fired_at
+                state.rekey_pending = False
         return True
 
     def _drain_park_outbox_rows(
@@ -2175,7 +2194,7 @@ class AgentScheduler:
         bound_reason: str,
         state: _OutboxDrainExtensionState,
         oldest_age: float,
-    ) -> tuple[int, int, float | None] | None:
+    ) -> tuple[int, int] | None:
         """Park every active row behind an expired drain budget (#635 B1).
 
         Parking replaces the old terminal abandonment: an idle agent behind a
@@ -2354,28 +2373,22 @@ class AgentScheduler:
                 or pending.drain_parked_at != 0
             ):
                 continue
-            if (
-                not current_schedule.one_shot
-                and pending.last_error.startswith("OUTBOX_DRAIN_RELEASED")
-            ):
-                # #635 B1 review rounds 2-3: a released recurring occurrence
+            if not current_schedule.one_shot and pending.released_at > 0:
+                # #635 B1 review rounds 2-4: a released recurring occurrence
                 # older than the newest ACCEPTED exact fire of its schedule
                 # is superseded work — that newer accepted row is absent
                 # from this pass, so recurrence collapse has no peer to
-                # catch this. The comparison is fire-identity against
-                # fire-identity: receipt wall-clock time is NOT ordering
-                # evidence (an older fire accepted late must never
-                # supersede newer owed work). The OUTBOX_DRAIN_RELEASED
-                # provenance is stamped by the release transition itself,
-                # so the floor covers every released row regardless of the
-                # original park reason, while the ordinary minutes-scale
-                # deferred-fire recovery path keeps its documented replay
-                # semantics.
-                accepted_high_water = (
-                    self._registry.get_max_accepted_fired_at(
-                        pending.schedule_id
-                    )
-                )
+                # catch this. Fire identity compares against fire identity:
+                # receipt wall-clock time is NOT ordering evidence (an older
+                # fire accepted late must never supersede newer owed work).
+                # ``released_at`` is structural provenance stamped by the
+                # release transition itself, so no park-reason text can
+                # dodge the floor, and the schedule's durable
+                # ``last_accepted_fired_at`` high-water mark outlives the
+                # reapable accepted receipt rows regardless of retention
+                # configuration. The ordinary minutes-scale deferred-fire
+                # recovery path keeps its documented replay semantics.
+                accepted_high_water = current_schedule.last_accepted_fired_at
                 if (
                     accepted_high_water > 0
                     and pending.fired_at <= accepted_high_water

--- a/src/pinky_daemon/scheduler.py
+++ b/src/pinky_daemon/scheduler.py
@@ -116,6 +116,12 @@ class _OutboxDrainExtensionState:
     unverified_checks: int = 0
 
 
+def _retrieve_probe_outcome(future: "asyncio.Future") -> None:
+    """Consume a drain-probe future's outcome so no exception goes unread."""
+    if not future.cancelled():
+        future.exception()
+
+
 def _positive_env_seconds(name: str, default: float) -> float:
     """Read one finite positive duration, falling back loudly."""
     raw_value = os.environ.get(name, str(default))
@@ -1836,13 +1842,31 @@ class AgentScheduler:
         if probe is None:
             return False, True
         outstanding = self._drain_probe_futures.get(agent_name)
-        if outstanding is not None and not outstanding.done():
-            _log(
-                f"scheduler: previous drain probe for '{agent_name}' is "
-                "still outstanding; deferring without a new probe"
-            )
-            return True, False
+        if outstanding is not None:
+            if not outstanding.done():
+                _log(
+                    f"scheduler: previous drain probe for '{agent_name}' is "
+                    "still outstanding; deferring without a new probe"
+                )
+                return True, False
+            # Structured harvesting: a probe that resolved with an exception
+            # AFTER its waits expired must surface in this log, not as an
+            # unstructured "exception was never retrieved" artifact when the
+            # future is overwritten below.
+            if not outstanding.cancelled():
+                late_error = outstanding.exception()
+                if late_error is not None:
+                    _log(
+                        f"scheduler: previous drain probe for "
+                        f"'{agent_name}' resolved late with "
+                        f"{type(late_error).__name__}: {late_error}"
+                    )
         future = asyncio.ensure_future(asyncio.to_thread(probe, agent_name))
+        # Retrieval-only callback: even if no later cycle ever visits this
+        # agent again, the exception is consumed so asyncio never reports an
+        # unretrieved shielded-future error; the log line above (or the
+        # in-band handler below) remains the human-visible record.
+        future.add_done_callback(_retrieve_probe_outcome)
         self._drain_probe_futures[agent_name] = future
         base_timeout = self._outbox_drain_probe_timeout_sec
         waits = (
@@ -2059,7 +2083,27 @@ class AgentScheduler:
                 "next cycle"
             )
             return True
-        targeted, parked, leftover_oldest_fired_at = park_outcome
+        targeted, parked = park_outcome
+        if parked == 0:
+            if targeted == 0:
+                # A second writer settled every row between the health
+                # sample and the listing: nothing recoverable to claim,
+                # nothing to page about. The budget is settled.
+                self._outbox_drain_extensions.pop(agent_name, None)
+                _log(
+                    "scheduler: OUTBOX_DRAIN_EXTENSION_EXPIRED settled for "
+                    f"'{agent_name}': no active rows remained to park"
+                )
+                return True
+            # Every park write failed: the owner page must never claim a
+            # recoverable transition that did not happen. Keep the budget
+            # (and its un-alerted status) so the next cycle retries.
+            _log(
+                "scheduler: OUTBOX_DRAIN_EXTENSION_EXPIRED park failed for "
+                f"'{agent_name}': 0/{targeted} rows parked; retrying next "
+                "cycle"
+            )
+            return True
         evidence_note = (
             ""
             if state.unverified_checks == 0
@@ -2100,18 +2144,28 @@ class AgentScheduler:
                     "and wake ledger before intervening."
                 ),
             )
-        if targeted == parked:
-            # Every active row is parked, so this oldest-fire budget is
-            # settled. Released rows start a fresh budget on a new oldest
-            # fire.
-            self._outbox_drain_extensions.pop(agent_name, None)
-        elif leftover_oldest_fired_at is not None:
-            # A partial park leaves NEWER rows active (parking iterates
-            # oldest-first), so the next health sample leads with a
-            # different oldest fire. Re-key the SAME budget state to it —
-            # this is one episode, and its alert-dedup and attempt history
-            # must survive the oldest-row change.
-            state.oldest_fired_at = leftover_oldest_fired_at
+        # Settle or re-key the budget from DURABLE state: a failed park
+        # write does not prove its row is still active (a second writer may
+        # have settled it), so the remaining cohort must be re-read, not
+        # inferred from UPDATE results.
+        try:
+            remaining = self._registry.list_pending_schedule_wakes(agent_name)
+        except Exception as exc:
+            remaining = None
+            _log(
+                "scheduler: OUTBOX_DRAIN_PARK_FAILURE re-listing active "
+                f"rows for '{agent_name}': {type(exc).__name__}: {exc}; "
+                "keeping the budget state as-is"
+            )
+        if remaining is not None:
+            if not remaining:
+                # Every active row is settled or parked; this budget is
+                # done. Released rows start a fresh budget later.
+                self._outbox_drain_extensions.pop(agent_name, None)
+            else:
+                # One partial-park episode: keep alert dedup and attempt
+                # history, keyed to the oldest row that is REALLY active.
+                state.oldest_fired_at = remaining[0].fired_at
         return True
 
     def _drain_park_outbox_rows(
@@ -2129,11 +2183,10 @@ class AgentScheduler:
         ever supersede a terminal state — abandonment there was silent loss.
         Parked rows stay recoverable and re-enter replay on delivery evidence.
 
-        Returns ``(targeted, parked, leftover_oldest_fired_at)`` where the
-        third element is the oldest fire that FAILED to park (``None`` when
-        everything parked), or ``None`` entirely when the active rows could
-        not even be listed — a listing failure must never read as an empty
-        outbox.
+        Returns ``(targeted, parked)``, or ``None`` when the active rows
+        could not even be listed — a listing failure must never read as an
+        empty outbox. The caller re-reads the durable cohort afterwards; a
+        failed park write here is NOT evidence its row is still active.
         """
         try:
             pending_wakes = self._registry.list_pending_schedule_wakes(
@@ -2155,25 +2208,20 @@ class AgentScheduler:
             f"max_age={self._outbox_drain_extension_max_age_sec:.1f}s)"
         )
         parked = 0
-        leftover_oldest_fired_at: float | None = None
         for pending in pending_wakes:
-            parked_this = False
             try:
-                parked_this = self._registry.drain_park_pending_schedule_wake(
+                if self._registry.drain_park_pending_schedule_wake(
                     pending.id,
                     reason=reason,
-                )
+                ):
+                    parked += 1
             except Exception as exc:
                 _log(
                     "scheduler: OUTBOX_DRAIN_PARK_FAILURE pending "
                     f"#{pending.id} for '{agent_name}': "
                     f"{type(exc).__name__}: {exc}"
                 )
-            if parked_this:
-                parked += 1
-            elif leftover_oldest_fired_at is None:
-                leftover_oldest_fired_at = pending.fired_at
-        return len(pending_wakes), parked, leftover_oldest_fired_at
+        return len(pending_wakes), parked
 
     async def _replay_pending_locked(
         self, agent_name: str, *, drain_recheck: bool = False
@@ -2308,35 +2356,49 @@ class AgentScheduler:
                 continue
             if (
                 not current_schedule.one_shot
-                and current_schedule.last_delivered > 0
-                and pending.fired_at <= current_schedule.last_delivered
-                and pending.last_error.startswith("OUTBOX_DRAIN_PARKED")
+                and pending.last_error.startswith("OUTBOX_DRAIN_RELEASED")
             ):
-                # #635 B1 review round 2: an un-parked recurring occurrence
-                # older than a delivery this schedule already confirmed is
-                # superseded work — the release trigger WAS that newer
-                # delivery, and the newer row is accepted (absent from this
-                # pass), so recurrence collapse has no peer to catch this.
-                # The persistent OUTBOX_DRAIN_PARKED trace scopes the floor
-                # to released rows; the ordinary minutes-scale deferred-fire
-                # recovery path keeps its documented replay semantics.
-                superseded = self._registry.park_pending_schedule_wake(
-                    pending.id,
-                    reason=(
-                        "terminal replay policy: recurrence superseded by "
-                        "confirmed delivery at "
-                        f"{current_schedule.last_delivered}"
-                    ),
+                # #635 B1 review rounds 2-3: a released recurring occurrence
+                # older than the newest ACCEPTED exact fire of its schedule
+                # is superseded work — that newer accepted row is absent
+                # from this pass, so recurrence collapse has no peer to
+                # catch this. The comparison is fire-identity against
+                # fire-identity: receipt wall-clock time is NOT ordering
+                # evidence (an older fire accepted late must never
+                # supersede newer owed work). The OUTBOX_DRAIN_RELEASED
+                # provenance is stamped by the release transition itself,
+                # so the floor covers every released row regardless of the
+                # original park reason, while the ordinary minutes-scale
+                # deferred-fire recovery path keeps its documented replay
+                # semantics.
+                accepted_high_water = (
+                    self._registry.get_max_accepted_fired_at(
+                        pending.schedule_id
+                    )
                 )
-                _log(
-                    f"scheduler: RECURRENCE_SUPERSEDED_BY_DELIVERY pending "
-                    f"#{pending.id}, schedule '{pending.schedule_name}' "
-                    f"(#{pending.schedule_id}) for agent "
-                    f"'{pending.agent_name}': fired_at={pending.fired_at} "
-                    f"last_delivered={current_schedule.last_delivered} "
-                    f"quarantined={superseded}"
-                )
-                continue
+                if (
+                    accepted_high_water > 0
+                    and pending.fired_at <= accepted_high_water
+                ):
+                    superseded = self._registry.park_pending_schedule_wake(
+                        pending.id,
+                        reason=(
+                            "terminal replay policy: recurrence superseded "
+                            "by accepted fire at "
+                            f"{accepted_high_water}"
+                        ),
+                    )
+                    _log(
+                        f"scheduler: RECURRENCE_SUPERSEDED_BY_DELIVERY "
+                        f"pending #{pending.id}, schedule "
+                        f"'{pending.schedule_name}' "
+                        f"(#{pending.schedule_id}) for agent "
+                        f"'{pending.agent_name}': "
+                        f"fired_at={pending.fired_at} "
+                        f"accepted_high_water={accepted_high_water} "
+                        f"quarantined={superseded}"
+                    )
+                    continue
             if pending.schedule_id in abandoned_schedule_ids:
                 _log(
                     f"scheduler: persisted wake #{pending.id}, schedule "

--- a/src/pinky_daemon/scheduler.py
+++ b/src/pinky_daemon/scheduler.py
@@ -77,6 +77,9 @@ _OUTBOX_DRAIN_EXTENSION_MAX_AGE_ENV = (
 _OUTBOX_DRAIN_EXTENSION_MAX_AGE_SEC = 30 * 60
 _OUTBOX_DRAIN_PROBE_TIMEOUT_ENV = "PINKY_OUTBOX_DRAIN_PROBE_TIMEOUT_SEC"
 _OUTBOX_DRAIN_PROBE_TIMEOUT_SEC = 5.0
+# #635 A1: one retry with a widened window before a probe verdict is treated
+# as indeterminate. A timeout is evidence about the probe, not the pane.
+_OUTBOX_DRAIN_PROBE_RETRY_MULTIPLIER = 3.0
 _OUTBOX_REAPER_RETAIN_ACCEPTED_ENV = (
     "PINKY_OUTBOX_REAPER_RETAIN_ACCEPTED_SEC"
 )
@@ -108,6 +111,9 @@ class _OutboxDrainExtensionState:
     oldest_fired_at: float
     attempts: int = 0
     alerted: bool = False
+    # #635 A1: deferrals whose busy verdict came from an indeterminate probe
+    # (timeout/exception after one retry), not a positive transport signal.
+    unverified_checks: int = 0
 
 
 def _positive_env_seconds(name: str, default: float) -> float:
@@ -1803,31 +1809,62 @@ class AgentScheduler:
             )
             return False
 
-    async def _agent_busy_for_drain(self, agent_name: str) -> bool:
-        """Re-read pane state without letting a hung probe hold the lane lock."""
+    async def _agent_busy_for_drain(self, agent_name: str) -> tuple[bool, bool]:
+        """Re-read pane state without letting a hung probe hold the lane lock.
+
+        Returns ``(busy, verified)``. A probe timeout or failure is retried
+        once with a widened window; a still-indeterminate probe defers safely
+        but reports ``verified=False`` — a timeout is not busy evidence, and
+        recording it as such let a 30-minute deferral budget terminalize real
+        wakes against an idle agent (#635 A1). A timed-out probe thread keeps
+        running detached; the retry is bounded to one to cap that leak.
+        """
         probe = self._delivery_drain_busy_fn or self._delivery_busy_fn
         if probe is None:
-            return False
-        try:
-            result = await asyncio.wait_for(
-                asyncio.to_thread(probe, agent_name),
-                timeout=self._outbox_drain_probe_timeout_sec,
-            )
-            return result is True
-        except asyncio.TimeoutError:
-            _log(
-                f"scheduler: drain-time transport recheck timed out for "
-                f"'{agent_name}' after "
-                f"{self._outbox_drain_probe_timeout_sec:.1f}s; "
-                "counting as busy and releasing the replay lock"
-            )
-            return True
-        except Exception as exc:
-            _log(
-                f"scheduler: drain-time transport recheck failed for "
-                f"'{agent_name}': {type(exc).__name__}: {exc}; deferring safely"
-            )
-            return True
+            return False, True
+        base_timeout = self._outbox_drain_probe_timeout_sec
+        timeouts = (
+            base_timeout,
+            base_timeout * _OUTBOX_DRAIN_PROBE_RETRY_MULTIPLIER,
+        )
+        for attempt, timeout in enumerate(timeouts, start=1):
+            final = attempt == len(timeouts)
+            try:
+                result = await asyncio.wait_for(
+                    asyncio.to_thread(probe, agent_name),
+                    timeout=timeout,
+                )
+                return result is True, True
+            except asyncio.TimeoutError:
+                if not final:
+                    _log(
+                        f"scheduler: drain-time transport recheck timed out "
+                        f"for '{agent_name}' after {timeout:.1f}s; "
+                        "retrying once with a widened window"
+                    )
+                    continue
+                _log(
+                    f"scheduler: drain-time transport recheck indeterminate "
+                    f"for '{agent_name}' (timed out twice, last "
+                    f"{timeout:.1f}s); deferring without busy evidence and "
+                    "releasing the replay lock"
+                )
+                return True, False
+            except Exception as exc:
+                if not final:
+                    _log(
+                        f"scheduler: drain-time transport recheck failed for "
+                        f"'{agent_name}': {type(exc).__name__}: {exc}; "
+                        "retrying once with a widened window"
+                    )
+                    continue
+                _log(
+                    f"scheduler: drain-time transport recheck indeterminate "
+                    f"for '{agent_name}': {type(exc).__name__}: {exc}; "
+                    "deferring without busy evidence"
+                )
+                return True, False
+        return True, False
 
     def _queue_owner_alert(self, agent_name: str, message: str) -> None:
         """Start one owner alert with a strong task reference and loud failure."""
@@ -1950,7 +1987,12 @@ class AgentScheduler:
         return True
 
     def _record_outbox_drain_extension(
-        self, agent_name: str, *, summary: dict, now: float
+        self,
+        agent_name: str,
+        *,
+        summary: dict,
+        now: float,
+        busy_verified: bool = True,
     ) -> bool:
         """Bound consecutive drain deferrals by count and oldest-fire age."""
         oldest_fired_at = float(summary["oldest_fired_at"])
@@ -1959,6 +2001,8 @@ class AgentScheduler:
             state = _OutboxDrainExtensionState(oldest_fired_at)
             self._outbox_drain_extensions[agent_name] = state
         state.attempts += 1
+        if not busy_verified:
+            state.unverified_checks += 1
         oldest_age = max(0.0, now - oldest_fired_at)
         wall_clock_expired = (
             oldest_age >= self._outbox_drain_extension_max_age_sec
@@ -1972,6 +2016,7 @@ class AgentScheduler:
                 f"'{agent_name}': fresh transport recheck remains busy "
                 f"(attempt {state.attempts}/"
                 f"{self._outbox_drain_extension_attempt_cap}, "
+                f"unverified={state.unverified_checks}, "
                 f"oldest_age_s={oldest_age:.1f}/"
                 f"{self._outbox_drain_extension_max_age_sec:.1f})"
             )
@@ -1980,87 +2025,108 @@ class AgentScheduler:
         bound_reason = (
             "wall-clock cap" if wall_clock_expired else "attempt cap"
         )
-        targeted, abandoned = self._abandon_outbox_drain_rows(
+        targeted, parked = self._drain_park_outbox_rows(
             agent_name,
-            now=now,
             bound_reason=bound_reason,
             state=state,
             oldest_age=oldest_age,
+        )
+        evidence_note = (
+            ""
+            if state.unverified_checks == 0
+            else (
+                f" ({state.unverified_checks}/{state.attempts} busy checks "
+                "were unverified probe timeouts)"
+            )
         )
         if state.alerted:
             _log(
                 "scheduler: OUTBOX_DRAIN_EXTENSION_EXPIRED owner already "
                 f"alerted for '{agent_name}' oldest_fired_at={oldest_fired_at} "
                 f"bound={bound_reason!r}; transport recheck remains busy, "
-                f"terminalized={abandoned}/{targeted}"
+                f"parked={parked}/{targeted}"
             )
-            return True
-        state.alerted = True
-        _log(
-            f"scheduler: OUTBOX_DRAIN_EXTENSION_EXPIRED agent='{agent_name}' "
-            f"oldest_fired_at={oldest_fired_at} oldest_age_s={oldest_age:.1f} "
-            f"attempts={state.attempts} bound={bound_reason!r} "
-            f"terminalized={abandoned}/{targeted}; owner alert queued"
-        )
-        self._queue_owner_alert(
-            agent_name,
-            (
-                "🚨 OUTBOX DRAIN EXTENSION EXPIRED: agent "
-                f"'{agent_name}' still reports busy at the fresh drain-time "
-                f"transport check after hitting its {bound_reason} "
-                f"({state.attempts} checks, oldest wake age "
-                f"{oldest_age:.1f}s). {abandoned}/{targeted} active wake row(s) "
-                "were moved to explicit OUTBOX_DRAIN_ABANDONED terminal state; "
-                "a late positive receipt can still supersede abandonment. "
-                "Inspect the transport and wake ledger before intervening."
-            ),
-        )
+        else:
+            state.alerted = True
+            _log(
+                f"scheduler: OUTBOX_DRAIN_EXTENSION_EXPIRED agent="
+                f"'{agent_name}' oldest_fired_at={oldest_fired_at} "
+                f"oldest_age_s={oldest_age:.1f} attempts={state.attempts} "
+                f"unverified={state.unverified_checks} bound={bound_reason!r} "
+                f"parked={parked}/{targeted}; owner alert queued"
+            )
+            self._queue_owner_alert(
+                agent_name,
+                (
+                    "🚨 OUTBOX DRAIN EXTENSION EXPIRED: agent "
+                    f"'{agent_name}' still reports busy at the fresh "
+                    f"drain-time transport check after hitting its "
+                    f"{bound_reason} ({state.attempts} checks, oldest wake "
+                    f"age {oldest_age:.1f}s){evidence_note}. "
+                    f"{parked}/{targeted} active wake row(s) were parked as "
+                    "recoverable OUTBOX_DRAIN_PARKED ledger state — they "
+                    "auto-replay at the next verified-idle transport check "
+                    "or confirmed delivery (stale wakes are then dropped by "
+                    "the normal replay-age policy). Inspect the transport "
+                    "and wake ledger before intervening."
+                ),
+            )
+        if targeted == parked:
+            # Every active row is parked, so this oldest-fire budget is
+            # settled. Released rows start a fresh budget on a new oldest
+            # fire; a partial park keeps state for alert dedup and bounding.
+            self._outbox_drain_extensions.pop(agent_name, None)
         return True
 
-    def _abandon_outbox_drain_rows(
+    def _drain_park_outbox_rows(
         self,
         agent_name: str,
         *,
-        now: float,
         bound_reason: str,
         state: _OutboxDrainExtensionState,
         oldest_age: float,
     ) -> tuple[int, int]:
-        """Move every active row behind an expired drain to honest terminal state."""
+        """Park every active row behind an expired drain budget (#635 B1).
+
+        Parking replaces the old terminal abandonment: an idle agent behind a
+        phantom busy signal never receives a delivery, so no late receipt can
+        ever supersede a terminal state — abandonment there was silent loss.
+        Parked rows stay recoverable and re-enter replay on delivery evidence.
+        """
         try:
             pending_wakes = self._registry.list_pending_schedule_wakes(
                 agent_name
             )
         except Exception as exc:
             _log(
-                "scheduler: OUTBOX_DRAIN_ABANDON_FAILURE listing active rows "
+                "scheduler: OUTBOX_DRAIN_PARK_FAILURE listing active rows "
                 f"for '{agent_name}': {type(exc).__name__}: {exc}"
             )
             return 0, 0
 
         reason = (
-            "OUTBOX_DRAIN_ABANDONED: drain-extension budget expired "
+            "OUTBOX_DRAIN_PARKED: drain-extension budget expired "
             f"by {bound_reason} (oldest_fired_at={state.oldest_fired_at}, "
             f"oldest_age={oldest_age:.1f}s, checks={state.attempts}, "
+            f"unverified_checks={state.unverified_checks}, "
             f"attempt_cap={self._outbox_drain_extension_attempt_cap}, "
             f"max_age={self._outbox_drain_extension_max_age_sec:.1f}s)"
         )
-        abandoned = 0
+        parked = 0
         for pending in pending_wakes:
             try:
-                if self._registry.abandon_pending_schedule_wake(
+                if self._registry.drain_park_pending_schedule_wake(
                     pending.id,
-                    abandoned_at=now,
                     reason=reason,
                 ):
-                    abandoned += 1
+                    parked += 1
             except Exception as exc:
                 _log(
-                    "scheduler: OUTBOX_DRAIN_ABANDON_FAILURE pending "
+                    "scheduler: OUTBOX_DRAIN_PARK_FAILURE pending "
                     f"#{pending.id} for '{agent_name}': "
                     f"{type(exc).__name__}: {exc}"
                 )
-        return len(pending_wakes), abandoned
+        return len(pending_wakes), parked
 
     async def _replay_pending_locked(
         self, agent_name: str, *, drain_recheck: bool = False
@@ -2070,31 +2136,46 @@ class AgentScheduler:
         health = self._registry.get_pending_schedule_wake_health(
             agent_name, now=replay_now
         )
-        if health and health[0]["count"] > 0:
-            summary = health[0]
+        summary = health[0] if health else None
+        active_count = int(summary["count"]) if summary else 0
+        drain_parked_count = (
+            int(summary.get("drain_parked_count", 0)) if summary else 0
+        )
+        if active_count > 0 or drain_parked_count > 0:
             _log(
                 f"scheduler: PERSISTED_WAKE_OUTBOX_HEALTH agent="
-                f"'{agent_name}' count={summary['count']} "
+                f"'{agent_name}' count={active_count} "
                 f"abandoned_count={summary['abandoned_count']} "
+                f"drain_parked_count={drain_parked_count} "
                 f"oldest_age_s={summary['oldest_age_seconds']:.1f} "
                 f"oldest_fired_at={summary['oldest_fired_at']}"
             )
-            busy = (
-                await self._agent_busy_for_drain(agent_name)
-                if drain_recheck
-                else self._agent_busy_not_wedged(agent_name)
-            )
+            if drain_recheck:
+                busy, busy_verified = await self._agent_busy_for_drain(
+                    agent_name
+                )
+            else:
+                busy = self._agent_busy_not_wedged(agent_name)
+                busy_verified = True
             if busy:
                 drain_expired = False
-                if drain_recheck:
+                if drain_recheck and active_count > 0:
                     drain_expired = self._record_outbox_drain_extension(
-                        agent_name, summary=summary, now=replay_now
+                        agent_name,
+                        summary=summary,
+                        now=replay_now,
+                        busy_verified=busy_verified,
                     )
                 if drain_expired:
                     _log(
                         "scheduler: persisted wake replay stopped for "
-                        f"'{agent_name}': drain-extension budget terminalized "
+                        f"'{agent_name}': drain-extension budget parked "
                         "the active rows"
+                    )
+                elif drain_parked_count > 0 and active_count == 0:
+                    _log(
+                        f"scheduler: drain-parked wakes held for "
+                        f"'{agent_name}': transport recheck remains busy"
                     )
                 else:
                     _log(
@@ -2104,6 +2185,22 @@ class AgentScheduler:
                 return
             if drain_recheck:
                 self._outbox_drain_extensions.pop(agent_name, None)
+                if drain_parked_count > 0:
+                    # #635 B1: a fresh verified-idle probe is the un-park
+                    # evidence. Released rows join this pass's listing, so
+                    # the zombie/staleness/collapse policy below still
+                    # bounds what actually replays (#1102).
+                    released = (
+                        self._registry.release_drain_parked_schedule_wakes(
+                            agent_name
+                        )
+                    )
+                    if released:
+                        _log(
+                            f"scheduler: OUTBOX_DRAIN_UNPARKED agent="
+                            f"'{agent_name}' released={released} on "
+                            "verified-idle transport recheck"
+                        )
         all_pending_wakes = self._registry.list_pending_schedule_wakes(
             agent_name, include_parked=True
         )
@@ -2156,7 +2253,11 @@ class AgentScheduler:
                         "park returned no state change"
                     )
                 continue
-            if pending.parked_at != 0 or pending.abandoned_at != 0:
+            if (
+                pending.parked_at != 0
+                or pending.abandoned_at != 0
+                or pending.drain_parked_at != 0
+            ):
                 continue
             if pending.schedule_id in abandoned_schedule_ids:
                 _log(
@@ -2280,6 +2381,7 @@ class AgentScheduler:
                 if pending.id not in collapsed_ids
             ]
 
+        delivered_any = False
         for pending in pending_wakes:
             if pending.attempts >= self.PERSISTED_WAKE_ATTEMPT_CAP:
                 self._park_pending_wake_if_capped(pending, pending.attempts)
@@ -2342,11 +2444,33 @@ class AgentScheduler:
                         f"delivery activity for '{agent_name}': "
                         f"{type(exc).__name__}: {exc}"
                     )
+            delivered_any = True
             _log(
                 f"scheduler: persisted wake delivery confirmed for "
                 f"schedule '{pending.schedule_name}' "
                 f"(#{pending.schedule_id}) for agent '{agent_name}'"
             )
+        if delivered_any:
+            # #635 B1: a confirmed delivery is transport-idle evidence on any
+            # replay path. Release parked debt and schedule a coalesced
+            # follow-up pass so it drains through the normal replay policy.
+            try:
+                released = self._registry.release_drain_parked_schedule_wakes(
+                    agent_name
+                )
+            except Exception as exc:
+                released = 0
+                _log(
+                    "scheduler: OUTBOX_DRAIN_UNPARK_FAILURE for "
+                    f"'{agent_name}': {type(exc).__name__}: {exc}"
+                )
+            if released:
+                self._outbox_drain_extensions.pop(agent_name, None)
+                _log(
+                    f"scheduler: OUTBOX_DRAIN_UNPARKED agent='{agent_name}' "
+                    f"released={released} on confirmed delivery"
+                )
+                self.replay_pending_for_agent(agent_name)
 
     def _pending_wake_replay_max_age(self, schedule, fired_at: float) -> float:
         """Return ``min(next fire interval, configured replay ceiling)``.
@@ -2691,6 +2815,9 @@ class AgentScheduler:
                 pending.agent_name
                 for pending in self._registry.list_pending_schedule_wakes()
             }
+            # #635 B1: agents whose only debt is drain-parked still need a
+            # periodic verified-idle visit — it is their un-park trigger.
+            agent_names.update(self._registry.list_drain_parked_agent_names())
         except Exception as exc:
             _log(
                 "scheduler: periodic outbox drain scan failed: "

--- a/src/pinky_daemon/scheduler.py
+++ b/src/pinky_daemon/scheduler.py
@@ -114,11 +114,14 @@ class _OutboxDrainExtensionState:
     # #635 A1: deferrals whose busy verdict came from an indeterminate probe
     # (timeout/exception after one retry), not a positive transport signal.
     unverified_checks: int = 0
-    # #635 review round 4: set when the post-park durable re-list failed, so
-    # this episode's identity could not be re-keyed. The next health sample
-    # ADOPTS its new oldest fire into this state (keeping alert dedup and
-    # attempt history) instead of starting a fresh un-alerted episode.
+    # #635 review rounds 4-5: set when the post-park durable re-list failed,
+    # so this episode's identity could not be re-keyed. The next health
+    # sample ADOPTS its new oldest fire into this state (keeping alert dedup
+    # and attempt history) — but only for fires at or below
+    # ``rekey_boundary`` (the newest fire the parking pass targeted). A
+    # later fire is a FRESH episode that must earn its own page.
     rekey_pending: bool = False
+    rekey_boundary: float = 0.0
 
 
 def _retrieve_probe_outcome(future: "asyncio.Future") -> None:
@@ -1134,9 +1137,37 @@ class AgentScheduler:
                 )
             )
             if not receipted_pending:
+                # Ledgerless confirmation (direct-send fires create no wake
+                # row): the exact fire identity still advances the durable
+                # supersession floor.
                 self._registry.update_schedule_last_delivered(
-                    schedule.id, delivered_at
+                    schedule.id,
+                    delivered_at,
+                    accepted_fired_at=schedule.last_run,
                 )
+            # #635 B1: every confirmed delivery — live, replay, or
+            # ledgerless — is release evidence for this agent's drain-parked
+            # debt. Without this, the minute-level drain probe (the exact
+            # evidence class this fix distrusts) would be the only recovery
+            # edge for parked-only agents.
+            try:
+                released = self._registry.release_drain_parked_schedule_wakes(
+                    schedule.agent_name
+                )
+            except Exception as exc:
+                released = 0
+                _log(
+                    "scheduler: OUTBOX_DRAIN_UNPARK_FAILURE for "
+                    f"'{schedule.agent_name}': {type(exc).__name__}: {exc}"
+                )
+            if released:
+                self._outbox_drain_extensions.pop(schedule.agent_name, None)
+                _log(
+                    f"scheduler: OUTBOX_DRAIN_UNPARKED agent="
+                    f"'{schedule.agent_name}' released={released} on "
+                    "confirmed live delivery"
+                )
+                self.replay_pending_for_agent(schedule.agent_name)
             if self._activity:
                 try:
                     self._activity.log(
@@ -2045,13 +2076,20 @@ class AgentScheduler:
         oldest_fired_at = float(summary["oldest_fired_at"])
         state = self._outbox_drain_extensions.get(agent_name)
         if state is not None and state.oldest_fired_at != oldest_fired_at:
-            if state.rekey_pending:
+            if (
+                state.rekey_pending
+                and oldest_fired_at <= state.rekey_boundary
+            ):
                 # The prior cycle parked rows but could not re-list the
-                # remaining cohort; this sample supplies the re-key. Same
-                # episode: alert dedup and attempt history survive.
+                # remaining cohort; this sample supplies the re-key for a
+                # fire the parking pass actually targeted. Same episode:
+                # alert dedup and attempt history survive.
                 state.oldest_fired_at = oldest_fired_at
                 state.rekey_pending = False
             else:
+                # Either an ordinary new-oldest transition or a fire NEWER
+                # than the parked cohort's boundary: a fresh episode with
+                # its own alert budget.
                 state = None
         if state is None:
             state = _OutboxDrainExtensionState(oldest_fired_at)
@@ -2168,8 +2206,11 @@ class AgentScheduler:
             remaining = None
             # Episode identity must survive this transient read failure:
             # the next health sample's changed oldest fire will be ADOPTED
-            # into this state instead of starting a fresh un-alerted one.
+            # into this state instead of starting a fresh un-alerted one —
+            # bounded by the newest fire this parking pass targeted, so a
+            # LATER fresh cohort still earns its own page.
             state.rekey_pending = True
+            state.rekey_boundary = float(summary["newest_fired_at"])
             _log(
                 "scheduler: OUTBOX_DRAIN_PARK_FAILURE re-listing active "
                 f"rows for '{agent_name}': {type(exc).__name__}: {exc}; "

--- a/src/pinky_daemon/scheduler.py
+++ b/src/pinky_daemon/scheduler.py
@@ -1148,31 +1148,31 @@ class AgentScheduler:
             # #635 B1: the durable confirm above already released this
             # agent's drain-parked debt at the authoritative edge (the
             # ledgerless branch releases here instead). Schedule a coalesced
-            # replay whenever released rows — or any other active debt —
-            # remain owed, so real positive transport evidence drains them
-            # promptly instead of waiting for the minute-level probe.
+            # replay ONLY when released rows remain owed: ordinary
+            # next-session backlog keeps its documented turn-idle/drain
+            # boundary, and a transiently failed FIFO row keeps its attempt
+            # cadence — neither carries release provenance.
             try:
                 released = self._registry.release_drain_parked_schedule_wakes(
                     schedule.agent_name
                 )
-                has_active = bool(
-                    self._registry.list_pending_schedule_wakes(
-                        schedule.agent_name
-                    )
+                has_released = self._registry.has_released_pending_wakes(
+                    schedule.agent_name
                 )
             except Exception as exc:
                 released = 0
-                has_active = False
+                has_released = False
                 _log(
                     "scheduler: OUTBOX_DRAIN_UNPARK_FAILURE for "
                     f"'{schedule.agent_name}': {type(exc).__name__}: {exc}"
                 )
-            if released or has_active:
+            if released or has_released:
                 self._outbox_drain_extensions.pop(schedule.agent_name, None)
                 _log(
                     f"scheduler: OUTBOX_DRAIN_UNPARKED agent="
                     f"'{schedule.agent_name}' released={released} "
-                    f"active={has_active} on confirmed live delivery"
+                    f"released_pending={has_released} on confirmed live "
+                    "delivery"
                 )
                 self.replay_pending_for_agent(schedule.agent_name)
             if self._activity:
@@ -1779,6 +1779,7 @@ class AgentScheduler:
                             schedule_id=schedule_id,
                             fired_at=fired_at,
                         )
+                        self._replay_released_debt(schedule.agent_name)
                         return
                     if not self._wake_prompt_inflight(
                         schedule, prompt=prompt
@@ -1798,6 +1799,7 @@ class AgentScheduler:
                                 schedule_id=schedule_id,
                                 fired_at=fired_at,
                             )
+                            self._replay_released_debt(schedule.agent_name)
                         return
                     await asyncio.sleep(
                         _ABANDONED_RECEIPT_OBSERVER_INTERVAL_SEC
@@ -1813,6 +1815,30 @@ class AgentScheduler:
 
         self._track_detached_receipt_task(_observe_existing_receipt())
         return True
+
+    def _replay_released_debt(self, agent_name: str) -> None:
+        """Coalesce a replay when released drain-park debt remains owed.
+
+        Called on late positive receipts: the durable confirm released the
+        debt at the authoritative edge, and this is the in-process follow-up
+        so it drains promptly instead of waiting for the minute-level probe.
+        Keys strictly on release provenance — never ordinary backlog.
+        """
+        try:
+            if not self._registry.has_released_pending_wakes(agent_name):
+                return
+        except Exception as exc:
+            _log(
+                "scheduler: released-debt check failed for "
+                f"'{agent_name}': {type(exc).__name__}: {exc}"
+            )
+            return
+        self._outbox_drain_extensions.pop(agent_name, None)
+        _log(
+            f"scheduler: OUTBOX_DRAIN_UNPARKED agent='{agent_name}' "
+            "released_pending=True on late positive receipt"
+        )
+        self.replay_pending_for_agent(agent_name)
 
     def _track_detached_receipt_task(self, observer) -> None:
         """Run one late-receipt observer outside the per-agent delivery lock."""
@@ -2655,28 +2681,28 @@ class AgentScheduler:
             # #635 B1: a confirmed delivery is transport-idle evidence on any
             # replay path. The durable confirm already released parked debt
             # at the authoritative edge; sweep any residue and schedule a
-            # coalesced follow-up pass whenever released rows — or other
-            # active debt that joined mid-pass — remain owed.
+            # coalesced follow-up pass ONLY when released rows remain owed —
+            # never for ordinary backlog or a transiently failed FIFO row.
             try:
                 released = self._registry.release_drain_parked_schedule_wakes(
                     agent_name
                 )
-                has_active = bool(
-                    self._registry.list_pending_schedule_wakes(agent_name)
+                has_released = self._registry.has_released_pending_wakes(
+                    agent_name
                 )
             except Exception as exc:
                 released = 0
-                has_active = False
+                has_released = False
                 _log(
                     "scheduler: OUTBOX_DRAIN_UNPARK_FAILURE for "
                     f"'{agent_name}': {type(exc).__name__}: {exc}"
                 )
-            if released or has_active:
+            if released or has_released:
                 self._outbox_drain_extensions.pop(agent_name, None)
                 _log(
                     f"scheduler: OUTBOX_DRAIN_UNPARKED agent='{agent_name}' "
-                    f"released={released} active={has_active} on confirmed "
-                    "delivery"
+                    f"released={released} released_pending={has_released} "
+                    "on confirmed delivery"
                 )
                 self.replay_pending_for_agent(agent_name)
 

--- a/src/pinky_daemon/scheduler.py
+++ b/src/pinky_daemon/scheduler.py
@@ -1145,27 +1145,34 @@ class AgentScheduler:
                     delivered_at,
                     accepted_fired_at=schedule.last_run,
                 )
-            # #635 B1: every confirmed delivery — live, replay, or
-            # ledgerless — is release evidence for this agent's drain-parked
-            # debt. Without this, the minute-level drain probe (the exact
-            # evidence class this fix distrusts) would be the only recovery
-            # edge for parked-only agents.
+            # #635 B1: the durable confirm above already released this
+            # agent's drain-parked debt at the authoritative edge (the
+            # ledgerless branch releases here instead). Schedule a coalesced
+            # replay whenever released rows — or any other active debt —
+            # remain owed, so real positive transport evidence drains them
+            # promptly instead of waiting for the minute-level probe.
             try:
                 released = self._registry.release_drain_parked_schedule_wakes(
                     schedule.agent_name
                 )
+                has_active = bool(
+                    self._registry.list_pending_schedule_wakes(
+                        schedule.agent_name
+                    )
+                )
             except Exception as exc:
                 released = 0
+                has_active = False
                 _log(
                     "scheduler: OUTBOX_DRAIN_UNPARK_FAILURE for "
                     f"'{schedule.agent_name}': {type(exc).__name__}: {exc}"
                 )
-            if released:
+            if released or has_active:
                 self._outbox_drain_extensions.pop(schedule.agent_name, None)
                 _log(
                     f"scheduler: OUTBOX_DRAIN_UNPARKED agent="
-                    f"'{schedule.agent_name}' released={released} on "
-                    "confirmed live delivery"
+                    f"'{schedule.agent_name}' released={released} "
+                    f"active={has_active} on confirmed live delivery"
                 )
                 self.replay_pending_for_agent(schedule.agent_name)
             if self._activity:
@@ -2646,23 +2653,30 @@ class AgentScheduler:
             )
         if delivered_any:
             # #635 B1: a confirmed delivery is transport-idle evidence on any
-            # replay path. Release parked debt and schedule a coalesced
-            # follow-up pass so it drains through the normal replay policy.
+            # replay path. The durable confirm already released parked debt
+            # at the authoritative edge; sweep any residue and schedule a
+            # coalesced follow-up pass whenever released rows — or other
+            # active debt that joined mid-pass — remain owed.
             try:
                 released = self._registry.release_drain_parked_schedule_wakes(
                     agent_name
                 )
+                has_active = bool(
+                    self._registry.list_pending_schedule_wakes(agent_name)
+                )
             except Exception as exc:
                 released = 0
+                has_active = False
                 _log(
                     "scheduler: OUTBOX_DRAIN_UNPARK_FAILURE for "
                     f"'{agent_name}': {type(exc).__name__}: {exc}"
                 )
-            if released:
+            if released or has_active:
                 self._outbox_drain_extensions.pop(agent_name, None)
                 _log(
                     f"scheduler: OUTBOX_DRAIN_UNPARKED agent='{agent_name}' "
-                    f"released={released} on confirmed delivery"
+                    f"released={released} active={has_active} on confirmed "
+                    "delivery"
                 )
                 self.replay_pending_for_agent(agent_name)
 

--- a/src/pinky_daemon/scheduler.py
+++ b/src/pinky_daemon/scheduler.py
@@ -536,6 +536,9 @@ class AgentScheduler:
         self._outbox_drain_extensions: dict[
             str, _OutboxDrainExtensionState
         ] = {}
+        # #635 single-flight fence: at most one outstanding drain-probe
+        # thread per agent (see _agent_busy_for_drain).
+        self._drain_probe_futures: dict[str, asyncio.Future] = {}
         self._receipt_extension_alerted: set[tuple[int, float]] = set()
         self._owner_alert_tasks: set[asyncio.Task] = set()
         self._last_schedule_prompt_warn_at: float | None = None
@@ -1001,16 +1004,19 @@ class AgentScheduler:
                 prompt=self._wake_prompt(schedule),
                 fired_at=schedule.last_run,
             )
-            # A terminal or already-accepted fire must not be delivered:
-            # an operator may have discarded this fire while its cohort task
-            # waited behind the per-agent delivery lock. Delivering would
-            # resurrect the tombstone (and the delivery-confirm would clear it).
-            # Set the cohort-start event first so ``_check_schedules`` does not
-            # wait out its timeout on a discarded first cohort member.
+            # A terminal, already-accepted, or drain-parked fire must not be
+            # delivered: an operator may have discarded this fire while its
+            # cohort task waited behind the per-agent delivery lock, and a
+            # drain-parked row waits for verified release evidence — a live
+            # cohort delivering it would bypass that rule and the confirm
+            # would clear the park marker. Set the cohort-start event first so
+            # ``_check_schedules`` does not wait out its timeout on a
+            # discarded first cohort member.
             if row is not None and (
                 row.parked_at > 0
                 or row.abandoned_at > 0
                 or row.accepted_at > 0
+                or row.drain_parked_at > 0
             ):
                 if attempt_started is not None:
                     attempt_started.set()
@@ -1812,55 +1818,67 @@ class AgentScheduler:
     async def _agent_busy_for_drain(self, agent_name: str) -> tuple[bool, bool]:
         """Re-read pane state without letting a hung probe hold the lane lock.
 
-        Returns ``(busy, verified)``. A probe timeout or failure is retried
-        once with a widened window; a still-indeterminate probe defers safely
-        but reports ``verified=False`` — a timeout is not busy evidence, and
-        recording it as such let a 30-minute deferral budget terminalize real
-        wakes against an idle agent (#635 A1). A timed-out probe thread keeps
-        running detached; the retry is bounded to one to cap that leak.
+        Returns ``(busy, verified)``. A timeout is not busy evidence: the
+        wait widens once on the SAME outstanding probe call, and a
+        still-indeterminate probe defers safely with ``verified=False`` —
+        recording timeouts as busy let a 30-minute deferral budget
+        terminalize real wakes against an idle agent (#635 A1).
+
+        Single-flight per agent: at most ONE probe thread may be outstanding.
+        The periodic scan revisits parked/pending agents every minute, so a
+        permanently hung probe must occupy exactly one executor worker, not
+        accumulate new detached threads per visit until the shared default
+        executor is exhausted. While the previous probe is still unresolved,
+        later cycles defer unverified without spawning; once it resolves (or
+        raises) the next cycle probes fresh.
         """
         probe = self._delivery_drain_busy_fn or self._delivery_busy_fn
         if probe is None:
             return False, True
+        outstanding = self._drain_probe_futures.get(agent_name)
+        if outstanding is not None and not outstanding.done():
+            _log(
+                f"scheduler: previous drain probe for '{agent_name}' is "
+                "still outstanding; deferring without a new probe"
+            )
+            return True, False
+        future = asyncio.ensure_future(asyncio.to_thread(probe, agent_name))
+        self._drain_probe_futures[agent_name] = future
         base_timeout = self._outbox_drain_probe_timeout_sec
-        timeouts = (
-            base_timeout,
-            base_timeout * _OUTBOX_DRAIN_PROBE_RETRY_MULTIPLIER,
+        waits = (
+            (base_timeout, False),
+            (base_timeout * _OUTBOX_DRAIN_PROBE_RETRY_MULTIPLIER, True),
         )
-        for attempt, timeout in enumerate(timeouts, start=1):
-            final = attempt == len(timeouts)
+        for timeout, final in waits:
             try:
+                # shield: the timeout must not cancel the probe future — a
+                # cancelled wrapper would read as done() and defeat the
+                # single-flight fence while its thread keeps running.
                 result = await asyncio.wait_for(
-                    asyncio.to_thread(probe, agent_name),
-                    timeout=timeout,
+                    asyncio.shield(future), timeout=timeout
                 )
+                self._drain_probe_futures.pop(agent_name, None)
                 return result is True, True
             except asyncio.TimeoutError:
                 if not final:
                     _log(
-                        f"scheduler: drain-time transport recheck timed out "
-                        f"for '{agent_name}' after {timeout:.1f}s; "
-                        "retrying once with a widened window"
+                        f"scheduler: drain-time transport recheck for "
+                        f"'{agent_name}' passed {timeout:.1f}s; continuing "
+                        "to wait on the same probe with a widened window"
                     )
                     continue
                 _log(
                     f"scheduler: drain-time transport recheck indeterminate "
-                    f"for '{agent_name}' (timed out twice, last "
-                    f"{timeout:.1f}s); deferring without busy evidence and "
-                    "releasing the replay lock"
+                    f"for '{agent_name}' (probe still unresolved after the "
+                    f"widened {timeout:.1f}s wait); deferring without busy "
+                    "evidence and releasing the replay lock"
                 )
                 return True, False
             except Exception as exc:
-                if not final:
-                    _log(
-                        f"scheduler: drain-time transport recheck failed for "
-                        f"'{agent_name}': {type(exc).__name__}: {exc}; "
-                        "retrying once with a widened window"
-                    )
-                    continue
+                self._drain_probe_futures.pop(agent_name, None)
                 _log(
-                    f"scheduler: drain-time transport recheck indeterminate "
-                    f"for '{agent_name}': {type(exc).__name__}: {exc}; "
+                    f"scheduler: drain-time transport recheck failed for "
+                    f"'{agent_name}': {type(exc).__name__}: {exc}; "
                     "deferring without busy evidence"
                 )
                 return True, False
@@ -2025,18 +2043,29 @@ class AgentScheduler:
         bound_reason = (
             "wall-clock cap" if wall_clock_expired else "attempt cap"
         )
-        targeted, parked = self._drain_park_outbox_rows(
+        park_outcome = self._drain_park_outbox_rows(
             agent_name,
             bound_reason=bound_reason,
             state=state,
             oldest_age=oldest_age,
         )
+        if park_outcome is None:
+            # A listing failure is not an empty outbox: park nothing, page
+            # nobody, and KEEP the budget state so the next cycle retries
+            # the park with its alert dedup intact.
+            _log(
+                "scheduler: OUTBOX_DRAIN_EXTENSION_EXPIRED park deferred "
+                f"for '{agent_name}': active-row listing failed; retrying "
+                "next cycle"
+            )
+            return True
+        targeted, parked, leftover_oldest_fired_at = park_outcome
         evidence_note = (
             ""
             if state.unverified_checks == 0
             else (
                 f" ({state.unverified_checks}/{state.attempts} busy checks "
-                "were unverified probe timeouts)"
+                "had indeterminate probes)"
             )
         )
         if state.alerted:
@@ -2074,8 +2103,15 @@ class AgentScheduler:
         if targeted == parked:
             # Every active row is parked, so this oldest-fire budget is
             # settled. Released rows start a fresh budget on a new oldest
-            # fire; a partial park keeps state for alert dedup and bounding.
+            # fire.
             self._outbox_drain_extensions.pop(agent_name, None)
+        elif leftover_oldest_fired_at is not None:
+            # A partial park leaves NEWER rows active (parking iterates
+            # oldest-first), so the next health sample leads with a
+            # different oldest fire. Re-key the SAME budget state to it —
+            # this is one episode, and its alert-dedup and attempt history
+            # must survive the oldest-row change.
+            state.oldest_fired_at = leftover_oldest_fired_at
         return True
 
     def _drain_park_outbox_rows(
@@ -2085,13 +2121,19 @@ class AgentScheduler:
         bound_reason: str,
         state: _OutboxDrainExtensionState,
         oldest_age: float,
-    ) -> tuple[int, int]:
+    ) -> tuple[int, int, float | None] | None:
         """Park every active row behind an expired drain budget (#635 B1).
 
         Parking replaces the old terminal abandonment: an idle agent behind a
         phantom busy signal never receives a delivery, so no late receipt can
         ever supersede a terminal state — abandonment there was silent loss.
         Parked rows stay recoverable and re-enter replay on delivery evidence.
+
+        Returns ``(targeted, parked, leftover_oldest_fired_at)`` where the
+        third element is the oldest fire that FAILED to park (``None`` when
+        everything parked), or ``None`` entirely when the active rows could
+        not even be listed — a listing failure must never read as an empty
+        outbox.
         """
         try:
             pending_wakes = self._registry.list_pending_schedule_wakes(
@@ -2102,7 +2144,7 @@ class AgentScheduler:
                 "scheduler: OUTBOX_DRAIN_PARK_FAILURE listing active rows "
                 f"for '{agent_name}': {type(exc).__name__}: {exc}"
             )
-            return 0, 0
+            return None
 
         reason = (
             "OUTBOX_DRAIN_PARKED: drain-extension budget expired "
@@ -2113,20 +2155,25 @@ class AgentScheduler:
             f"max_age={self._outbox_drain_extension_max_age_sec:.1f}s)"
         )
         parked = 0
+        leftover_oldest_fired_at: float | None = None
         for pending in pending_wakes:
+            parked_this = False
             try:
-                if self._registry.drain_park_pending_schedule_wake(
+                parked_this = self._registry.drain_park_pending_schedule_wake(
                     pending.id,
                     reason=reason,
-                ):
-                    parked += 1
+                )
             except Exception as exc:
                 _log(
                     "scheduler: OUTBOX_DRAIN_PARK_FAILURE pending "
                     f"#{pending.id} for '{agent_name}': "
                     f"{type(exc).__name__}: {exc}"
                 )
-        return len(pending_wakes), parked
+            if parked_this:
+                parked += 1
+            elif leftover_oldest_fired_at is None:
+                leftover_oldest_fired_at = pending.fired_at
+        return len(pending_wakes), parked, leftover_oldest_fired_at
 
     async def _replay_pending_locked(
         self, agent_name: str, *, drain_recheck: bool = False
@@ -2258,6 +2305,37 @@ class AgentScheduler:
                 or pending.abandoned_at != 0
                 or pending.drain_parked_at != 0
             ):
+                continue
+            if (
+                not current_schedule.one_shot
+                and current_schedule.last_delivered > 0
+                and pending.fired_at <= current_schedule.last_delivered
+                and pending.last_error.startswith("OUTBOX_DRAIN_PARKED")
+            ):
+                # #635 B1 review round 2: an un-parked recurring occurrence
+                # older than a delivery this schedule already confirmed is
+                # superseded work — the release trigger WAS that newer
+                # delivery, and the newer row is accepted (absent from this
+                # pass), so recurrence collapse has no peer to catch this.
+                # The persistent OUTBOX_DRAIN_PARKED trace scopes the floor
+                # to released rows; the ordinary minutes-scale deferred-fire
+                # recovery path keeps its documented replay semantics.
+                superseded = self._registry.park_pending_schedule_wake(
+                    pending.id,
+                    reason=(
+                        "terminal replay policy: recurrence superseded by "
+                        "confirmed delivery at "
+                        f"{current_schedule.last_delivered}"
+                    ),
+                )
+                _log(
+                    f"scheduler: RECURRENCE_SUPERSEDED_BY_DELIVERY pending "
+                    f"#{pending.id}, schedule '{pending.schedule_name}' "
+                    f"(#{pending.schedule_id}) for agent "
+                    f"'{pending.agent_name}': fired_at={pending.fired_at} "
+                    f"last_delivered={current_schedule.last_delivered} "
+                    f"quarantined={superseded}"
+                )
                 continue
             if pending.schedule_id in abandoned_schedule_ids:
                 _log(

--- a/src/pinky_daemon/scheduler.py
+++ b/src/pinky_daemon/scheduler.py
@@ -1619,6 +1619,10 @@ class AgentScheduler:
                 self._log_late_abandoned_receipt(
                     schedule, schedule_id=schedule_id, fired_at=fired_at
                 )
+                # The durable confirm above released this agent's parked
+                # debt at the authoritative edge; supply the in-process
+                # coalesced follow-up, same as every other acceptance path.
+                self._replay_released_debt(schedule.agent_name)
             except asyncio.CancelledError:
                 raise
             except Exception as exc:

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -8023,9 +8023,28 @@ class TmuxSession(TransportReplacementMixin):
             live = live_status_fn() or {}
         except Exception:
             return True
+        last_updated = live.get("last_updated")
+        spawn_at = self._current_session_started_at
+        if (
+            not self._inflight_metas
+            and spawn_at > 0
+            and isinstance(last_updated, (int, float))
+            and not isinstance(last_updated, bool)
+            and 0 < last_updated <= spawn_at
+        ):
+            # #635 A3 — boot-phantom reconciliation. ``connect()`` always
+            # reaps any surviving pane before freshly spawning the REPL, so a
+            # persisted hook row stamped BEFORE ``_current_session_started_at``
+            # can only describe a dead process. Every in-daemon busy signal is
+            # already quiet here (tool calls, in-hand turn, queue, unresolved
+            # pastes above; the empty meta deque means nothing was pasted this
+            # process life), so nothing can be in flight that this row could
+            # be describing. Without this, an unclean-restart "working" row
+            # froze every scheduler drain until an unrelated turn rewrote it,
+            # and the drain budget then terminalized real wakes (#635).
+            return False
         if live.get("status") != "idle":
             return True
-        last_updated = live.get("last_updated")
         if not (
             isinstance(last_updated, (int, float))
             and not isinstance(last_updated, bool)

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -4489,6 +4489,235 @@ class TestScheduler:
         assert "superseded" in older_row.last_error
 
     @pytest.mark.asyncio
+    async def test_release_provenance_is_structural(self, registry):
+        """R4-1: no park-reason text can dodge the supersession floor.
+
+        SQLite LIKE is ASCII-case-insensitive while Python startswith is
+        not, so string-stamped provenance was bypassable by a case-variant
+        reason. Provenance must be structural state, not text.
+        """
+        registry.register("worker")
+        schedule = registry.add_schedule(
+            "worker", "* * * * *", name="case variant", prompt="sweep now"
+        )
+        now = time.time()
+        older, _ = registry.persist_schedule_wake(
+            schedule.id,
+            agent_name="worker",
+            schedule_name=schedule.name,
+            prompt=schedule.prompt,
+            fired_at=now - 45,
+        )
+        assert registry.drain_park_pending_schedule_wake(
+            older.id, reason="outbox_drain_released: case-variant fixture"
+        )
+        registry.persist_schedule_wake(
+            schedule.id,
+            agent_name="worker",
+            schedule_name=schedule.name,
+            prompt=schedule.prompt,
+            fired_at=now - 30,
+        )
+        deliveries: list[str] = []
+
+        async def confirmed(agent_name, session_id, prompt):
+            del agent_name, session_id
+            deliveries.append(prompt)
+            return True
+
+        scheduler = AgentScheduler(registry, wake_callback=confirmed)
+        scheduler.replay_pending_for_agent("worker")
+        await scheduler._pending_replay_tasks["worker"]
+        for _ in range(200):
+            older_row = registry.get_schedule_wake_by_fire(
+                schedule.id, older.fired_at
+            )
+            if older_row is not None and older_row.ledger_state not in (
+                "pending",
+                "drain-parked",
+            ):
+                break
+            await asyncio.sleep(0)
+
+        assert deliveries == ["sweep now"]
+        older_row = registry.get_schedule_wake_by_fire(
+            schedule.id, older.fired_at
+        )
+        assert older_row is not None
+        assert older_row.ledger_state == "quarantined"
+
+    @pytest.mark.asyncio
+    async def test_supersession_survives_accepted_row_reaping(
+        self, registry
+    ):
+        """R4-2: execution-ordering authority must outlive reapable receipts.
+
+        retain_accepted and the abandon ceiling are independently
+        configurable; with a short accepted-retention the accepted row that
+        proves a newer fire ran can be reaped while older parked debt is
+        still recoverable. The high-water mark must live on the schedule,
+        not in reapable rows.
+        """
+        registry.register("worker")
+        schedule = registry.add_schedule(
+            "worker", "* * * * *", name="reaped authority", prompt="sweep now"
+        )
+        now = time.time()
+        older, _ = registry.persist_schedule_wake(
+            schedule.id,
+            agent_name="worker",
+            schedule_name=schedule.name,
+            prompt=schedule.prompt,
+            fired_at=now - 45,
+        )
+        assert registry.drain_park_pending_schedule_wake(older.id)
+        newer, _ = registry.persist_schedule_wake(
+            schedule.id,
+            agent_name="worker",
+            schedule_name=schedule.name,
+            prompt=schedule.prompt,
+            fired_at=now - 30,
+        )
+        assert registry.confirm_pending_schedule_wake(
+            newer.id, delivered_at=now - 10
+        )
+        # Valid (if aggressive) retention: the accepted receipt is reaped
+        # while the parked row stays comfortably under its fired-at ceiling.
+        registry.reap_pending_schedule_wakes(
+            now=now,
+            abandon_after=3_600,
+            retain_accepted=1,
+            retain_abandoned=86_400,
+            retain_parked=86_400,
+            payload_trim_after=86_400,
+        )
+        assert registry.get_schedule_wake_by_fire(
+            schedule.id, newer.fired_at
+        ) is None
+        deliveries: list[str] = []
+
+        async def confirmed(agent_name, session_id, prompt):
+            del agent_name, session_id
+            deliveries.append(prompt)
+            return True
+
+        scheduler = AgentScheduler(
+            registry,
+            wake_callback=confirmed,
+            delivery_drain_busy_fn=lambda agent_name: False,
+            pending_wake_max_age_sec=1_000,
+        )
+        scheduler.replay_pending_for_agent("worker", drain_recheck=True)
+        await scheduler._pending_replay_tasks["worker"]
+
+        assert deliveries == []
+        older_row = registry.get_schedule_wake_by_fire(
+            schedule.id, older.fired_at
+        )
+        assert older_row is not None
+        assert older_row.ledger_state == "quarantined"
+        assert "superseded" in older_row.last_error
+
+    @pytest.mark.asyncio
+    async def test_partial_park_page_survives_relist_failure(
+        self, registry, monkeypatch
+    ):
+        """R4-3: episode identity must survive a transient re-list failure."""
+        registry.register("worker")
+        schedule = registry.add_schedule(
+            "worker", "0 * * * *", name="relist fail", prompt="owed work"
+        )
+        base = 1_800_000_000.0
+        clock = [base]
+        monkeypatch.setattr(
+            "pinky_daemon.scheduler.time.time", lambda: clock[0]
+        )
+        row_a, _ = registry.persist_schedule_wake(
+            schedule.id,
+            agent_name="worker",
+            schedule_name=schedule.name,
+            prompt=schedule.prompt,
+            fired_at=base,
+        )
+        row_b, _ = registry.persist_schedule_wake(
+            schedule.id,
+            agent_name="worker",
+            schedule_name=schedule.name,
+            prompt=schedule.prompt,
+            fired_at=base + 5,
+        )
+        alerts: list[str] = []
+
+        async def owner_notify(agent_name, message):
+            del agent_name
+            alerts.append(message)
+            return True
+
+        scheduler = AgentScheduler(
+            registry,
+            delivery_busy_fn=lambda agent_name: True,
+            delivery_drain_busy_fn=lambda agent_name: True,
+            owner_notify_callback=owner_notify,
+            pending_wake_max_age_sec=100_000,
+            outbox_drain_extension_attempt_cap=1,
+        )
+        real_park = registry.drain_park_pending_schedule_wake
+        park_wedged = [True]
+
+        def flaky_park(pending_id, **kwargs):
+            if park_wedged[0] and pending_id == row_b.id:
+                raise RuntimeError("park write failed")
+            return real_park(pending_id, **kwargs)
+
+        real_list = registry.list_pending_schedule_wakes
+        relist_calls = [0]
+        fail_relist_once = [False]
+
+        def flaky_list(*args, **kwargs):
+            if (
+                fail_relist_once[0]
+                and args == ("worker",)
+                and not kwargs
+            ):
+                relist_calls[0] += 1
+                if relist_calls[0] == 2:
+                    # First matching call is the park listing; the second
+                    # is the post-park durable re-list. Fail only that.
+                    fail_relist_once[0] = False
+                    raise RuntimeError("re-list failed")
+            return real_list(*args, **kwargs)
+
+        monkeypatch.setattr(
+            registry, "drain_park_pending_schedule_wake", flaky_park
+        )
+        monkeypatch.setattr(
+            registry, "list_pending_schedule_wakes", flaky_list
+        )
+        fail_relist_once[0] = True
+        scheduler._check_pending_wake_liveness(base)
+        clock[0] = base + 60
+        scheduler._check_pending_wake_liveness(clock[0])
+        await scheduler._pending_replay_tasks["worker"]
+        await asyncio.gather(*list(scheduler._owner_alert_tasks))
+        assert len(alerts) == 1
+        assert registry.get_schedule_wake_by_fire(
+            schedule.id, row_a.fired_at
+        ).ledger_state == "drain-parked"
+
+        # Next cycle: the oldest active fire changed (A parked, B active),
+        # the re-list works, B parks — same episode, NO second page.
+        park_wedged[0] = False
+        clock[0] = base + 120
+        scheduler._check_pending_wake_liveness(clock[0])
+        await scheduler._pending_replay_tasks["worker"]
+        await asyncio.gather(*list(scheduler._owner_alert_tasks))
+        assert len(alerts) == 1
+        assert registry.get_schedule_wake_by_fire(
+            schedule.id, row_b.fired_at
+        ).ledger_state == "drain-parked"
+        assert "worker" not in scheduler._outbox_drain_extensions
+
+    @pytest.mark.asyncio
     async def test_partial_park_zero_success_defers_alert(
         self, registry, monkeypatch
     ):

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -4489,6 +4489,62 @@ class TestScheduler:
         assert "superseded" in older_row.last_error
 
     @pytest.mark.asyncio
+    async def test_restart_after_durable_accept_recovers_parked_debt(
+        self, registry
+    ):
+        """R6-2 crash seam: a durable accept before a crash releases parked
+        debt, so a fresh process's ordinary catch-up replay delivers it."""
+        registry.register("worker")
+        parked_schedule = registry.add_schedule(
+            "worker", "0 * * * *", name="parked lane", prompt="parked work"
+        )
+        parked_row, _ = registry.persist_schedule_wake(
+            parked_schedule.id,
+            agent_name="worker",
+            schedule_name=parked_schedule.name,
+            prompt=parked_schedule.prompt,
+            fired_at=time.time() - 30,
+        )
+        assert registry.drain_park_pending_schedule_wake(parked_row.id)
+        live_schedule = registry.add_schedule(
+            "worker", "30 * * * *", name="live lane", prompt="live work"
+        )
+        live_row, _ = registry.persist_schedule_wake(
+            live_schedule.id,
+            agent_name="worker",
+            schedule_name=live_schedule.name,
+            prompt=live_schedule.prompt,
+            fired_at=time.time() - 5,
+        )
+        # Durable accept lands; the process dies before any in-process
+        # confirmed=True handling runs (the #991 seam).
+        assert registry.confirm_pending_schedule_wake_by_fire(
+            live_schedule.id, live_row.fired_at
+        )
+        deliveries: list[str] = []
+
+        async def confirmed(agent_name, session_id, prompt):
+            del agent_name, session_id
+            deliveries.append(prompt)
+            return True
+
+        restarted = AgentScheduler(
+            registry,
+            wake_callback=confirmed,
+            pending_wake_max_age_sec=100_000,
+        )
+        # Ordinary startup catch-up: drain_recheck=False.
+        restarted.replay_pending_for_agent("worker")
+        await restarted._pending_replay_tasks["worker"]
+
+        assert deliveries == ["parked work"]
+        ledger = registry.get_schedule_wake_by_fire(
+            parked_schedule.id, parked_row.fired_at
+        )
+        assert ledger is not None
+        assert ledger.ledger_state == "receipted-ran-once"
+
+    @pytest.mark.asyncio
     async def test_live_confirmed_delivery_releases_parked_debt(
         self, registry
     ):
@@ -6573,6 +6629,80 @@ class TestDrainParkedWakeRegistry:
             )
         finally:
             reopened.close()
+
+    def test_migration_survives_pre_accepted_wake_schema(self, registry):
+        """R6-1: the backfill must not read wake columns the wake migration
+        has not added yet — released upgrade sources have the wake table
+        without accepted_at, and a boot abort there bricks the daemon."""
+        schedule, pending = self._persist(registry)
+        registry._db.executescript(
+            """
+            DROP INDEX IF EXISTS idx_schedule_wake_ledger_state;
+            DROP INDEX IF EXISTS idx_schedule_wake_reaper_state;
+            ALTER TABLE pending_schedule_wakes DROP COLUMN accepted_at;
+            ALTER TABLE agent_schedules DROP COLUMN last_accepted_fired_at;
+            """
+        )
+        registry._db.commit()
+
+        reopened = AgentRegistry(db_path=registry._db_path)
+        try:
+            migrated = reopened.get_schedule(schedule.id)
+            assert migrated is not None
+            # No accepted stamps existed pre-upgrade, so zero is correct —
+            # the requirement is that the reopen does not abort.
+            assert migrated.last_accepted_fired_at == 0.0
+        finally:
+            reopened.close()
+
+    def test_durable_confirm_releases_parked_debt_atomically(self, registry):
+        """R6-2: release evidence lives at the durable accept edge.
+
+        A crash between the durable accept and the in-process Future
+        resolution (the #991 seam) must not strand parked debt: the confirm
+        itself releases, so restart catch-up finds active rows.
+        """
+        schedule, parked = self._persist(registry)
+        assert registry.drain_park_pending_schedule_wake(parked.id)
+        other = registry.add_schedule(
+            "worker", "30 * * * *", name="live", prompt="live work"
+        )
+        live, _ = registry.persist_schedule_wake(
+            other.id,
+            agent_name="worker",
+            schedule_name=other.name,
+            prompt=other.prompt,
+            fired_at=time.time() - 5,
+        )
+        # The durable accept — no scheduler process involvement at all.
+        assert registry.confirm_pending_schedule_wake_by_fire(
+            other.id, live.fired_at
+        )
+        row = registry.get_schedule_wake_by_fire(
+            schedule.id, parked.fired_at
+        )
+        assert row is not None
+        assert row.ledger_state == "pending"
+        assert row.drain_parked_at == 0
+        assert row.released_at > 0
+
+        # The by-id confirm variant (late positive observer path) must
+        # release identically.
+        schedule2, parked2 = self._persist2(registry)
+        assert registry.drain_park_pending_schedule_wake(parked2.id)
+        live2, _ = registry.persist_schedule_wake(
+            other.id,
+            agent_name="worker",
+            schedule_name=other.name,
+            prompt=other.prompt,
+            fired_at=time.time() - 2,
+        )
+        assert registry.confirm_pending_schedule_wake(live2.id)
+        row2 = registry.get_schedule_wake_by_fire(
+            schedule2.id, parked2.fired_at
+        )
+        assert row2 is not None
+        assert row2.ledger_state == "pending"
 
     def test_reaper_abandons_expired_drain_parked_rows(self, registry):
         now = time.time()

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -513,6 +513,7 @@ class TestAgentSchedules:
                 "agent_name": "oleg",
                 "count": 1,
                 "abandoned_count": 0,
+                "drain_parked_count": 0,
                 "oldest_fired_at": 100.0,
                 "newest_fired_at": 100.0,
                 "oldest_age_seconds": 400.0,
@@ -888,6 +889,7 @@ class TestOutboxReaper:
                 "agent_name": "oleg",
                 "count": 2,
                 "abandoned_count": 2,
+                "drain_parked_count": 0,
                 "oldest_fired_at": now - 3_600,
                 "newest_fired_at": now - 3_599,
                 "oldest_age_seconds": 3_600.0,
@@ -939,6 +941,7 @@ class TestOutboxReaper:
                 "agent_name": "oleg",
                 "count": 0,
                 "abandoned_count": 5,
+                "drain_parked_count": 0,
                 "oldest_fired_at": 0.0,
                 "newest_fired_at": 0.0,
                 "oldest_age_seconds": 0.0,
@@ -3883,22 +3886,39 @@ class TestScheduler:
         )
         assert ledger is not None
         assert ledger.attempts == 0
-        assert ledger.ledger_state == "abandoned"
-        assert ledger.last_error.startswith("OUTBOX_DRAIN_ABANDONED:")
+        # #635: cap expiry parks recoverably instead of terminalizing. The
+        # wake stays out of drain retry pressure but is not silently lost.
+        assert ledger.ledger_state == "drain-parked"
+        assert ledger.abandoned_at == 0
+        assert ledger.last_error.startswith("OUTBOX_DRAIN_PARKED:")
+        assert registry.list_pending_schedule_wakes("worker") == []
+        health = registry.get_pending_schedule_wake_health("worker")
+        assert health and health[0]["drain_parked_count"] == 1
+        assert health[0]["count"] == 0
         assert len(alerts) == 1
         assert alerts[0][0] == "worker"
         assert "OUTBOX DRAIN EXTENSION EXPIRED" in alerts[0][1]
+        assert "parked" in alerts[0][1]
         assert expected_bound in alerts[0][1]
+        assert "worker" not in scheduler._outbox_drain_extensions
 
+        # A still-busy follow-up cycle probes for un-park evidence but must
+        # neither replay the parked row nor duplicate the owner alert.
         clock[0] += 60
         scheduler._check_pending_wake_liveness(clock[0])
-        await asyncio.sleep(0)
-        assert "worker" not in scheduler._pending_replay_tasks
-        assert "worker" not in scheduler._outbox_drain_extensions
+        follow_up = scheduler._pending_replay_tasks.get("worker")
+        if follow_up is not None:
+            await follow_up
+        await asyncio.gather(*list(scheduler._owner_alert_tasks))
+        assert deliveries == []
         assert len(alerts) == 1
+        ledger = registry.get_schedule_wake_by_fire(
+            schedule.id, pending.fired_at
+        )
+        assert ledger is not None and ledger.ledger_state == "drain-parked"
         logs = capsys.readouterr().err
         assert "OUTBOX_DRAIN_EXTENSION_EXPIRED" in logs
-        assert "terminalized=1/1" in logs
+        assert "parked=1/1" in logs
 
     @pytest.mark.asyncio
     async def test_drain_probe_timeout_counts_busy_and_releases_replay_lock(
@@ -3940,14 +3960,21 @@ class TestScheduler:
         )
         scheduler.replay_pending_for_agent("worker", drain_recheck=True)
         task = scheduler._pending_replay_tasks["worker"]
-        await asyncio.wait_for(asyncio.shield(task), timeout=0.1)
+        await asyncio.wait_for(asyncio.shield(task), timeout=1.0)
         release_probe.set()
 
         assert probe_started.is_set()
         assert deliveries == []
         assert len(registry.list_pending_schedule_wakes("worker")) == 1
-        assert scheduler._outbox_drain_extensions["worker"].attempts == 1
-        assert "counting as busy and releasing" in capsys.readouterr().err
+        # #635 A1: a probe timeout is not busy evidence. The probe is retried
+        # once with a longer window; a still-indeterminate verdict defers but
+        # records the extension as unverified instead of manufacturing busy.
+        state = scheduler._outbox_drain_extensions["worker"]
+        assert state.attempts == 1
+        assert state.unverified_checks == 1
+        logs = capsys.readouterr().err
+        assert "retrying once" in logs
+        assert "indeterminate" in logs
 
     @pytest.mark.asyncio
     async def test_drain_wall_cap_uses_oldest_active_not_abandoned_history(
@@ -3999,6 +4026,253 @@ class TestScheduler:
         assert scheduler._outbox_drain_extensions["worker"].oldest_fired_at == (
             active.fired_at
         )
+
+    @pytest.mark.asyncio
+    async def test_drain_probe_timeout_retry_success_delivers(self, registry):
+        """#635 A1: one slow probe sample must not defer a deliverable wake."""
+        registry.register("worker")
+        schedule = registry.add_schedule(
+            "worker", "0 * * * *", name="flaky probe", prompt="owed work"
+        )
+        registry.persist_schedule_wake(
+            schedule.id,
+            agent_name="worker",
+            schedule_name=schedule.name,
+            prompt=schedule.prompt,
+            fired_at=time.time(),
+        )
+        probe_calls: list[str] = []
+        deliveries: list[str] = []
+
+        def flaky_probe(agent_name):
+            probe_calls.append(agent_name)
+            if len(probe_calls) == 1:
+                # Exceeds the first probe window but not the retry window.
+                time.sleep(0.3)
+                return True
+            return False
+
+        async def confirmed(agent_name, session_id, prompt):
+            del agent_name, session_id
+            deliveries.append(prompt)
+            return True
+
+        scheduler = AgentScheduler(
+            registry,
+            wake_callback=confirmed,
+            delivery_drain_busy_fn=flaky_probe,
+            outbox_drain_probe_timeout_sec=0.05,
+        )
+        scheduler.replay_pending_for_agent("worker", drain_recheck=True)
+        await asyncio.wait_for(
+            asyncio.shield(scheduler._pending_replay_tasks["worker"]),
+            timeout=5.0,
+        )
+
+        assert probe_calls == ["worker", "worker"]
+        assert deliveries == ["owed work"]
+        assert registry.list_pending_schedule_wakes("worker") == []
+        assert "worker" not in scheduler._outbox_drain_extensions
+
+    @pytest.mark.asyncio
+    async def test_drain_parked_rows_release_on_verified_idle(
+        self, registry, monkeypatch
+    ):
+        """#635 B1: a parked wake auto-replays at the next verified idle."""
+        registry.register("worker")
+        schedule = registry.add_schedule(
+            "worker", "0 * * * *", name="parked recovery", prompt="owed work"
+        )
+        base = 1_800_000_000.0
+        clock = [base]
+        monkeypatch.setattr(
+            "pinky_daemon.scheduler.time.time", lambda: clock[0]
+        )
+        pending, _ = registry.persist_schedule_wake(
+            schedule.id,
+            agent_name="worker",
+            schedule_name=schedule.name,
+            prompt=schedule.prompt,
+            fired_at=base,
+        )
+        busy = [True]
+        alerts: list[str] = []
+        deliveries: list[str] = []
+
+        async def confirmed(agent_name, session_id, prompt):
+            del agent_name, session_id
+            deliveries.append(prompt)
+            return True
+
+        async def owner_notify(agent_name, message):
+            del agent_name
+            alerts.append(message)
+            return True
+
+        scheduler = AgentScheduler(
+            registry,
+            wake_callback=confirmed,
+            delivery_busy_fn=lambda agent_name: True,
+            delivery_drain_busy_fn=lambda agent_name: busy[0],
+            owner_notify_callback=owner_notify,
+            pending_wake_max_age_sec=1_000,
+            outbox_drain_extension_attempt_cap=1,
+        )
+        scheduler._check_pending_wake_liveness(base)
+        clock[0] = base + 60
+        scheduler._check_pending_wake_liveness(clock[0])
+        await scheduler._pending_replay_tasks["worker"]
+        await asyncio.gather(*list(scheduler._owner_alert_tasks))
+
+        parked = registry.get_schedule_wake_by_fire(
+            schedule.id, pending.fired_at
+        )
+        assert parked is not None
+        assert parked.ledger_state == "drain-parked"
+        assert deliveries == []
+        assert len(alerts) == 1
+
+        # The phantom clears (e.g. the #118 watchdog reconciled the pane, or
+        # a real turn completed): the next periodic cycle must still visit
+        # the agent, verify idle, un-park, and deliver the retained wake.
+        busy[0] = False
+        clock[0] = base + 120
+        scheduler._check_pending_wake_liveness(clock[0])
+        await scheduler._pending_replay_tasks["worker"]
+
+        assert deliveries == ["owed work"]
+        recovered = registry.get_schedule_wake_by_fire(
+            schedule.id, pending.fired_at
+        )
+        assert recovered is not None
+        assert recovered.ledger_state == "receipted-ran-once"
+        assert recovered.drain_parked_at == 0
+        assert len(alerts) == 1
+        assert "worker" not in scheduler._outbox_drain_extensions
+
+    @pytest.mark.asyncio
+    async def test_drain_parked_release_still_drops_stale_rows(
+        self, registry, monkeypatch, capsys
+    ):
+        """#635 B1: un-park replays through the #1102 staleness policy."""
+        registry.register("worker")
+        schedule = registry.add_schedule(
+            "worker", "* * * * *", name="stale parked", prompt="stale work"
+        )
+        base = 1_800_000_000.0
+        clock = [base]
+        monkeypatch.setattr(
+            "pinky_daemon.scheduler.time.time", lambda: clock[0]
+        )
+        pending, _ = registry.persist_schedule_wake(
+            schedule.id,
+            agent_name="worker",
+            schedule_name=schedule.name,
+            prompt=schedule.prompt,
+            fired_at=base,
+        )
+        busy = [True]
+        deliveries: list[str] = []
+
+        async def confirmed(agent_name, session_id, prompt):
+            del agent_name, session_id
+            deliveries.append(prompt)
+            return True
+
+        scheduler = AgentScheduler(
+            registry,
+            wake_callback=confirmed,
+            delivery_drain_busy_fn=lambda agent_name: busy[0],
+            pending_wake_max_age_sec=1_000,
+            outbox_drain_extension_attempt_cap=1,
+        )
+        scheduler._check_pending_wake_liveness(base)
+        clock[0] = base + 60
+        scheduler._check_pending_wake_liveness(clock[0])
+        await scheduler._pending_replay_tasks["worker"]
+        parked = registry.get_schedule_wake_by_fire(
+            schedule.id, pending.fired_at
+        )
+        assert parked is not None
+        assert parked.ledger_state == "drain-parked"
+
+        # By the time the transport verifies idle the wake has aged past its
+        # every-minute replay window: release must drop it with the existing
+        # explicit stale policy, not deliver a zombie prompt.
+        busy[0] = False
+        clock[0] = base + 400
+        scheduler._check_pending_wake_liveness(clock[0])
+        await scheduler._pending_replay_tasks["worker"]
+
+        assert deliveries == []
+        assert registry.get_schedule_wake_by_fire(
+            schedule.id, pending.fired_at
+        ) is None
+        drops = registry.list_recurring_schedule_stale_drops("worker")
+        assert len(drops) == 1
+        assert "PERSISTED_WAKE_STALE_DROPPED" in capsys.readouterr().err
+
+    @pytest.mark.asyncio
+    async def test_confirmed_delivery_releases_drain_parked_backlog(
+        self, registry
+    ):
+        """#635 B1: a successful delivery is un-park evidence on any path."""
+        registry.register("worker")
+        parked_schedule = registry.add_schedule(
+            "worker", "0 * * * *", name="parked lane", prompt="parked work"
+        )
+        active_schedule = registry.add_schedule(
+            "worker", "30 * * * *", name="active lane", prompt="fresh work"
+        )
+        now = time.time()
+        parked_row, _ = registry.persist_schedule_wake(
+            parked_schedule.id,
+            agent_name="worker",
+            schedule_name=parked_schedule.name,
+            prompt=parked_schedule.prompt,
+            fired_at=now - 30,
+        )
+        assert registry.drain_park_pending_schedule_wake(
+            parked_row.id, reason="OUTBOX_DRAIN_PARKED: test fixture"
+        )
+        registry.persist_schedule_wake(
+            active_schedule.id,
+            agent_name="worker",
+            schedule_name=active_schedule.name,
+            prompt=active_schedule.prompt,
+            fired_at=now - 10,
+        )
+        deliveries: list[str] = []
+
+        async def confirmed(agent_name, session_id, prompt):
+            del agent_name, session_id
+            deliveries.append(prompt)
+            return True
+
+        scheduler = AgentScheduler(
+            registry,
+            wake_callback=confirmed,
+            pending_wake_max_age_sec=100_000,
+        )
+        scheduler.replay_pending_for_agent("worker")
+        await scheduler._pending_replay_tasks["worker"]
+        # The success-release follow-up pass coalesces through the done
+        # callback; spin the loop until the released row fully drains.
+        for _ in range(200):
+            if (
+                len(deliveries) == 2
+                and not registry.list_pending_schedule_wakes("worker")
+            ):
+                break
+            await asyncio.sleep(0)
+
+        assert deliveries == ["fresh work", "parked work"]
+        assert registry.list_pending_schedule_wakes("worker") == []
+        ledger = registry.get_schedule_wake_by_fire(
+            parked_schedule.id, parked_row.fired_at
+        )
+        assert ledger is not None
+        assert ledger.ledger_state == "receipted-ran-once"
 
     @pytest.mark.asyncio
     async def test_idle_trigger_during_replay_guarantees_follow_up_pass(
@@ -4973,6 +5247,137 @@ class TestScheduler:
 
 
 # ── Heartbeat Watchdog Resurrection (issue #338) ──────────────────────────
+
+
+class TestDrainParkedWakeRegistry:
+    """#635 B1: the recoverable drain-parked outbox state machine."""
+
+    def _persist(self, registry, *, fired_at=None):
+        registry.register("worker")
+        schedule = registry.add_schedule(
+            "worker", "0 * * * *", name="parked", prompt="owed work"
+        )
+        pending, _ = registry.persist_schedule_wake(
+            schedule.id,
+            agent_name="worker",
+            schedule_name=schedule.name,
+            prompt=schedule.prompt,
+            fired_at=time.time() - 60 if fired_at is None else fired_at,
+        )
+        return schedule, pending
+
+    def test_drain_park_state_machine(self, registry):
+        schedule, pending = self._persist(registry)
+        assert registry.drain_park_pending_schedule_wake(
+            pending.id, reason="OUTBOX_DRAIN_PARKED: budget expired"
+        )
+        # Idempotent: a second park is a no-op, not a fresh transition.
+        assert not registry.drain_park_pending_schedule_wake(
+            pending.id, reason="OUTBOX_DRAIN_PARKED: duplicate"
+        )
+
+        assert registry.list_pending_schedule_wakes("worker") == []
+        visible = registry.list_pending_schedule_wakes(
+            "worker", include_parked=True
+        )
+        assert [row.id for row in visible] == [pending.id]
+        row = registry.get_schedule_wake_by_fire(
+            schedule.id, pending.fired_at
+        )
+        assert row is not None
+        assert row.ledger_state == "drain-parked"
+        assert row.drain_parked_at > 0
+        assert row.abandoned_at == 0 and row.parked_at == 0
+        assert row.last_error.startswith("OUTBOX_DRAIN_PARKED:")
+        assert row.to_dict()["state"] == "drain-parked"
+
+        assert [
+            r.id
+            for r in registry.list_schedule_wake_ledger(
+                "worker", state="drain-parked"
+            )
+        ] == [pending.id]
+        assert registry.list_schedule_wake_ledger(
+            "worker", state="pending"
+        ) == []
+        health = registry.get_pending_schedule_wake_health("worker")
+        assert health[0]["count"] == 0
+        assert health[0]["drain_parked_count"] == 1
+        assert registry.list_drain_parked_agent_names() == ["worker"]
+        # A parked row is excluded from delivery bookkeeping entirely.
+        assert registry.increment_pending_schedule_wake_attempts(
+            pending.id
+        ) is None
+
+        assert registry.release_drain_parked_schedule_wakes("worker") == 1
+        assert registry.release_drain_parked_schedule_wakes("worker") == 0
+        released = registry.get_schedule_wake_by_fire(
+            schedule.id, pending.fired_at
+        )
+        assert released is not None
+        assert released.ledger_state == "pending"
+        assert released.drain_parked_at == 0
+        assert [
+            row.id for row in registry.list_pending_schedule_wakes("worker")
+        ] == [pending.id]
+        assert registry.list_drain_parked_agent_names() == []
+        health = registry.get_pending_schedule_wake_health("worker")
+        assert health[0]["count"] == 1
+        assert health[0]["drain_parked_count"] == 0
+
+    def test_confirm_clears_drain_park(self, registry):
+        schedule, pending = self._persist(registry)
+        assert registry.drain_park_pending_schedule_wake(
+            pending.id, reason="OUTBOX_DRAIN_PARKED: budget expired"
+        )
+        assert registry.confirm_pending_schedule_wake_by_fire(
+            schedule.id, pending.fired_at
+        )
+        row = registry.get_schedule_wake_by_fire(
+            schedule.id, pending.fired_at
+        )
+        assert row is not None
+        assert row.ledger_state == "receipted-ran-once"
+        assert row.drain_parked_at == 0
+
+    def test_terminal_transitions_win_over_drain_park(self, registry):
+        schedule, pending = self._persist(registry)
+        assert registry.drain_park_pending_schedule_wake(
+            pending.id, reason="OUTBOX_DRAIN_PARKED: budget expired"
+        )
+        # An explicit operator discard/zombie quarantine terminalizes even a
+        # drain-parked row, and release must not resurrect it afterwards.
+        assert registry.park_pending_schedule_wake(
+            pending.id, reason="retired via discard"
+        )
+        row = registry.get_schedule_wake_by_fire(
+            schedule.id, pending.fired_at
+        )
+        assert row is not None
+        assert row.ledger_state == "quarantined"
+        assert registry.release_drain_parked_schedule_wakes("worker") == 0
+        assert registry.list_pending_schedule_wakes("worker") == []
+
+    def test_reaper_abandons_expired_drain_parked_rows(self, registry):
+        now = time.time()
+        schedule, pending = self._persist(registry, fired_at=now - 10_000)
+        assert registry.drain_park_pending_schedule_wake(
+            pending.id, reason="OUTBOX_DRAIN_PARKED: budget expired"
+        )
+        registry.reap_pending_schedule_wakes(
+            now=now,
+            abandon_after=3_600,
+            retain_accepted=86_400,
+            retain_abandoned=86_400,
+            retain_parked=86_400,
+            payload_trim_after=86_400,
+        )
+        row = registry.get_schedule_wake_by_fire(
+            schedule.id, pending.fired_at
+        )
+        assert row is not None
+        assert row.ledger_state == "abandoned"
+        assert row.prompt == "owed work"
 
 
 class TestHeartbeatResurrection:

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -4049,7 +4049,8 @@ class TestScheduler:
             probe_calls.append(agent_name)
             # Exceeds the first wait window but resolves inside the
             # widened continuation wait on the same single probe call.
-            time.sleep(0.1)
+            # Generous margins: thread-pool spin-up must not eat the window.
+            time.sleep(0.4)
             return False
 
         async def confirmed(agent_name, session_id, prompt):
@@ -4061,7 +4062,7 @@ class TestScheduler:
             registry,
             wake_callback=confirmed,
             delivery_drain_busy_fn=slow_probe,
-            outbox_drain_probe_timeout_sec=0.05,
+            outbox_drain_probe_timeout_sec=0.2,
         )
         scheduler.replay_pending_for_agent("worker", drain_recheck=True)
         await asyncio.wait_for(

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -4390,7 +4390,7 @@ class TestScheduler:
         schedule = registry.add_schedule(
             "worker", "* * * * *", name="late accept", prompt="sweep now"
         )
-        base = time.time() - 120
+        base = time.time() - 90
         fire_a, _ = registry.persist_schedule_wake(
             schedule.id,
             agent_name="worker",

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -3966,14 +3966,15 @@ class TestScheduler:
         assert probe_started.is_set()
         assert deliveries == []
         assert len(registry.list_pending_schedule_wakes("worker")) == 1
-        # #635 A1: a probe timeout is not busy evidence. The probe is retried
-        # once with a longer window; a still-indeterminate verdict defers but
-        # records the extension as unverified instead of manufacturing busy.
+        # #635 A1: a probe timeout is not busy evidence. The wait widens once
+        # on the SAME outstanding probe; a still-indeterminate verdict defers
+        # but records the extension as unverified instead of manufacturing
+        # busy — and no second probe thread is ever spawned.
         state = scheduler._outbox_drain_extensions["worker"]
         assert state.attempts == 1
         assert state.unverified_checks == 1
         logs = capsys.readouterr().err
-        assert "retrying once" in logs
+        assert "widened" in logs
         assert "indeterminate" in logs
 
     @pytest.mark.asyncio
@@ -4044,12 +4045,11 @@ class TestScheduler:
         probe_calls: list[str] = []
         deliveries: list[str] = []
 
-        def flaky_probe(agent_name):
+        def slow_probe(agent_name):
             probe_calls.append(agent_name)
-            if len(probe_calls) == 1:
-                # Exceeds the first probe window but not the retry window.
-                time.sleep(0.3)
-                return True
+            # Exceeds the first wait window but resolves inside the
+            # widened continuation wait on the same single probe call.
+            time.sleep(0.1)
             return False
 
         async def confirmed(agent_name, session_id, prompt):
@@ -4060,7 +4060,7 @@ class TestScheduler:
         scheduler = AgentScheduler(
             registry,
             wake_callback=confirmed,
-            delivery_drain_busy_fn=flaky_probe,
+            delivery_drain_busy_fn=slow_probe,
             outbox_drain_probe_timeout_sec=0.05,
         )
         scheduler.replay_pending_for_agent("worker", drain_recheck=True)
@@ -4069,7 +4069,7 @@ class TestScheduler:
             timeout=5.0,
         )
 
-        assert probe_calls == ["worker", "worker"]
+        assert probe_calls == ["worker"]
         assert deliveries == ["owed work"]
         assert registry.list_pending_schedule_wakes("worker") == []
         assert "worker" not in scheduler._outbox_drain_extensions
@@ -4273,6 +4273,359 @@ class TestScheduler:
         )
         assert ledger is not None
         assert ledger.ledger_state == "receipted-ran-once"
+
+    @pytest.mark.asyncio
+    async def test_live_cohort_fence_skips_drain_parked_row(self, registry):
+        """R2-1: a live cohort must not deliver a drain-parked exact fire.
+
+        Re-persisting the same ``(schedule_id, fired_at)`` returns the parked
+        row; delivering it would bypass the verified-release evidence rule and
+        the confirmation would clear the park marker.
+        """
+        registry.register("oleg")
+        schedule = registry.add_schedule(
+            "oleg", "* * * * *", name="fenced", prompt="parked prompt"
+        )
+        fired_at = time.time()
+        registry.update_schedule_last_run(schedule.id, fired_at)
+        schedule.last_run = fired_at
+        row, _ = registry.persist_schedule_wake(
+            schedule.id,
+            agent_name="oleg",
+            schedule_name=schedule.name,
+            prompt=schedule.prompt,
+            fired_at=fired_at,
+        )
+        assert registry.drain_park_pending_schedule_wake(
+            row.id, reason="OUTBOX_DRAIN_PARKED: fixture"
+        )
+        deliveries: list[str] = []
+
+        async def confirmed(agent_name, session_id, prompt):
+            del agent_name, session_id
+            deliveries.append(prompt)
+            return True
+
+        scheduler = AgentScheduler(registry, wake_callback=confirmed)
+        await scheduler._deliver_schedule(schedule)
+
+        assert deliveries == []
+        ledger = registry.get_schedule_wake_by_fire(schedule.id, fired_at)
+        assert ledger is not None
+        assert ledger.ledger_state == "drain-parked"
+
+    @pytest.mark.asyncio
+    async def test_release_never_resurrects_superseded_recurrence(
+        self, registry
+    ):
+        """R2-2: un-park must not execute an occurrence older than a
+        confirmed delivery of the same recurring schedule."""
+        registry.register("worker")
+        schedule = registry.add_schedule(
+            "worker", "* * * * *", name="supersede", prompt="sweep now"
+        )
+        now = time.time()
+        older, _ = registry.persist_schedule_wake(
+            schedule.id,
+            agent_name="worker",
+            schedule_name=schedule.name,
+            prompt=schedule.prompt,
+            fired_at=now - 45,
+        )
+        assert registry.drain_park_pending_schedule_wake(
+            older.id, reason="OUTBOX_DRAIN_PARKED: fixture"
+        )
+        registry.persist_schedule_wake(
+            schedule.id,
+            agent_name="worker",
+            schedule_name=schedule.name,
+            prompt=schedule.prompt,
+            fired_at=now - 30,
+        )
+        deliveries: list[str] = []
+
+        async def confirmed(agent_name, session_id, prompt):
+            del agent_name, session_id
+            deliveries.append(prompt)
+            return True
+
+        scheduler = AgentScheduler(registry, wake_callback=confirmed)
+        scheduler.replay_pending_for_agent("worker")
+        await scheduler._pending_replay_tasks["worker"]
+        for _ in range(200):
+            older_row = registry.get_schedule_wake_by_fire(
+                schedule.id, older.fired_at
+            )
+            if older_row is not None and older_row.ledger_state not in (
+                "pending",
+                "drain-parked",
+            ):
+                break
+            await asyncio.sleep(0)
+
+        # Exactly one execution: the newer fire. The released older
+        # occurrence is superseded by that confirmed delivery.
+        assert deliveries == ["sweep now"]
+        older_row = registry.get_schedule_wake_by_fire(
+            schedule.id, older.fired_at
+        )
+        assert older_row is not None
+        assert older_row.accepted_at == 0
+        assert older_row.ledger_state == "quarantined"
+        assert "superseded" in older_row.last_error
+
+    @pytest.mark.asyncio
+    async def test_hung_drain_probe_is_single_flight_across_cycles(
+        self, registry
+    ):
+        """R2-3: a permanently hung probe must occupy ONE executor worker.
+
+        The once-per-minute scan keeps visiting the agent; without a
+        single-flight fence each visit stacked one-to-two more detached
+        threads onto the shared default executor forever.
+        """
+        registry.register("worker")
+        schedule = registry.add_schedule(
+            "worker", "0 * * * *", name="hung", prompt="owed work"
+        )
+        registry.persist_schedule_wake(
+            schedule.id,
+            agent_name="worker",
+            schedule_name=schedule.name,
+            prompt=schedule.prompt,
+            fired_at=time.time(),
+        )
+        release = threading.Event()
+        probe_calls: list[float] = []
+
+        def hung_probe(agent_name):
+            del agent_name
+            probe_calls.append(time.time())
+            release.wait(timeout=5.0)
+            return False
+
+        scheduler = AgentScheduler(
+            registry,
+            delivery_drain_busy_fn=hung_probe,
+            outbox_drain_probe_timeout_sec=0.01,
+        )
+        try:
+            for _ in range(3):
+                scheduler.replay_pending_for_agent(
+                    "worker", drain_recheck=True
+                )
+                await asyncio.wait_for(
+                    asyncio.shield(
+                        scheduler._pending_replay_tasks["worker"]
+                    ),
+                    timeout=2.0,
+                )
+            assert len(probe_calls) == 1
+            state = scheduler._outbox_drain_extensions["worker"]
+            assert state.attempts == 3
+            assert state.unverified_checks == 3
+        finally:
+            release.set()
+
+    @pytest.mark.asyncio
+    async def test_probe_exception_is_logged_truthfully(
+        self, registry, capsys
+    ):
+        """R2-3b: a raising probe must not be reported as a timeout."""
+        registry.register("worker")
+        schedule = registry.add_schedule(
+            "worker", "0 * * * *", name="raising", prompt="owed work"
+        )
+        registry.persist_schedule_wake(
+            schedule.id,
+            agent_name="worker",
+            schedule_name=schedule.name,
+            prompt=schedule.prompt,
+            fired_at=time.time(),
+        )
+
+        def raising_probe(agent_name):
+            raise RuntimeError("transport exploded")
+
+        scheduler = AgentScheduler(
+            registry,
+            delivery_drain_busy_fn=raising_probe,
+            outbox_drain_probe_timeout_sec=0.05,
+        )
+        scheduler.replay_pending_for_agent("worker", drain_recheck=True)
+        await scheduler._pending_replay_tasks["worker"]
+
+        logs = capsys.readouterr().err
+        assert "RuntimeError" in logs
+        assert "transport exploded" in logs
+        assert "timed out twice" not in logs
+        assert len(registry.list_pending_schedule_wakes("worker")) == 1
+        assert (
+            scheduler._outbox_drain_extensions["worker"].unverified_checks
+            == 1
+        )
+
+    @pytest.mark.asyncio
+    async def test_partial_park_keeps_alert_dedup_across_oldest_change(
+        self, registry, monkeypatch
+    ):
+        """R2-4a: one partial-park episode must page the owner exactly once.
+
+        Parking iterates oldest-first, so the common partial failure parks
+        the oldest row and leaves a newer one active; the next cycle's health
+        sample then leads with a DIFFERENT oldest fire and must not restart
+        the alert budget.
+        """
+        registry.register("worker")
+        schedule = registry.add_schedule(
+            "worker", "0 * * * *", name="partial", prompt="owed work"
+        )
+        base = 1_800_000_000.0
+        clock = [base]
+        monkeypatch.setattr(
+            "pinky_daemon.scheduler.time.time", lambda: clock[0]
+        )
+        first, _ = registry.persist_schedule_wake(
+            schedule.id,
+            agent_name="worker",
+            schedule_name=schedule.name,
+            prompt=schedule.prompt,
+            fired_at=base,
+        )
+        second, _ = registry.persist_schedule_wake(
+            schedule.id,
+            agent_name="worker",
+            schedule_name=schedule.name,
+            prompt=schedule.prompt,
+            fired_at=base + 5,
+        )
+        alerts: list[str] = []
+
+        async def owner_notify(agent_name, message):
+            del agent_name
+            alerts.append(message)
+            return True
+
+        scheduler = AgentScheduler(
+            registry,
+            delivery_drain_busy_fn=lambda agent_name: True,
+            owner_notify_callback=owner_notify,
+            pending_wake_max_age_sec=100_000,
+            outbox_drain_extension_attempt_cap=1,
+        )
+        real_park = registry.drain_park_pending_schedule_wake
+        failing = [True]
+
+        def flaky_park(pending_id, **kwargs):
+            if failing[0] and pending_id == second.id:
+                raise RuntimeError("park write failed")
+            return real_park(pending_id, **kwargs)
+
+        monkeypatch.setattr(
+            registry, "drain_park_pending_schedule_wake", flaky_park
+        )
+        scheduler._check_pending_wake_liveness(base)
+        clock[0] = base + 60
+        scheduler._check_pending_wake_liveness(clock[0])
+        await scheduler._pending_replay_tasks["worker"]
+        await asyncio.gather(*list(scheduler._owner_alert_tasks))
+        assert len(alerts) == 1
+        assert registry.get_schedule_wake_by_fire(
+            schedule.id, first.fired_at
+        ).ledger_state == "drain-parked"
+
+        # Second cycle: park still failing for the remaining row. Same
+        # episode, so no second page.
+        clock[0] = base + 120
+        scheduler._check_pending_wake_liveness(clock[0])
+        await scheduler._pending_replay_tasks["worker"]
+        await asyncio.gather(*list(scheduler._owner_alert_tasks))
+        assert len(alerts) == 1
+        assert "worker" in scheduler._outbox_drain_extensions
+
+        # Third cycle: the write heals; the row parks with no new page.
+        failing[0] = False
+        clock[0] = base + 180
+        scheduler._check_pending_wake_liveness(clock[0])
+        await scheduler._pending_replay_tasks["worker"]
+        await asyncio.gather(*list(scheduler._owner_alert_tasks))
+        assert len(alerts) == 1
+        assert registry.get_schedule_wake_by_fire(
+            schedule.id, second.fired_at
+        ).ledger_state == "drain-parked"
+        assert "worker" not in scheduler._outbox_drain_extensions
+
+    @pytest.mark.asyncio
+    async def test_park_listing_failure_preserves_extension_state(
+        self, registry, monkeypatch
+    ):
+        """R2-4b: a listing error is not an empty outbox; keep the budget."""
+        registry.register("worker")
+        schedule = registry.add_schedule(
+            "worker", "0 * * * *", name="listing", prompt="owed work"
+        )
+        base = 1_800_000_000.0
+        clock = [base]
+        monkeypatch.setattr(
+            "pinky_daemon.scheduler.time.time", lambda: clock[0]
+        )
+        pending, _ = registry.persist_schedule_wake(
+            schedule.id,
+            agent_name="worker",
+            schedule_name=schedule.name,
+            prompt=schedule.prompt,
+            fired_at=base,
+        )
+        alerts: list[str] = []
+
+        async def owner_notify(agent_name, message):
+            del agent_name
+            alerts.append(message)
+            return True
+
+        scheduler = AgentScheduler(
+            registry,
+            delivery_busy_fn=lambda agent_name: True,
+            delivery_drain_busy_fn=lambda agent_name: True,
+            owner_notify_callback=owner_notify,
+            pending_wake_max_age_sec=100_000,
+            outbox_drain_extension_attempt_cap=1,
+        )
+        real_list = registry.list_pending_schedule_wakes
+        fail_park_listing = [True]
+
+        def flaky_list(*args, **kwargs):
+            # The park pass lists with a bare positional agent name; the
+            # scan (no args) and replay (include_parked kwarg) differ.
+            if fail_park_listing[0] and args == ("worker",) and not kwargs:
+                raise RuntimeError("listing failed")
+            return real_list(*args, **kwargs)
+
+        monkeypatch.setattr(
+            registry, "list_pending_schedule_wakes", flaky_list
+        )
+        scheduler._check_pending_wake_liveness(base)
+        clock[0] = base + 60
+        scheduler._check_pending_wake_liveness(clock[0])
+        await scheduler._pending_replay_tasks["worker"]
+        await asyncio.gather(*list(scheduler._owner_alert_tasks))
+
+        # Nothing parked, no page yet, and the budget state survives.
+        assert alerts == []
+        assert "worker" in scheduler._outbox_drain_extensions
+        assert registry.get_schedule_wake_by_fire(
+            schedule.id, pending.fired_at
+        ).ledger_state == "pending"
+
+        fail_park_listing[0] = False
+        clock[0] = base + 120
+        scheduler._check_pending_wake_liveness(clock[0])
+        await scheduler._pending_replay_tasks["worker"]
+        await asyncio.gather(*list(scheduler._owner_alert_tasks))
+        assert len(alerts) == 1
+        assert registry.get_schedule_wake_by_fire(
+            schedule.id, pending.fired_at
+        ).ledger_state == "drain-parked"
 
     @pytest.mark.asyncio
     async def test_idle_trigger_during_replay_guarantees_follow_up_pass(
@@ -5355,8 +5708,66 @@ class TestDrainParkedWakeRegistry:
         )
         assert row is not None
         assert row.ledger_state == "quarantined"
+        # R2-1c: terminal transitions clear the recoverable marker so no row
+        # ever carries terminal and recoverable state simultaneously.
+        assert row.drain_parked_at == 0
         assert registry.release_drain_parked_schedule_wakes("worker") == 0
         assert registry.list_pending_schedule_wakes("worker") == []
+
+    def test_abandon_and_collapse_clear_drain_park_marker(self, registry):
+        schedule, pending = self._persist(registry)
+        assert registry.drain_park_pending_schedule_wake(
+            pending.id, reason="OUTBOX_DRAIN_PARKED: budget expired"
+        )
+        assert registry.abandon_pending_schedule_wake(
+            pending.id, reason="RECEIPT_ABANDONED: fixture"
+        )
+        row = registry.get_schedule_wake_by_fire(
+            schedule.id, pending.fired_at
+        )
+        assert row is not None
+        assert row.ledger_state == "abandoned"
+        assert row.drain_parked_at == 0
+
+        schedule2, pending2 = self._persist2(registry)
+        assert registry.drain_park_pending_schedule_wake(
+            pending2.id, reason="OUTBOX_DRAIN_PARKED: budget expired"
+        )
+        assert registry.collapse_pending_schedule_wake(
+            pending2.id, superseded_by_fired_at=pending2.fired_at + 60
+        )
+        row2 = registry.get_schedule_wake_by_fire(
+            schedule2.id, pending2.fired_at
+        )
+        assert row2 is not None
+        assert row2.ledger_state == "quarantined"
+        assert row2.drain_parked_at == 0
+
+    def _persist2(self, registry):
+        schedule = registry.add_schedule(
+            "worker", "30 * * * *", name="parked-2", prompt="owed work 2"
+        )
+        pending, _ = registry.persist_schedule_wake(
+            schedule.id,
+            agent_name="worker",
+            schedule_name=schedule.name,
+            prompt=schedule.prompt,
+            fired_at=time.time() - 60,
+        )
+        return schedule, pending
+
+    def test_hard_delete_refuses_drain_parked_row(self, registry):
+        """R2-1b: recoverable debt cannot be erased by the stale-drop path."""
+        schedule, pending = self._persist(registry)
+        assert registry.drain_park_pending_schedule_wake(
+            pending.id, reason="OUTBOX_DRAIN_PARKED: budget expired"
+        )
+        assert registry.delete_pending_schedule_wake(pending.id) is False
+        row = registry.get_schedule_wake_by_fire(
+            schedule.id, pending.fired_at
+        )
+        assert row is not None
+        assert row.ledger_state == "drain-parked"
 
     def test_reaper_abandons_expired_drain_parked_rows(self, registry):
         now = time.time()
@@ -5377,6 +5788,7 @@ class TestDrainParkedWakeRegistry:
         )
         assert row is not None
         assert row.ledger_state == "abandoned"
+        assert row.drain_parked_at == 0
         assert row.prompt == "owed work"
 
 

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -4489,6 +4489,213 @@ class TestScheduler:
         assert "superseded" in older_row.last_error
 
     @pytest.mark.asyncio
+    async def test_live_confirmed_delivery_releases_parked_debt(
+        self, registry
+    ):
+        """R5-2: a confirmed LIVE fire is release evidence, not only replay.
+
+        The persisted replay loop's success path releases parked debt; a
+        normal live scheduled fire must do the same, or the minute-level
+        drain probe — the exact evidence class this fix distrusts — remains
+        the only recovery edge.
+        """
+        registry.register("worker")
+        parked_schedule = registry.add_schedule(
+            "worker", "0 * * * *", name="parked lane", prompt="parked work"
+        )
+        parked_row, _ = registry.persist_schedule_wake(
+            parked_schedule.id,
+            agent_name="worker",
+            schedule_name=parked_schedule.name,
+            prompt=parked_schedule.prompt,
+            fired_at=time.time() - 30,
+        )
+        assert registry.drain_park_pending_schedule_wake(parked_row.id)
+        live_schedule = registry.add_schedule(
+            "worker", "30 * * * *", name="live lane", prompt="live work"
+        )
+        fired_at = time.time()
+        registry.update_schedule_last_run(live_schedule.id, fired_at)
+        live_schedule.last_run = fired_at
+        deliveries: list[str] = []
+
+        async def confirmed(agent_name, session_id, prompt):
+            del agent_name, session_id
+            deliveries.append(prompt)
+            return True
+
+        scheduler = AgentScheduler(
+            registry,
+            wake_callback=confirmed,
+            pending_wake_max_age_sec=100_000,
+        )
+        await scheduler._deliver_schedule(live_schedule)
+        for _ in range(200):
+            if (
+                len(deliveries) == 2
+                and not registry.list_pending_schedule_wakes("worker")
+            ):
+                break
+            await asyncio.sleep(0)
+
+        assert deliveries == ["live work", "parked work"]
+        ledger = registry.get_schedule_wake_by_fire(
+            parked_schedule.id, parked_row.fired_at
+        )
+        assert ledger is not None
+        assert ledger.ledger_state == "receipted-ran-once"
+
+    @pytest.mark.asyncio
+    async def test_direct_send_success_advances_floor_and_releases(
+        self, registry
+    ):
+        """R5-3: a ledgerless direct-send success carries exact fire
+        identity and must advance the durable floor and release debt."""
+        registry.register("worker")
+        schedule = registry.add_schedule(
+            "worker", "* * * * *", name="switched", prompt="sweep now"
+        )
+        now = time.time()
+        older, _ = registry.persist_schedule_wake(
+            schedule.id,
+            agent_name="worker",
+            schedule_name=schedule.name,
+            prompt=schedule.prompt,
+            fired_at=now - 45,
+        )
+        assert registry.drain_park_pending_schedule_wake(older.id)
+        # Supported partial update: the same schedule identity switches to
+        # direct-send delivery.
+        registry.update_schedule(
+            schedule.id, direct_send=True, target_channel="chan"
+        )
+        direct = registry.get_schedule(schedule.id)
+        fired_at = now - 30
+        registry.update_schedule_last_run(schedule.id, fired_at)
+        direct.last_run = fired_at
+        sent: list[str] = []
+
+        async def direct_send(agent_name, platform, chat_id, message):
+            del agent_name, platform, chat_id
+            sent.append(message)
+
+        deliveries: list[str] = []
+
+        async def confirmed(agent_name, session_id, prompt):
+            del agent_name, session_id
+            deliveries.append(prompt)
+            return True
+
+        scheduler = AgentScheduler(
+            registry,
+            wake_callback=confirmed,
+            direct_send_callback=direct_send,
+        )
+        await scheduler._deliver_schedule(direct)
+        assert sent == ["sweep now"]
+        refreshed = registry.get_schedule(schedule.id)
+        assert refreshed.last_accepted_fired_at == pytest.approx(fired_at)
+        for _ in range(200):
+            older_row = registry.get_schedule_wake_by_fire(
+                schedule.id, older.fired_at
+            )
+            if older_row is not None and older_row.ledger_state not in (
+                "pending",
+                "drain-parked",
+            ):
+                break
+            await asyncio.sleep(0)
+
+        # The released older occurrence is superseded by the newer direct
+        # fire; it must not replay into the agent.
+        assert deliveries == []
+        older_row = registry.get_schedule_wake_by_fire(
+            schedule.id, older.fired_at
+        )
+        assert older_row is not None
+        assert older_row.ledger_state == "quarantined"
+
+    @pytest.mark.asyncio
+    async def test_rekey_boundary_rejects_fresh_cohort(
+        self, registry, monkeypatch
+    ):
+        """R5-4: a deferred re-key must not merge a LATER fresh cohort into
+        an already-alerted episode and suppress its page."""
+        registry.register("worker")
+        schedule = registry.add_schedule(
+            "worker", "0 * * * *", name="boundary", prompt="owed work"
+        )
+        base = 1_800_000_000.0
+        clock = [base]
+        monkeypatch.setattr(
+            "pinky_daemon.scheduler.time.time", lambda: clock[0]
+        )
+        first, _ = registry.persist_schedule_wake(
+            schedule.id,
+            agent_name="worker",
+            schedule_name=schedule.name,
+            prompt=schedule.prompt,
+            fired_at=base,
+        )
+        alerts: list[str] = []
+
+        async def owner_notify(agent_name, message):
+            del agent_name
+            alerts.append(message)
+            return True
+
+        scheduler = AgentScheduler(
+            registry,
+            delivery_busy_fn=lambda agent_name: True,
+            delivery_drain_busy_fn=lambda agent_name: True,
+            owner_notify_callback=owner_notify,
+            pending_wake_max_age_sec=100_000,
+            outbox_drain_extension_attempt_cap=1,
+        )
+        real_list = registry.list_pending_schedule_wakes
+        relist_state = [0]
+
+        def flaky_list(*args, **kwargs):
+            if args == ("worker",) and not kwargs:
+                relist_state[0] += 1
+                if relist_state[0] == 2:
+                    # Fail only the post-park durable re-list of cycle 1.
+                    raise RuntimeError("re-list failed")
+            return real_list(*args, **kwargs)
+
+        monkeypatch.setattr(
+            registry, "list_pending_schedule_wakes", flaky_list
+        )
+        scheduler._check_pending_wake_liveness(base)
+        clock[0] = base + 60
+        scheduler._check_pending_wake_liveness(clock[0])
+        await scheduler._pending_replay_tasks["worker"]
+        await asyncio.gather(*list(scheduler._owner_alert_tasks))
+        assert len(alerts) == 1
+        assert registry.get_schedule_wake_by_fire(
+            schedule.id, first.fired_at
+        ).ledger_state == "drain-parked"
+
+        # A brand-new fire arrives AFTER the fully-parked first cohort. It
+        # is a fresh episode and must earn its own page when it parks.
+        second, _ = registry.persist_schedule_wake(
+            schedule.id,
+            agent_name="worker",
+            schedule_name=schedule.name,
+            prompt=schedule.prompt,
+            fired_at=base + 90,
+        )
+        clock[0] = base + 120
+        scheduler._check_pending_wake_liveness(clock[0])
+        await scheduler._pending_replay_tasks["worker"]
+        await asyncio.gather(*list(scheduler._owner_alert_tasks))
+
+        assert registry.get_schedule_wake_by_fire(
+            schedule.id, second.fired_at
+        ).ledger_state == "drain-parked"
+        assert len(alerts) == 2
+
+    @pytest.mark.asyncio
     async def test_release_provenance_is_structural(self, registry):
         """R4-1: no park-reason text can dodge the supersession floor.
 
@@ -6339,6 +6546,33 @@ class TestDrainParkedWakeRegistry:
         )
         assert row is not None
         assert row.ledger_state == "drain-parked"
+
+    def test_migration_backfills_accepted_fire_authority(self, registry):
+        """R5-1: adding the schedule high-water column must backfill from
+        retained accepted rows — that evidence is provable, not ambiguous."""
+        schedule, pending = self._persist(registry)
+        assert registry.confirm_pending_schedule_wake(pending.id)
+        assert registry.get_schedule(
+            schedule.id
+        ).last_accepted_fired_at == pytest.approx(pending.fired_at)
+
+        # Simulate a pre-upgrade database: drop the column, discarding the
+        # authority, while the accepted wake row remains retained. Reopening
+        # runs the migration, which must backfill from that retained row.
+        registry._db.execute(
+            "ALTER TABLE agent_schedules DROP COLUMN last_accepted_fired_at"
+        )
+        registry._db.commit()
+
+        reopened = AgentRegistry(db_path=registry._db_path)
+        try:
+            migrated = reopened.get_schedule(schedule.id)
+            assert migrated is not None
+            assert migrated.last_accepted_fired_at == pytest.approx(
+                pending.fired_at
+            )
+        finally:
+            reopened.close()
 
     def test_reaper_abandons_expired_drain_parked_rows(self, registry):
         now = time.time()

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -4489,6 +4489,187 @@ class TestScheduler:
         assert "superseded" in older_row.last_error
 
     @pytest.mark.asyncio
+    async def test_live_confirm_does_not_replay_ordinary_backlog(
+        self, registry
+    ):
+        """R7-1: released debt replays on confirm evidence; ordinary
+        backlog does not — a new cron fire never replays backlog into the
+        old session (documented contract)."""
+        registry.register("worker")
+        backlog_schedule = registry.add_schedule(
+            "worker", "0 * * * *", name="backlog lane", prompt="backlog work"
+        )
+        registry.persist_schedule_wake(
+            backlog_schedule.id,
+            agent_name="worker",
+            schedule_name=backlog_schedule.name,
+            prompt=backlog_schedule.prompt,
+            fired_at=time.time() - 30,
+        )
+        live_schedule = registry.add_schedule(
+            "worker", "30 * * * *", name="live lane", prompt="live work"
+        )
+        fired_at = time.time()
+        registry.update_schedule_last_run(live_schedule.id, fired_at)
+        live_schedule.last_run = fired_at
+        deliveries: list[str] = []
+
+        async def confirmed(agent_name, session_id, prompt):
+            del agent_name, session_id
+            deliveries.append(prompt)
+            return True
+
+        scheduler = AgentScheduler(
+            registry,
+            wake_callback=confirmed,
+            pending_wake_max_age_sec=100_000,
+        )
+        await scheduler._deliver_schedule(live_schedule)
+        for _ in range(50):
+            await asyncio.sleep(0)
+
+        # The live fire delivered; the never-parked backlog row waits for
+        # its own turn-idle/drain boundary as before.
+        assert deliveries == ["live work"]
+        assert [
+            row.schedule_id
+            for row in registry.list_pending_schedule_wakes("worker")
+        ] == [backlog_schedule.id]
+
+    @pytest.mark.asyncio
+    async def test_confirmed_pass_does_not_self_retry_failed_fifo(
+        self, registry
+    ):
+        """R7-2: a transient FIFO failure keeps its attempt cadence — a
+        confirmed earlier delivery must not immediately re-attempt it."""
+        registry.register("worker")
+        schedule_ok = registry.add_schedule(
+            "worker", "0 * * * *", name="ok lane", prompt="ok work"
+        )
+        ok_row, _ = registry.persist_schedule_wake(
+            schedule_ok.id,
+            agent_name="worker",
+            schedule_name=schedule_ok.name,
+            prompt=schedule_ok.prompt,
+            fired_at=time.time() - 40,
+        )
+        schedule_flaky = registry.add_schedule(
+            "worker", "30 * * * *", name="flaky lane", prompt="flaky work"
+        )
+        flaky_row, _ = registry.persist_schedule_wake(
+            schedule_flaky.id,
+            agent_name="worker",
+            schedule_name=schedule_flaky.name,
+            prompt=schedule_flaky.prompt,
+            fired_at=time.time() - 20,
+        )
+        attempts_by_prompt: dict[str, int] = {}
+
+        async def flaky(agent_name, session_id, prompt):
+            del agent_name, session_id
+            attempts_by_prompt[prompt] = attempts_by_prompt.get(prompt, 0) + 1
+            return prompt == "ok work"
+
+        scheduler = AgentScheduler(
+            registry,
+            wake_callback=flaky,
+            pending_wake_max_age_sec=100_000,
+        )
+        scheduler.replay_pending_for_agent("worker")
+        await scheduler._pending_replay_tasks["worker"]
+        for _ in range(100):
+            await asyncio.sleep(0)
+
+        assert attempts_by_prompt == {"ok work": 1, "flaky work": 1}
+        assert registry.get_schedule_wake_by_fire(
+            schedule_ok.id, ok_row.fired_at
+        ).ledger_state == "receipted-ran-once"
+        flaky_ledger = registry.get_schedule_wake_by_fire(
+            schedule_flaky.id, flaky_row.fired_at
+        )
+        assert flaky_ledger.ledger_state == "pending"
+        assert flaky_ledger.attempts == 1
+
+    @pytest.mark.asyncio
+    async def test_late_observer_confirm_replays_released_debt(
+        self, registry, monkeypatch
+    ):
+        """R7-3: a late positive receipt observed by the detached observer
+        must trigger the coalesced replay of the debt it released."""
+        registry.register("worker")
+        schedule = registry.add_schedule(
+            "worker", "0 8 * * *", name="daily", prompt="same prompt"
+        )
+        older_fired_at = 1_800_000_000.0
+        older, _ = registry.persist_schedule_wake(
+            schedule.id,
+            agent_name="worker",
+            schedule_name=schedule.name,
+            prompt=schedule.prompt,
+            fired_at=older_fired_at,
+        )
+        parked_schedule = registry.add_schedule(
+            "worker", "0 9 * * *", name="parked lane", prompt="parked work"
+        )
+        parked_row, _ = registry.persist_schedule_wake(
+            parked_schedule.id,
+            agent_name="worker",
+            schedule_name=parked_schedule.name,
+            prompt=parked_schedule.prompt,
+            fired_at=older_fired_at + 50.0,
+        )
+        assert registry.drain_park_pending_schedule_wake(parked_row.id)
+        monkeypatch.setattr(
+            "pinky_daemon.scheduler.time.time",
+            lambda: older_fired_at + 3_601.0,
+        )
+        monkeypatch.setattr(
+            "pinky_daemon.scheduler._ABANDONED_RECEIPT_OBSERVER_INTERVAL_SEC",
+            0.01,
+        )
+        pasted_inflight = [True]
+        deliveries: list[str] = []
+
+        async def confirmed(agent_name, session_id, prompt):
+            del agent_name, session_id
+            deliveries.append(prompt)
+            return True
+
+        def inflight(agent_name, prompt):
+            del agent_name, prompt
+            return pasted_inflight[0]
+
+        scheduler = AgentScheduler(
+            registry,
+            wake_callback=confirmed,
+            delivery_inflight_fn=inflight,
+            pending_wake_max_age_sec=100_000,
+        )
+        await scheduler._replay_pending_locked("worker")
+        assert registry.get_schedule_wake_by_fire(
+            schedule.id, older_fired_at
+        ).ledger_state == "abandoned"
+
+        # The transport's late positive receipt lands durably; the detached
+        # observer sees it and must replay the released parked debt.
+        pasted_inflight[0] = False
+        assert ScheduleWakeReceipt(
+            registry, schedule.id, older_fired_at
+        ).accept() is True
+        await asyncio.gather(*list(scheduler._detached_receipt_tasks))
+        for _ in range(200):
+            if deliveries:
+                break
+            await asyncio.sleep(0.01)
+
+        assert deliveries == ["parked work"]
+        ledger = registry.get_schedule_wake_by_fire(
+            parked_schedule.id, parked_row.fired_at
+        )
+        assert ledger is not None
+        assert ledger.ledger_state == "receipted-ran-once"
+
+    @pytest.mark.asyncio
     async def test_restart_after_durable_accept_recovers_parked_debt(
         self, registry
     ):

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -4673,6 +4673,85 @@ class TestScheduler:
         assert ledger.ledger_state == "receipted-ran-once"
 
     @pytest.mark.asyncio
+    async def test_receipt_wait_late_confirm_replays_released_debt(
+        self, registry
+    ):
+        """R7 follow-up: the receipt-extension abandon path's OWN late
+        observer must also replay the debt its durable confirm released —
+        both detached observers share the acceptance contract."""
+        registry.register("oleg")
+        parked_schedule = registry.add_schedule(
+            "oleg", "0 9 * * *", name="parked lane", prompt="parked work"
+        )
+        parked_row, _ = registry.persist_schedule_wake(
+            parked_schedule.id,
+            agent_name="oleg",
+            schedule_name=parked_schedule.name,
+            prompt=parked_schedule.prompt,
+            fired_at=time.time() - 30,
+        )
+        assert registry.drain_park_pending_schedule_wake(parked_row.id)
+        schedule = registry.add_schedule(
+            "oleg", "* * * * *", name="bounded busy", prompt="run once"
+        )
+        fired_at = time.time()
+        registry.update_schedule_last_run(schedule.id, fired_at)
+        schedule.last_run = fired_at
+        receipt = asyncio.get_running_loop().create_future()
+        deliveries: list[str] = []
+        first_call = [True]
+        busy = [True]
+
+        async def wake_cb(agent_name, session_id, prompt):
+            del agent_name, session_id
+            if first_call[0]:
+                first_call[0] = False
+                return receipt
+            deliveries.append(prompt)
+            return True
+
+        async def owner_notify(agent_name, message):
+            del agent_name, message
+            return True
+
+        scheduler = AgentScheduler(
+            registry,
+            wake_callback=wake_cb,
+            delivery_busy_fn=lambda agent_name: busy[0],
+            delivery_inflight_fn=lambda agent_name, prompt: True,
+            owner_notify_callback=owner_notify,
+            schedule_delivery_timeout=0.01,
+            receipt_extension_attempt_cap=1,
+            receipt_extension_max_age_sec=1_000.0,
+            pending_wake_max_age_sec=100_000,
+        )
+        await scheduler._deliver_schedule(schedule)
+        assert registry.get_schedule_wake_by_fire(
+            schedule.id, fired_at
+        ).ledger_state == "abandoned"
+
+        # The transport's receipt lands late with the pane now free: the
+        # observer's durable confirm releases parked debt and must replay it.
+        busy[0] = False
+        receipt.set_result(True)
+        await asyncio.gather(*list(scheduler._detached_receipt_tasks))
+        ledger = None
+        for _ in range(300):
+            ledger = registry.get_schedule_wake_by_fire(
+                parked_schedule.id, parked_row.fired_at
+            )
+            if ledger is not None and ledger.ledger_state == (
+                "receipted-ran-once"
+            ):
+                break
+            await asyncio.sleep(0.01)
+
+        assert deliveries == ["parked work"]
+        assert ledger is not None
+        assert ledger.ledger_state == "receipted-ran-once"
+        await scheduler.stop()
+
+    @pytest.mark.asyncio
     async def test_restart_after_durable_accept_recovers_parked_debt(
         self, registry
     ):

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -4657,15 +4657,18 @@ class TestScheduler:
             registry, schedule.id, older_fired_at
         ).accept() is True
         await asyncio.gather(*list(scheduler._detached_receipt_tasks))
-        for _ in range(200):
-            if deliveries:
+        ledger = None
+        for _ in range(300):
+            ledger = registry.get_schedule_wake_by_fire(
+                parked_schedule.id, parked_row.fired_at
+            )
+            if ledger is not None and ledger.ledger_state == (
+                "receipted-ran-once"
+            ):
                 break
             await asyncio.sleep(0.01)
 
         assert deliveries == ["parked work"]
-        ledger = registry.get_schedule_wake_by_fire(
-            parked_schedule.id, parked_row.fired_at
-        )
         assert ledger is not None
         assert ledger.ledger_state == "receipted-ran-once"
 

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -4376,6 +4376,347 @@ class TestScheduler:
         assert "superseded" in older_row.last_error
 
     @pytest.mark.asyncio
+    async def test_supersession_uses_accepted_fire_high_water_mark(
+        self, registry
+    ):
+        """R3-1a: a released occurrence NEWER than every accepted fire is
+        owed work, even when an older fire was accepted late.
+
+        ``last_delivered`` is receipt wall-clock time; comparing a fired_at
+        against it falsely supersedes newer work whenever an older fire is
+        accepted after the newer one fired.
+        """
+        registry.register("worker")
+        schedule = registry.add_schedule(
+            "worker", "* * * * *", name="late accept", prompt="sweep now"
+        )
+        base = time.time() - 120
+        fire_a, _ = registry.persist_schedule_wake(
+            schedule.id,
+            agent_name="worker",
+            schedule_name=schedule.name,
+            prompt=schedule.prompt,
+            fired_at=base,
+        )
+        fire_b, _ = registry.persist_schedule_wake(
+            schedule.id,
+            agent_name="worker",
+            schedule_name=schedule.name,
+            prompt=schedule.prompt,
+            fired_at=base + 60,
+        )
+        # Older fire A is accepted LATE — after B fired.
+        assert registry.confirm_pending_schedule_wake(
+            fire_a.id, delivered_at=base + 90
+        )
+        # B was drain-parked through the registry's own DEFAULT reason: the
+        # floor must not depend on any caller-supplied magic string.
+        assert registry.drain_park_pending_schedule_wake(fire_b.id)
+        deliveries: list[str] = []
+
+        async def confirmed(agent_name, session_id, prompt):
+            del agent_name, session_id
+            deliveries.append(prompt)
+            return True
+
+        scheduler = AgentScheduler(
+            registry,
+            wake_callback=confirmed,
+            delivery_drain_busy_fn=lambda agent_name: False,
+            pending_wake_max_age_sec=1_000,
+        )
+        scheduler.replay_pending_for_agent("worker", drain_recheck=True)
+        await scheduler._pending_replay_tasks["worker"]
+
+        assert deliveries == ["sweep now"]
+        row = registry.get_schedule_wake_by_fire(schedule.id, fire_b.fired_at)
+        assert row is not None
+        assert row.ledger_state == "receipted-ran-once"
+
+    @pytest.mark.asyncio
+    async def test_supersession_applies_regardless_of_park_reason(
+        self, registry
+    ):
+        """R3-1b: default-reason parks must not dodge the supersession floor."""
+        registry.register("worker")
+        schedule = registry.add_schedule(
+            "worker", "* * * * *", name="default reason", prompt="sweep now"
+        )
+        now = time.time()
+        older, _ = registry.persist_schedule_wake(
+            schedule.id,
+            agent_name="worker",
+            schedule_name=schedule.name,
+            prompt=schedule.prompt,
+            fired_at=now - 45,
+        )
+        # Parked via the registry default reason — no magic prefix.
+        assert registry.drain_park_pending_schedule_wake(older.id)
+        registry.persist_schedule_wake(
+            schedule.id,
+            agent_name="worker",
+            schedule_name=schedule.name,
+            prompt=schedule.prompt,
+            fired_at=now - 30,
+        )
+        deliveries: list[str] = []
+
+        async def confirmed(agent_name, session_id, prompt):
+            del agent_name, session_id
+            deliveries.append(prompt)
+            return True
+
+        scheduler = AgentScheduler(registry, wake_callback=confirmed)
+        scheduler.replay_pending_for_agent("worker")
+        await scheduler._pending_replay_tasks["worker"]
+        for _ in range(200):
+            older_row = registry.get_schedule_wake_by_fire(
+                schedule.id, older.fired_at
+            )
+            if older_row is not None and older_row.ledger_state not in (
+                "pending",
+                "drain-parked",
+            ):
+                break
+            await asyncio.sleep(0)
+
+        assert deliveries == ["sweep now"]
+        older_row = registry.get_schedule_wake_by_fire(
+            schedule.id, older.fired_at
+        )
+        assert older_row is not None
+        assert older_row.ledger_state == "quarantined"
+        assert "superseded" in older_row.last_error
+
+    @pytest.mark.asyncio
+    async def test_partial_park_zero_success_defers_alert(
+        self, registry, monkeypatch
+    ):
+        """R3-2a: the recoverable-park page may only claim an actual park."""
+        registry.register("worker")
+        schedule = registry.add_schedule(
+            "worker", "0 * * * *", name="zero park", prompt="owed work"
+        )
+        base = 1_800_000_000.0
+        clock = [base]
+        monkeypatch.setattr(
+            "pinky_daemon.scheduler.time.time", lambda: clock[0]
+        )
+        pending, _ = registry.persist_schedule_wake(
+            schedule.id,
+            agent_name="worker",
+            schedule_name=schedule.name,
+            prompt=schedule.prompt,
+            fired_at=base,
+        )
+        alerts: list[str] = []
+
+        async def owner_notify(agent_name, message):
+            del agent_name
+            alerts.append(message)
+            return True
+
+        scheduler = AgentScheduler(
+            registry,
+            delivery_busy_fn=lambda agent_name: True,
+            delivery_drain_busy_fn=lambda agent_name: True,
+            owner_notify_callback=owner_notify,
+            pending_wake_max_age_sec=100_000,
+            outbox_drain_extension_attempt_cap=1,
+        )
+        failing = [True]
+        real_park = registry.drain_park_pending_schedule_wake
+
+        def broken_park(pending_id, **kwargs):
+            if failing[0]:
+                raise RuntimeError("park write failed")
+            return real_park(pending_id, **kwargs)
+
+        monkeypatch.setattr(
+            registry, "drain_park_pending_schedule_wake", broken_park
+        )
+        scheduler._check_pending_wake_liveness(base)
+        clock[0] = base + 60
+        scheduler._check_pending_wake_liveness(clock[0])
+        await scheduler._pending_replay_tasks["worker"]
+        await asyncio.gather(*list(scheduler._owner_alert_tasks))
+
+        # Zero rows parked: no page, and the budget survives for a retry.
+        assert alerts == []
+        assert "worker" in scheduler._outbox_drain_extensions
+        assert not scheduler._outbox_drain_extensions["worker"].alerted
+
+        failing[0] = False
+        clock[0] = base + 120
+        scheduler._check_pending_wake_liveness(clock[0])
+        await scheduler._pending_replay_tasks["worker"]
+        await asyncio.gather(*list(scheduler._owner_alert_tasks))
+        assert len(alerts) == 1
+        assert registry.get_schedule_wake_by_fire(
+            schedule.id, pending.fired_at
+        ).ledger_state == "drain-parked"
+
+    @pytest.mark.asyncio
+    async def test_partial_park_rekey_uses_durable_state(
+        self, registry, monkeypatch
+    ):
+        """R3-2b: re-key must come from the durable active cohort.
+
+        A False park return can mean a CONCURRENTLY SETTLED row, not a
+        still-active one; keying the budget to it lets the next health
+        sample replace the state and double-page one episode.
+        """
+        registry.register("worker")
+        schedule = registry.add_schedule(
+            "worker", "0 * * * *", name="two writer", prompt="owed work"
+        )
+        base = 1_800_000_000.0
+        clock = [base]
+        monkeypatch.setattr(
+            "pinky_daemon.scheduler.time.time", lambda: clock[0]
+        )
+        row_a, _ = registry.persist_schedule_wake(
+            schedule.id,
+            agent_name="worker",
+            schedule_name=schedule.name,
+            prompt=schedule.prompt,
+            fired_at=base,
+        )
+        row_b, _ = registry.persist_schedule_wake(
+            schedule.id,
+            agent_name="worker",
+            schedule_name=schedule.name,
+            prompt=schedule.prompt,
+            fired_at=base + 5,
+        )
+        row_c, _ = registry.persist_schedule_wake(
+            schedule.id,
+            agent_name="worker",
+            schedule_name=schedule.name,
+            prompt=schedule.prompt,
+            fired_at=base + 10,
+        )
+        alerts: list[str] = []
+
+        async def owner_notify(agent_name, message):
+            del agent_name
+            alerts.append(message)
+            return True
+
+        scheduler = AgentScheduler(
+            registry,
+            delivery_busy_fn=lambda agent_name: True,
+            delivery_drain_busy_fn=lambda agent_name: True,
+            owner_notify_callback=owner_notify,
+            pending_wake_max_age_sec=100_000,
+            outbox_drain_extension_attempt_cap=1,
+        )
+        real_park = registry.drain_park_pending_schedule_wake
+        wedged = [True]
+
+        def two_writer_park(pending_id, **kwargs):
+            if pending_id == row_b.id:
+                # A second writer terminalized B between the listing and
+                # this write: our own park honestly returns False.
+                registry.park_pending_schedule_wake(
+                    row_b.id, reason="terminal replay policy: fixture"
+                )
+                return real_park(pending_id, **kwargs)
+            if wedged[0] and pending_id == row_c.id:
+                raise RuntimeError("park write failed")
+            return real_park(pending_id, **kwargs)
+
+        monkeypatch.setattr(
+            registry, "drain_park_pending_schedule_wake", two_writer_park
+        )
+        scheduler._check_pending_wake_liveness(base)
+        clock[0] = base + 60
+        scheduler._check_pending_wake_liveness(clock[0])
+        await scheduler._pending_replay_tasks["worker"]
+        await asyncio.gather(*list(scheduler._owner_alert_tasks))
+        assert len(alerts) == 1
+        # The budget must be keyed to the still-active row C, not the
+        # concurrently settled row B.
+        state = scheduler._outbox_drain_extensions["worker"]
+        assert state.oldest_fired_at == row_c.fired_at
+        assert state.alerted
+
+        clock[0] = base + 120
+        scheduler._check_pending_wake_liveness(clock[0])
+        await scheduler._pending_replay_tasks["worker"]
+        await asyncio.gather(*list(scheduler._owner_alert_tasks))
+        assert len(alerts) == 1
+
+        wedged[0] = False
+        clock[0] = base + 180
+        scheduler._check_pending_wake_liveness(clock[0])
+        await scheduler._pending_replay_tasks["worker"]
+        await asyncio.gather(*list(scheduler._owner_alert_tasks))
+        assert len(alerts) == 1
+        assert registry.get_schedule_wake_by_fire(
+            schedule.id, row_a.fired_at
+        ).ledger_state == "drain-parked"
+        assert registry.get_schedule_wake_by_fire(
+            schedule.id, row_c.fired_at
+        ).ledger_state == "drain-parked"
+        assert "worker" not in scheduler._outbox_drain_extensions
+
+    @pytest.mark.asyncio
+    async def test_late_raising_probe_is_harvested(self, registry, capsys):
+        """R3-3: a probe that raises after both waits must surface in OUR log
+        on the next cycle, not as an unstructured asyncio error."""
+        registry.register("worker")
+        schedule = registry.add_schedule(
+            "worker", "0 * * * *", name="late raise", prompt="owed work"
+        )
+        registry.persist_schedule_wake(
+            schedule.id,
+            agent_name="worker",
+            schedule_name=schedule.name,
+            prompt=schedule.prompt,
+            fired_at=time.time(),
+        )
+        release = threading.Event()
+        calls: list[int] = []
+
+        def late_raising_probe(agent_name):
+            del agent_name
+            calls.append(1)
+            if len(calls) == 1:
+                release.wait(timeout=5.0)
+                raise RuntimeError("late probe explosion")
+            return True
+
+        scheduler = AgentScheduler(
+            registry,
+            delivery_drain_busy_fn=late_raising_probe,
+            outbox_drain_probe_timeout_sec=0.01,
+        )
+        scheduler.replay_pending_for_agent("worker", drain_recheck=True)
+        await asyncio.wait_for(
+            asyncio.shield(scheduler._pending_replay_tasks["worker"]),
+            timeout=2.0,
+        )
+        # Let the blocked probe resolve with its exception.
+        release.set()
+        for _ in range(200):
+            outstanding = scheduler._drain_probe_futures.get("worker")
+            if outstanding is not None and outstanding.done():
+                break
+            await asyncio.sleep(0.01)
+
+        scheduler.replay_pending_for_agent("worker", drain_recheck=True)
+        await asyncio.wait_for(
+            asyncio.shield(scheduler._pending_replay_tasks["worker"]),
+            timeout=2.0,
+        )
+
+        logs = capsys.readouterr().err
+        assert "late probe explosion" in logs
+        assert "RuntimeError" in logs
+        assert len(calls) == 2
+
+    @pytest.mark.asyncio
     async def test_hung_drain_probe_is_single_flight_across_cycles(
         self, registry
     ):

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -11991,3 +11991,70 @@ async def test_scheduler_drain_busy_pasted_unaccepted_outranks_newer_idle(
     assert turn.transport_accepted is False
     assert ss.scheduler_wake_inflight(turn.prompt) is True
     assert ss.scheduler_drain_busy() is True
+
+
+def test_scheduler_drain_busy_discounts_pre_spawn_working_row() -> None:
+    """#635 A3: a hook row from a dead REPL process is not busy evidence.
+
+    ``connect()`` always reaps any surviving pane and freshly spawns the
+    REPL, so a persisted working-status row stamped BEFORE
+    ``_current_session_started_at`` cannot describe the current process.
+    After an unclean host reboot that frozen "working" row otherwise pins
+    every scheduler drain busy until an unrelated turn rewrites it — the
+    exact starvation that terminalized a real wake on 08-18.
+    """
+    ss, _ = _make_session(state=SessionState.CONNECTED)
+    now = _time.time()
+    ss._current_session_started_at = now - 5.0
+    ss._config.live_status_fn = lambda: {
+        "status": "working",
+        "last_updated": now - 100.0,
+    }
+
+    assert not ss._inflight_metas
+    assert ss.scheduler_drain_busy() is False
+
+
+def test_scheduler_drain_busy_post_spawn_working_row_stays_busy() -> None:
+    """A working row stamped by THIS process life keeps failing closed."""
+    ss, _ = _make_session(state=SessionState.CONNECTED)
+    now = _time.time()
+    ss._current_session_started_at = now - 5.0
+    ss._config.live_status_fn = lambda: {
+        "status": "working",
+        "last_updated": now - 1.0,
+    }
+
+    assert ss.scheduler_drain_busy() is True
+
+
+def test_scheduler_drain_busy_pre_spawn_discount_needs_quiet_pane() -> None:
+    """A paste this process life outranks the pre-spawn discount.
+
+    If the daemon pasted a turn and the hooks then broke (no status write),
+    the stale row plus a live inflight meta must still read busy — the
+    discount only applies when nothing was ever pasted into the fresh REPL.
+    """
+    ss, _ = _make_session(state=SessionState.CONNECTED)
+    now = _time.time()
+    ss._current_session_started_at = now - 5.0
+    _seed_inflight(ss)
+    ss._config.live_status_fn = lambda: {
+        "status": "working",
+        "last_updated": now - 100.0,
+    }
+
+    assert ss.scheduler_drain_busy() is True
+
+
+def test_scheduler_drain_busy_unstamped_spawn_keeps_fail_closed() -> None:
+    """Without a spawn stamp the stale-row discount must never engage."""
+    ss, _ = _make_session(state=SessionState.CONNECTED)
+    now = _time.time()
+    assert ss._current_session_started_at == 0.0
+    ss._config.live_status_fn = lambda: {
+        "status": "working",
+        "last_updated": now - 100.0,
+    }
+
+    assert ss.scheduler_drain_busy() is True


### PR DESCRIPTION
# Stop the wake drain terminalizing deliverable work

## Problem

The periodic outbox drain could starve and then destroy real scheduled work through two stacked defects, both observed in production the same day (multiple recurring wakes terminalized on one host):

1. **A probe timeout was counted as busy.** `_agent_busy_for_drain` treated a 5s transport-probe timeout as a positive busy verdict. A slow probe manufactured "busy" out of no evidence.
2. **A stale status row from a dead process pinned the pane busy.** After an unclean host restart, the persisted working-status row written by the *previous* REPL process still said `working`. The daemon always reaps and freshly spawns the REPL at connect, so that row could not describe the new process — but the pane-busy verdict trusted it, freezing every scheduler drain until an unrelated turn happened to rewrite the row.
3. **Cap expiry was silent data loss.** When the drain-extension budget (30 checks / 30 min) expired, every active wake row went to terminal `OUTBOX_DRAIN_ABANDONED`. The alert text promised "a late positive receipt can still supersede abandonment" — but an idle agent behind a false busy signal never received a delivery, so no receipt could ever arrive. The wake was simply gone. The same loss shape also hit genuinely-busy agents whose long turns outlived the budget.

## Fix

**Probe honesty (scheduler).** A drain-probe timeout retries once with a 3× window. A still-indeterminate probe defers safely but returns `verified=False`; the extension state, logs, and the owner alert now carry the unverified count instead of presenting timeouts as positive busy evidence.

**Boot-phantom reconciliation (tmux transport).** In the pane-busy verdict, a working-status row with `last_updated <= _current_session_started_at` is discounted — but only when every in-daemon pane signal is quiet *and* the inflight meta deque is empty (nothing was pasted this process life). A pasted-but-unhooked turn, an unresolved receipt, tool activity, or queue depth all still fail closed, and a session without a spawn stamp keeps the old behavior entirely.

**Park, don't abandon (scheduler + registry).** Cap expiry now moves active rows to a new **non-terminal** `drain-parked` ledger state (`drain_parked_at` column, `_ensure_columns` migration). Parked rows:
- carry no drain retry pressure (excluded from the active outbox and attempt accounting),
- release back to the active outbox on the next **verified-idle transport probe** or **confirmed delivery** to that agent (the once-per-minute drain scan now also visits agents whose only debt is parked, so a turn-idle boundary is picked up within one cycle),
- re-enter the normal replay policy on release — the existing staleness, zombie-quarantine, and recurrence-collapse rules still bound what actually replays,
- stay bounded: a late positive receipt clears the park, an explicit operator discard or zombie quarantine terminalizes it, and the outbox reaper's fired-at ceiling remains the ultimate terminal bound, so parked debt cannot become immortal. Prompt payloads are never trimmed while a row is recoverable.

The owner alert still fires exactly once per expiry, now describing the recoverable semantics honestly.

## Tests

Red-first: 12 failing fixtures committed before the implementation (`baa435f`), covering probe-retry delivery, double-timeout unverified deferral, cap-expiry parking + single alert, release-on-verified-idle delivery, release-through-staleness dropping, confirmed-delivery release of parked backlog, the registry state machine (park/release/confirm/terminal-wins/ledger/health), reaper abandonment of expired parked rows, and four transport-probe cases (pre-spawn discount plus three fail-closed guards). Existing drain/receipt/replay suites updated only where the approved behavior deliberately changed (abandon → park); the receipt-extension, replay-wedge, and timing suites are untouched and green.

Full local runs: `test_scheduler.py` 207 passed, `test_tmux_session.py` 423 passed, `test_api.py` 437 passed, `pinky_self` wake tests green, ruff clean.

## Screenshot

None — daemon scheduler internals with no UI surface; behavior is exercised and demonstrated by the test suite and log/alert text above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🤖 Opened by Barsik
