### PR TITLE
Fix transcript-verified tmux phantom draining

### DIFF
--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -65,6 +65,8 @@ import shlex
 import threading
 import time
 from collections import OrderedDict, deque
+from collections.abc import Iterator
+from contextlib import ExitStack
 from dataclasses import dataclass, field, replace
 from pathlib import Path
 
@@ -1302,6 +1304,72 @@ async def reconcile_tmux_spawn_cleanup_debts(
 # ──────────────────────────────────────────────────────────────────────────
 
 
+def _snapshot_transcript_boundary(
+    path: Path,
+    *,
+    expected_identity: tuple[int, int] | None = None,
+    expected_offset: int | None = None,
+) -> tuple[tuple[int, int], int, int, bytes, int] | None:
+    """Read one descriptor-bound EOF and its exact bounded suffix."""
+    try:
+        with path.open("rb") as handle:
+            opened = os.fstat(handle.fileno())
+            identity = (opened.st_dev, opened.st_ino)
+            offset = opened.st_size
+            if (
+                (expected_identity is not None and identity != expected_identity)
+                or (expected_offset is not None and offset != expected_offset)
+            ):
+                return None
+            anchor_start = max(
+                0, offset - _TRANSCRIPT_BOUNDARY_ANCHOR_BYTES
+            )
+            handle.seek(anchor_start)
+            anchor = handle.read(offset - anchor_start)
+            revalidated = os.fstat(handle.fileno())
+    except (OSError, TypeError, ValueError):
+        return None
+    if (
+        (revalidated.st_dev, revalidated.st_ino) != identity
+        or revalidated.st_size != offset
+        or len(anchor) != offset - anchor_start
+    ):
+        return None
+    return (identity, offset, anchor_start, anchor, time.time_ns())
+
+
+@dataclass(frozen=True)
+class _TranscriptOccurrenceTicket:
+    """Descriptor-validated pre-paste boundary plus its content epoch anchor.
+
+    Iteration intentionally exposes the historical three-tuple interface used
+    by focused tests; production reads the anchor fields explicitly.
+    """
+
+    path: Path | None
+    identity: tuple[int, int] | None
+    offset: int | None
+    anchor_start: int | None = None
+    anchor: bytes | None = None
+    captured_at_ns: int | None = None
+
+    def __iter__(
+        self,
+    ) -> Iterator[Path | tuple[int, int] | int | None]:
+        yield self.path
+        yield self.identity
+        yield self.offset
+
+
+_TranscriptSourceKey = tuple[int, int]
+_TranscriptCandidateSource = tuple[
+    _TranscriptSourceKey,
+    int,
+    bool,
+    bool | None,
+]
+
+
 @dataclass
 class _QueuedTurn:
     """Inbound message awaiting delivery to the claude REPL.
@@ -1379,6 +1447,9 @@ class _QueuedTurn:
     transcript_path_at_paste: Path | None = None
     transcript_file_identity_at_paste: tuple[int, int] | None = None
     transcript_offset_at_paste: int | None = None
+    transcript_anchor_start_at_paste: int | None = None
+    transcript_anchor_at_paste: bytes | None = None
+    transcript_ticket_captured_at_ns: int | None = None
     # Wake-only exact submission receipt (#953). True requires a matching
     # transcript user row or queue enqueue→dequeue; successful tmux paste/Enter
     # commands alone are deliberately insufficient. Kept separate from the
@@ -1502,19 +1573,43 @@ class _InflightMeta:
     transcript_mtime_at_paste: float | None = None
     paste_succeeded_at: float | None = None
     # Direct idle-reconcile fallback ticket. ``transcript_offset_at_paste``
-    # is the file size sampled immediately before the pane paste. The device /
-    # inode pair prevents a stale offset from hiding rows when a new transcript
-    # materializes at the same pathname; identity change or truncation resets
-    # the scan boundary to byte zero.
+    # is the opened descriptor's size immediately before the pane paste. The
+    # device/inode pair and exact EOF suffix bind a physical append epoch.
+    # Identity/epoch loss may scan byte zero only to reserve FIFO rows; it
+    # cannot prove acceptance by matching content alone.
     transcript_path_at_paste: Path | None = None
     transcript_file_identity_at_paste: tuple[int, int] | None = None
     transcript_offset_at_paste: int | None = None
+    transcript_anchor_start_at_paste: int | None = None
+    transcript_anchor_at_paste: bytes | None = None
+    transcript_ticket_captured_at_ns: int | None = None
     # Non-zero only for turns delivered during the active post-fresh lineage.
     # A completion may end ``_fresh_context_respawn_grace_until`` only when
     # this epoch matches the session's active epoch.  This prevents an
     # autonomous/stale Stop hook (or any pre-fresh metadata) from reopening
     # ``--continue`` before the replacement turn completes.
     fresh_context_epoch: int = 0
+
+    def __post_init__(self) -> None:
+        """Give direct production-shaped fixtures the same boundary guard."""
+        if (
+            self.transcript_ticket_captured_at_ns is not None
+            or self.transcript_path_at_paste is None
+            or self.transcript_file_identity_at_paste is None
+            or self.transcript_offset_at_paste is None
+        ):
+            return
+        snapshot = _snapshot_transcript_boundary(
+            self.transcript_path_at_paste,
+            expected_identity=self.transcript_file_identity_at_paste,
+            expected_offset=self.transcript_offset_at_paste,
+        )
+        if snapshot is None:
+            return
+        _identity, _offset, anchor_start, anchor, captured_at_ns = snapshot
+        self.transcript_anchor_start_at_paste = anchor_start
+        self.transcript_anchor_at_paste = anchor
+        self.transcript_ticket_captured_at_ns = captured_at_ns
 
 
 # ──────────────────────────────────────────────────────────────────────────
@@ -1725,6 +1820,17 @@ def _inflight_replay_tail_cap() -> int:
     except (TypeError, ValueError):
         val = 20
     return max(0, val)
+
+
+# A watchdog reconciliation runs on the daemon event loop, so transcript
+# evidence must have a fixed synchronous I/O ceiling. The bound is cumulative
+# per opened physical file, not per candidate/path alias.
+_PHANTOM_TRANSCRIPT_SCAN_BYTES = 4 * 1024 * 1024
+
+# Exact bytes immediately below the pre-paste EOF distinguish a stable append
+# epoch from copy-truncate/regrow on the same inode. The anchor is deliberately
+# small because it is captured on every pane delivery.
+_TRANSCRIPT_BOUNDARY_ANCHOR_BYTES = 4096
 
 
 # Issue #570 — wake-prompt readiness-gate timeout. ``_deliver_turn`` awaits
@@ -7119,140 +7225,327 @@ class TmuxSession(TransportReplacementMixin):
 
     def _capture_transcript_occurrence_ticket(
         self,
-    ) -> tuple[Path | None, tuple[int, int] | None, int | None]:
+    ) -> _TranscriptOccurrenceTicket:
         """Snapshot the active transcript identity and EOF before one paste.
 
         The transcript user row can be written before ``paste_text`` returns,
         so the boundary must be sampled immediately before the physical paste,
         not during post-paste metadata recording. A missing-but-bound path is a
-        valid cold-start ticket at byte zero; the first materialized file then
-        scans from its beginning.
+        cold-start allocation ticket at byte zero; the first materialized file
+        may reserve rows from its beginning but cannot positively certify them
+        without independent occurrence-bound evidence.
         """
         tailer = self._tailer
         raw_path = getattr(tailer, "transcript_path", None) if tailer else None
         if not raw_path:
-            return (None, None, None)
+            return _TranscriptOccurrenceTicket(None, None, None)
         try:
             path = Path(raw_path)
         except (TypeError, ValueError):
-            return (None, None, None)
+            return _TranscriptOccurrenceTicket(None, None, None)
         try:
-            stat = path.stat()
+            # Preserve the fail-safe distinction between a missing path and an
+            # inaccessible bound path. Identity never comes from this lookup;
+            # the opened descriptor below is the sole identity authority.
+            path.stat()
         except FileNotFoundError:
-            return (path, None, 0)
+            return _TranscriptOccurrenceTicket(
+                path,
+                None,
+                0,
+                anchor_start=0,
+                anchor=b"",
+                captured_at_ns=time.time_ns(),
+            )
         except OSError:
-            return (path, None, None)
-        return (path, (stat.st_dev, stat.st_ino), stat.st_size)
+            return _TranscriptOccurrenceTicket(path, None, None)
+
+        snapshot = _snapshot_transcript_boundary(path)
+        if snapshot is None:
+            return _TranscriptOccurrenceTicket(path, None, None)
+        identity, offset, anchor_start, anchor, captured_at_ns = snapshot
+        return _TranscriptOccurrenceTicket(
+            path,
+            identity,
+            offset,
+            anchor_start=anchor_start,
+            anchor=anchor,
+            captured_at_ns=captured_at_ns,
+        )
 
     def _phantom_consumption_verdicts(
         self, candidates: list[_InflightMeta]
     ) -> list[bool | None]:
         """Allocate complete post-paste user rows to candidates one-to-one.
 
-        ``True`` proves this exact occurrence was accepted, ``False`` means a
-        usable transcript contained no allocatable occurrence, and ``None``
-        means the transcript itself was unavailable (the historical fail-safe
-        drain remains in force for that case).
+        ``True`` proves this exact occurrence was accepted, ``False`` means
+        no paste-bound occurrence was proved (including allocation-only rows
+        from a lost epoch), and ``None`` means the transcript evidence was
+        unavailable (the historical fail-safe drain remains in force).
 
         Already accepted candidates still participate in FIFO row allocation:
         acceptance outranks a missing fallback row, but an earlier accepted
         duplicate must claim its own row so that row cannot falsely certify a
         later unaccepted duplicate.
         """
-        # Per candidate: either a readable source key + scan boundary, False
-        # for a usable transcript without a paste ticket, or None when no
-        # transcript can be inspected at all.
-        sources: list[
-            tuple[tuple[Path, tuple[int, int]], int] | bool | None
-        ] = []
-        scan_starts: dict[tuple[Path, tuple[int, int]], int] = {}
-        for entry in candidates:
-            path = entry.transcript_path_at_paste
-            offset = entry.transcript_offset_at_paste
-            if path is None or offset is None:
-                tailer = self._tailer
-                raw_path = (
-                    getattr(tailer, "transcript_path", None) if tailer else None
-                )
-                try:
-                    usable = bool(raw_path) and Path(raw_path).is_file()
-                except (OSError, TypeError, ValueError):
-                    usable = False
-                sources.append(False if usable else None)
-                continue
-            try:
-                transcript = Path(path)
-                stat = transcript.stat()
-            except (OSError, TypeError, ValueError):
-                sources.append(None)
-                continue
-            current_identity = (stat.st_dev, stat.st_ino)
-            start = max(0, offset)
-            if (
-                entry.transcript_file_identity_at_paste != current_identity
-                or stat.st_size < start
-            ):
-                # A new/truncated file at the same path must not inherit the
-                # predecessor's stale EOF. Its occurrence namespace starts at 0.
-                start = 0
-            key = (transcript, current_identity)
-            sources.append((key, start))
-            scan_starts[key] = min(scan_starts.get(key, start), start)
-
-        rows: dict[
-            tuple[Path, tuple[int, int]], list[tuple[int, str]]
+        # Per candidate: opened physical source, allocation boundary, whether
+        # row-local post-ticket proof is available, and the conservative result
+        # when no paste-bound row can be proved.
+        sources: list[_TranscriptCandidateSource | None] = []
+        handles: dict[_TranscriptSourceKey, object] = {}
+        scan_starts: dict[_TranscriptSourceKey, int] = {}
+        budget_remaining: dict[_TranscriptSourceKey, int] = {}
+        anchor_checks: dict[
+            tuple[_TranscriptSourceKey, int, int, bytes],
+            bool,
         ] = {}
-        unreadable: set[tuple[Path, tuple[int, int]]] = set()
-        for key, start in scan_starts.items():
-            transcript, _identity = key
-            found: list[tuple[int, str]] = []
-            try:
-                with transcript.open("rb") as handle:
+
+        def _descriptor(handle: object) -> int:
+            """Reach the real descriptor through transparent test wrappers."""
+            current = handle
+            for _ in range(4):
+                fileno = getattr(current, "fileno", None)
+                if fileno is not None:
+                    return int(fileno())
+                current = getattr(current, "_wrapped")
+            raise AttributeError("opened transcript has no file descriptor")
+
+        with ExitStack() as stack:
+            for entry in candidates:
+                ticket_had_path = entry.transcript_path_at_paste is not None
+                path = entry.transcript_path_at_paste
+                if path is None:
+                    tailer = self._tailer
+                    path = (
+                        getattr(tailer, "transcript_path", None)
+                        if tailer
+                        else None
+                    )
+                try:
+                    transcript = Path(path) if path is not None else None
+                except (TypeError, ValueError):
+                    transcript = None
+                if transcript is None:
+                    sources.append(None)
+                    continue
+
+                try:
+                    handle = stack.enter_context(transcript.open("rb"))
+                    descriptor = _descriptor(handle)
+                    opened = os.fstat(descriptor)
+                except (AttributeError, OSError, TypeError, ValueError):
+                    sources.append(None)
+                    continue
+
+                key = (opened.st_dev, opened.st_ino)
+                handles.setdefault(key, handle)
+                budget_remaining.setdefault(
+                    key, _PHANTOM_TRANSCRIPT_SCAN_BYTES
+                )
+                ticket_identity = entry.transcript_file_identity_at_paste
+                offset = entry.transcript_offset_at_paste
+
+                # Allocation is broader than proof. A candidate whose ticket
+                # capture failed still claims an equal physical row in FIFO
+                # order, but that row cannot turn its unavailable verdict into
+                # positive acceptance.
+                if ticket_identity is None or offset is None:
+                    allocation_start = 0
+                    proof_available = False
+                    # A bound path whose descriptor ticket failed is
+                    # unavailable. A legacy/pathless entry inspected through
+                    # the current tailer is provenance-lost and non-positive.
+                    fallback: bool | None = None if ticket_had_path else False
+                elif ticket_identity == key:
+                    start = max(0, offset)
+                    anchor_start = entry.transcript_anchor_start_at_paste
+                    anchor = entry.transcript_anchor_at_paste
+                    guard_valid = (
+                        entry.transcript_ticket_captured_at_ns is not None
+                        and anchor_start is not None
+                        and anchor is not None
+                        and anchor_start >= 0
+                        and len(anchor) <= _TRANSCRIPT_BOUNDARY_ANCHOR_BYTES
+                        and anchor_start + len(anchor) == start
+                    )
+                    epoch_stable = False
+                    if guard_valid:
+                        check_key = (key, start, anchor_start, anchor)
+                        cached = anchor_checks.get(check_key)
+                        if cached is not None:
+                            epoch_stable = cached
+                        elif len(anchor) <= budget_remaining[key]:
+                            try:
+                                current_anchor = os.pread(
+                                    descriptor,
+                                    len(anchor),
+                                    anchor_start,
+                                )
+                            except OSError:
+                                guard_valid = False
+                            else:
+                                budget_remaining[key] -= len(current_anchor)
+                                epoch_stable = (
+                                    len(current_anchor) == len(anchor)
+                                    and current_anchor == anchor
+                                    and opened.st_size >= start
+                                )
+                                anchor_checks[check_key] = epoch_stable
+                        else:
+                            guard_valid = False
+
+                    proof_available = guard_valid
+                    if epoch_stable:
+                        allocation_start = start
+                    else:
+                        # Same-inode epoch loss scans from byte zero for FIFO
+                        # reservation. Positive proof, if any, is decided per
+                        # row against the captured suffix below.
+                        allocation_start = 0
+                    fallback = False
+                else:
+                    # A different opened inode is allocation-only regardless
+                    # of pathname timing, timestamps, or matching content.
+                    allocation_start = 0
+                    proof_available = False
+                    fallback = False
+
+                source = (
+                    key,
+                    allocation_start,
+                    proof_available,
+                    fallback,
+                )
+                sources.append(source)
+                scan_starts[key] = min(
+                    scan_starts.get(key, allocation_start),
+                    allocation_start,
+                )
+
+            def _allocation_complete(
+                key: _TranscriptSourceKey,
+                found: list[tuple[int, int, str, bytes]],
+            ) -> bool:
+                """Whether every candidate on one source owns a distinct row."""
+                reserved: set[int] = set()
+                for entry, source in zip(candidates, sources, strict=True):
+                    if source is None or source[0] != key:
+                        continue
+                    allocation_start = source[1]
+                    for row_offset, _row_end, prompt, _raw in found:
+                        if (
+                            row_offset >= allocation_start
+                            and row_offset not in reserved
+                            and prompt == entry.turn.prompt
+                        ):
+                            reserved.add(row_offset)
+                            break
+                    else:
+                        return False
+                return True
+
+            rows: dict[
+                _TranscriptSourceKey,
+                list[tuple[int, int, str, bytes]],
+            ] = {}
+            incomplete: set[_TranscriptSourceKey] = set()
+            for key, start in scan_starts.items():
+                found: list[tuple[int, int, str, bytes]] = []
+                handle = handles[key]
+                remaining = budget_remaining[key]
+                try:
                     handle.seek(start)
-                    while True:
+                    while remaining > 0:
                         row_offset = handle.tell()
-                        raw = handle.readline()
+                        raw = handle.readline(remaining)
                         if not raw:
+                            break
+                        remaining -= len(raw)
+                        if not raw.endswith(b"\n"):
+                            incomplete.add(key)
                             break
                         try:
                             parsed = json.loads(raw)
                         except (json.JSONDecodeError, UnicodeDecodeError):
                             continue
-                        if not isinstance(parsed, dict) or parsed.get("type") != "user":
+                        if (
+                            not isinstance(parsed, dict)
+                            or parsed.get("type") != "user"
+                        ):
                             continue
                         prompt = self._transcript_user_text(parsed)
-                        if prompt is not None:
-                            found.append((row_offset, prompt))
-            except (OSError, TypeError, ValueError):
-                unreadable.add(key)
-            rows[key] = found
+                        if prompt is None:
+                            continue
+                        found.append(
+                            (row_offset, row_offset + len(raw), prompt, raw)
+                        )
+                        if _allocation_complete(key, found):
+                            break
+                    else:
+                        incomplete.add(key)
+                except (AttributeError, OSError, TypeError, ValueError):
+                    incomplete.add(key)
+                rows[key] = found
 
-        used: set[tuple[tuple[Path, tuple[int, int]], int]] = set()
-        verdicts: list[bool | None] = []
-        for entry, source in zip(candidates, sources, strict=True):
-            claimed = False
-            if isinstance(source, tuple):
-                key, start = source
-                if key not in unreadable:
-                    for row_offset, prompt in rows.get(key, []):
+            used: set[tuple[_TranscriptSourceKey, int]] = set()
+            verdicts: list[bool | None] = []
+            for entry, source in zip(candidates, sources, strict=True):
+                claimed: tuple[int, int, bytes] | None = None
+                if source is not None:
+                    (
+                        key,
+                        allocation_start,
+                        proof_available,
+                        fallback,
+                    ) = source
+                    for row_offset, row_end, prompt, raw in rows.get(key, []):
                         occurrence = (key, row_offset)
                         if (
-                            row_offset >= start
+                            row_offset >= allocation_start
                             and occurrence not in used
                             and prompt == entry.turn.prompt
                         ):
                             used.add(occurrence)
-                            claimed = True
+                            claimed = (row_offset, row_end, raw)
                             break
                 else:
-                    source = None
-            if entry.turn.transport_accepted:
-                verdicts.append(True)
-            elif source is None:
-                verdicts.append(None)
-            else:
-                verdicts.append(claimed)
-        return verdicts
+                    key = None
+                    proof_available = False
+                    fallback = None
+
+                paste_bound = False
+                if claimed is not None and proof_available and key is not None:
+                    row_offset, row_end, raw = claimed
+                    offset = entry.transcript_offset_at_paste
+                    anchor_start = entry.transcript_anchor_start_at_paste
+                    anchor = entry.transcript_anchor_at_paste
+                    if offset is not None and row_end > offset:
+                        paste_bound = True
+                    elif (
+                        offset is not None
+                        and anchor_start is not None
+                        and anchor is not None
+                        and row_offset >= anchor_start
+                        and row_end <= offset
+                    ):
+                        relative_start = row_offset - anchor_start
+                        relative_end = row_end - anchor_start
+                        prior = anchor[relative_start:relative_end]
+                        paste_bound = len(prior) == len(raw) and prior != raw
+
+                if entry.turn.transport_accepted:
+                    verdicts.append(True)
+                elif paste_bound:
+                    verdicts.append(True)
+                elif (
+                    key is not None
+                    and key in incomplete
+                    and (proof_available or fallback is None)
+                ):
+                    verdicts.append(None)
+                else:
+                    verdicts.append(fallback)
+            return verdicts
 
     def _background_task_recent_age(self, now: float, window: float) -> float | None:
         """Seconds since a background task last wrote a transcript, or None.
@@ -9488,11 +9781,21 @@ class TmuxSession(TransportReplacementMixin):
                     retry_scheduler_gate = True
                 else:
                     retry_scheduler_gate = False
+                    transcript_ticket = (
+                        self._capture_transcript_occurrence_ticket()
+                    )
                     (
                         turn.transcript_path_at_paste,
                         turn.transcript_file_identity_at_paste,
                         turn.transcript_offset_at_paste,
-                    ) = self._capture_transcript_occurrence_ticket()
+                    ) = transcript_ticket
+                    turn.transcript_anchor_start_at_paste = (
+                        transcript_ticket.anchor_start
+                    )
+                    turn.transcript_anchor_at_paste = transcript_ticket.anchor
+                    turn.transcript_ticket_captured_at_ns = (
+                        transcript_ticket.captured_at_ns
+                    )
                     turn.pane_delivery_started = True
                     result = await self._tmux.paste_text(
                         turn.prompt, enter=True
@@ -9617,6 +9920,13 @@ class TmuxSession(TransportReplacementMixin):
                 turn.transcript_file_identity_at_paste
             ),
             transcript_offset_at_paste=turn.transcript_offset_at_paste,
+            transcript_anchor_start_at_paste=(
+                turn.transcript_anchor_start_at_paste
+            ),
+            transcript_anchor_at_paste=turn.transcript_anchor_at_paste,
+            transcript_ticket_captured_at_ns=(
+                turn.transcript_ticket_captured_at_ns
+            ),
             fresh_context_epoch=self._fresh_context_respawn_epoch,
         ))
         # Watchdog head-clock. If this entry just became the head (deque

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -1348,12 +1348,12 @@ class _QueuedTurn:
     # non-wake turns and for any internal turn whose enqueuer doesn't
     # care about post-delivery hooks.
     on_delivered: object = None  # Callable() -> None — fires on delivery proof
-    # #846 — replay-amplification guard. Incremented each time the inflight
-    # watchdog requeues this turn for replay after a stuck-head force_restart.
-    # Once it exceeds ``_inflight_replay_cap()`` the watchdog DROPS the turn
-    # (fires its completion_event, logs loudly) instead of requeuing it again,
-    # so a never-clearing wedge can't replay the same turn forever and grow
-    # the deque unboundedly (the murzik #846 loop).
+    # #846 — replay-amplification guard. Incremented whenever inflight recovery
+    # requeues this turn (watchdog restart, idle-phantom proof, or graceful
+    # disconnect). Once it exceeds ``_inflight_replay_cap()`` recovery DROPS
+    # the turn (fires its completion_event, logs loudly) instead of requeuing
+    # it again, so a never-clearing wedge can't replay the same turn forever
+    # and grow the deque unboundedly.
     replay_count: int = 0
     # Scheduler-only receipt. A serialized scheduler turn waits for the
     # pane to become explicitly idle before paste. True requires a matching
@@ -1710,6 +1710,13 @@ def _inflight_replay_tail_cap() -> int:
     except (TypeError, ValueError):
         val = 20
     return max(0, val)
+
+
+# #1127 — idle-phantom consumption proof only needs the recent transcript.
+# Aged candidates are minutes old, so a bounded binary tail read avoids loading
+# long-lived multi-gigabyte JSONL histories while preserving their UTF-8 header
+# bytes exactly (JSON escapes only the prompt's later newline separators).
+_PHANTOM_TRANSCRIPT_TAIL_BYTES = 4 * 1024 * 1024
 
 # Issue #570 — wake-prompt readiness-gate timeout. ``_deliver_turn`` awaits
 # ``_session_ready_event`` for turns with ``internal=True and
@@ -4291,11 +4298,11 @@ class TmuxSession(TransportReplacementMixin):
         self._processing = False
 
         # Drain the in-flight metadata deque (#560 replaces PR #496
-        # round-2's single-dict clear). Critical safety: unblock every
-        # pending ``completion_event`` BEFORE clearing the deque, so a
-        # ``wait_for_completion=True`` caller (e.g. pre-sleep save)
-        # doesn't hang forever when its turn is abandoned by a
-        # disconnect / force_restart cycle. Murzik review point #2.
+        # round-2's single-dict clear). Scheduler turns resolve False so
+        # their durable owner redelivers; plain turns replay after a warm
+        # reconnect with completion/submission receipts still pending
+        # (#1127 parity with #561). Only a replay-cap drop unblocks a plain
+        # turn as definitively abandoned.
         #
         # Also defends #496 round-1 Case 2: a straggler stop_hook_summary
         # read from a stale transcript on reconnect can't route a late
@@ -4306,13 +4313,49 @@ class TmuxSession(TransportReplacementMixin):
         # #731: session is being torn down — drop in-flight tool state so a
         # stale entry can't leak across the disconnect/reconnect boundary.
         self._inflight_tool_calls.clear()
+        replay_cap = _inflight_replay_cap()
+        replay: list[_QueuedTurn] = []
         for entry in drained:
-            if entry.completion_event is not None and not entry.completion_event.is_set():
-                entry.completion_event.set()
-            delivery = entry.turn.scheduler_delivery
-            if delivery is not None and not delivery.done():
-                delivery.set_result(False)
-            self._resolve_submission_receipt(entry.turn, False)
+            turn = entry.turn
+            delivery = turn.scheduler_delivery
+            if delivery is not None:
+                # Scheduler turns retain their existing single-owner contract:
+                # resolve False and let the durable scheduler redeliver. Also
+                # requeueing here would create two replay paths for one wake.
+                if entry.completion_event is not None and not entry.completion_event.is_set():
+                    entry.completion_event.set()
+                if not delivery.done():
+                    delivery.set_result(False)
+                self._resolve_submission_receipt(turn, False)
+                continue
+
+            # #1127 parity with the watchdog's #561/#846 replay path. Plain
+            # pasted turns survive a warm disconnect on this retained session
+            # object, and their waiters stay pending until the replay completes.
+            turn.replay_count += 1
+            if replay_cap and turn.replay_count > replay_cap:
+                header = turn.prompt.splitlines()[0] if turn.prompt else ""
+                _log(
+                    f"tmux[{self.agent_name}]: DROPPING disconnect replay "
+                    f"after {turn.replay_count - 1} replay(s) (cap={replay_cap}); "
+                    f"prompt_header={header!r}"
+                )
+                if entry.completion_event is not None and not entry.completion_event.is_set():
+                    entry.completion_event.set()
+                self._resolve_submission_receipt(turn, False)
+                continue
+
+            turn.pane_delivery_recorded = False
+            turn.pane_delivery_started = False
+            turn.pane_queue_enqueued = False
+            turn.transport_accepted = False
+            replay.append(turn)
+        self._prepend_message_queue(replay)
+        if replay:
+            _log(
+                f"tmux[{self.agent_name}]: requeued {len(replay)} plain "
+                f"inflight turn(s) across disconnect (#1127)"
+            )
 
         # Issue #547: also unblock ``_inflight_turn`` — the turn the
         # worker pulled from the queue but had NOT yet pasted (e.g.
@@ -6585,6 +6628,21 @@ class TmuxSession(TransportReplacementMixin):
             return None
         return jsonls[0] if jsonls else None
 
+    def _prepend_message_queue(self, turns: list[_QueuedTurn]) -> None:
+        """Put ``turns`` ahead of the existing backlog without changing FIFO."""
+        if not turns:
+            return
+        backlog: list[_QueuedTurn] = []
+        while not self._message_queue.empty():
+            try:
+                backlog.append(self._message_queue.get_nowait())
+            except asyncio.QueueEmpty:
+                break
+        for turn in turns:
+            self._message_queue.put_nowait(turn)
+        for turn in backlog:
+            self._message_queue.put_nowait(turn)
+
     async def _message_worker(self) -> None:
         """Drain ``_message_queue``, pasting each turn into the tmux pane.
 
@@ -6959,6 +7017,28 @@ class TmuxSession(TransportReplacementMixin):
         """
         age = self._main_transcript_age(now)
         return age is not None and age < window
+
+    def _read_phantom_transcript_tail(self) -> bytes | None:
+        """Return a bounded transcript tail for idle-phantom consumption proof.
+
+        ``None`` means the active tailer has no usable bound transcript.  The
+        caller preserves the historical drain verdict in that case, but logs
+        the missing proof distinctly.  Binary reads keep non-ASCII prompt
+        headers byte-exact and avoid JSON newline-escape mismatches (#1127).
+        """
+        tailer = self._tailer
+        path = getattr(tailer, "transcript_path", None) if tailer else None
+        if not path:
+            return None
+        try:
+            transcript = Path(path)
+            with transcript.open("rb") as handle:
+                handle.seek(0, os.SEEK_END)
+                size = handle.tell()
+                handle.seek(max(0, size - _PHANTOM_TRANSCRIPT_TAIL_BYTES))
+                return handle.read(_PHANTOM_TRANSCRIPT_TAIL_BYTES)
+        except (OSError, TypeError, ValueError):
+            return None
 
     def _background_task_recent_age(self, now: float, window: float) -> float | None:
         """Seconds since a background task last wrote a transcript, or None.
@@ -7531,35 +7611,136 @@ class TmuxSession(TransportReplacementMixin):
                     )
                     continue
                 if verdict == "idle":
-                    # #118: head aged out, transcript quiet, and the REPL last
-                    # reported idle — nothing is actually in flight, so the
-                    # lingering meta(s) are phantom (a paste with no matching
-                    # stop_hook). Reconcile by draining + firing their
-                    # completion events; do NOT restart an idle REPL. This is
-                    # the core fix for "torn down ~10min after activity even
-                    # though nothing was wedged."
-                    drained = list(self._inflight_metas)
+                    # #1127: an idle REPL proves there is no work running, but
+                    # not that every mechanically successful paste was ever
+                    # submitted.  Search each turn's single-line header in one
+                    # bounded transcript tail: present means a true phantom
+                    # stop-hook miss; absent means the REPL never consumed it.
+                    candidates = list(self._inflight_metas)
                     self._inflight_metas.clear()
                     self._head_started_at = None
                     self._inflight_pane_ext_anchor = None
-                    for m in drained:
-                        ev = m.completion_event
+                    transcript_tail = self._read_phantom_transcript_tail()
+                    replay_cap = _inflight_replay_cap()
+                    replay: list[_QueuedTurn] = []
+                    drained_count = 0
+                    dropped_count = 0
+                    if transcript_tail is None:
+                        _log(
+                            f"tmux[{self.agent_name}]: "
+                            f"PHANTOM_CONSUMPTION_PROBE_UNAVAILABLE "
+                            f"deque_depth={depth} head_age_s={age:.1f} — "
+                            f"preserving legacy drain verdict"
+                        )
+
+                    for entry in candidates:
+                        turn = entry.turn
+                        header = turn.prompt.splitlines()[0] if turn.prompt else ""
+                        try:
+                            consumed = (
+                                None
+                                if transcript_tail is None or not header
+                                else header.encode("utf-8") in transcript_tail
+                            )
+                        except UnicodeEncodeError:
+                            consumed = None
+
+                        if consumed is False:
+                            turn.replay_count += 1
+                            if replay_cap and turn.replay_count > replay_cap:
+                                dropped_count += 1
+                                _log(
+                                    f"tmux[{self.agent_name}]: DROPPING "
+                                    f"unconsumed phantom turn after "
+                                    f"{turn.replay_count - 1} replay(s) "
+                                    f"(cap={replay_cap}); "
+                                    f"prompt_header={header!r}"
+                                )
+                                ev = entry.completion_event
+                                if ev is not None and not ev.is_set():
+                                    ev.set()
+                                delivery = turn.scheduler_delivery
+                                if delivery is not None and not delivery.done():
+                                    delivery.set_result(False)
+                                self._resolve_submission_receipt(turn, False)
+                                log_watchdog_decision(
+                                    watchdog="inflight",
+                                    agent=self.agent_name,
+                                    decision="drop",
+                                    reason="phantom_replay_cap_dropped",
+                                    state=self.state.value,
+                                    progress_stale_s=age,
+                                    inflight_turns=depth,
+                                    inflight_active=False,
+                                )
+                                continue
+
+                            # The old pane occurrence has no transcript proof.
+                            # Re-arm all paste/acceptance bookkeeping so the
+                            # worker records one fresh meta for the replay.
+                            turn.pane_delivery_recorded = False
+                            turn.pane_delivery_started = False
+                            turn.pane_queue_enqueued = False
+                            turn.transport_accepted = False
+                            replay.append(turn)
+                            log_watchdog_decision(
+                                watchdog="inflight",
+                                agent=self.agent_name,
+                                decision="requeue",
+                                reason="phantom_requeued_unconsumed",
+                                state=self.state.value,
+                                progress_stale_s=age,
+                                inflight_turns=depth,
+                                inflight_active=False,
+                            )
+                            continue
+
+                        # Found: the turn started, so the missing Stop hook left
+                        # only phantom routing metadata. Unavailable: preserve
+                        # #118's historical drain behavior, already audited
+                        # above, rather than changing a binding failure into a
+                        # potentially duplicate replay.
+                        drained_count += 1
+                        ev = entry.completion_event
                         if ev is not None and not ev.is_set():
                             ev.set()
-                        delivery = m.turn.scheduler_delivery
-                        if delivery is not None and not delivery.done():
+                        delivery = turn.scheduler_delivery
+                        if consumed is True:
+                            # Reuse the exact-transcript acceptance edge so a
+                            # scheduler's durable accept callback runs before
+                            # its positive in-process receipt (#1068 contract).
+                            self._mark_transport_accepted(turn)
+                            if delivery is not None and not delivery.done():
+                                # Defensive for an inconsistent pre-accepted
+                                # turn whose receipt somehow remained pending.
+                                delivery.set_result(True)
+                        elif delivery is not None and not delivery.done():
                             delivery.set_result(False)
+                        verdict_label = (
+                            "verified_consumed"
+                            if consumed is True
+                            else "unverified_legacy_fallback"
+                        )
+                        _log(
+                            f"tmux[{self.agent_name}]: drained idle phantom "
+                            f"verdict={verdict_label} prompt_header={header!r}"
+                        )
+
+                    self._prepend_message_queue(replay)
                     _log(
                         f"tmux[{self.agent_name}]: inflight head aged {age:.1f}s "
-                        f"but REPL is idle — reconciled {len(drained)} phantom "
-                        f"meta(s), NOT restarting (#118)"
+                        f"but REPL is idle — reconciled {drained_count} phantom "
+                        f"meta(s), requeued {len(replay)} unconsumed turn(s), "
+                        f"dropped {dropped_count} capped turn(s), NOT restarting "
+                        f"(#118/#1127)"
                     )
-                    log_watchdog_decision(
-                        watchdog="inflight", agent=self.agent_name,
-                        decision="reconcile", reason="idle_phantom",
-                        state=self.state.value, progress_stale_s=age,
-                        inflight_turns=depth, inflight_active=False,
-                    )
+                    if drained_count:
+                        log_watchdog_decision(
+                            watchdog="inflight", agent=self.agent_name,
+                            decision="reconcile", reason="idle_phantom",
+                            state=self.state.value, progress_stale_s=age,
+                            inflight_turns=depth, inflight_active=False,
+                        )
                     continue
                 if verdict == "unknown":
                     # #943 prevents one stale sample from proving a wedge.
@@ -7883,16 +8064,7 @@ class TmuxSession(TransportReplacementMixin):
                     # the original backlog. Preserves FIFO across the
                     # boundary. ``asyncio.Queue`` has no put-front, so
                     # the drain+repush is the canonical pattern.
-                    backlog: list[_QueuedTurn] = []
-                    while not self._message_queue.empty():
-                        try:
-                            backlog.append(self._message_queue.get_nowait())
-                        except asyncio.QueueEmpty:
-                            break
-                    for t in replay:
-                        self._message_queue.put_nowait(t)
-                    for t in backlog:
-                        self._message_queue.put_nowait(t)
+                    self._prepend_message_queue(replay)
                     _log(
                         f"tmux[{self.agent_name}]: requeued "
                         f"{len(replay)} turn(s) for replay after "

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -1372,6 +1372,13 @@ class _QueuedTurn:
     # race ahead of the tmux command coroutine's return; in that case the
     # transcript callback records metadata before a same-read Stop row fires.
     pane_delivery_recorded: bool = False
+    # Occurrence ticket captured immediately before the physical pane paste.
+    # The idle-phantom fallback uses the exact file identity + byte boundary
+    # to prove that one complete user row belongs to this paste, rather than
+    # accepting matching text retained from an older occurrence.
+    transcript_path_at_paste: Path | None = None
+    transcript_file_identity_at_paste: tuple[int, int] | None = None
+    transcript_offset_at_paste: int | None = None
     # Wake-only exact submission receipt (#953). True requires a matching
     # transcript user row or queue enqueue→dequeue; successful tmux paste/Enter
     # commands alone are deliberately insufficient. Kept separate from the
@@ -1494,6 +1501,14 @@ class _InflightMeta:
     # this turn's paste time regardless of write lag. Both None ⇒ fall back to wedged.
     transcript_mtime_at_paste: float | None = None
     paste_succeeded_at: float | None = None
+    # Direct idle-reconcile fallback ticket. ``transcript_offset_at_paste``
+    # is the file size sampled immediately before the pane paste. The device /
+    # inode pair prevents a stale offset from hiding rows when a new transcript
+    # materializes at the same pathname; identity change or truncation resets
+    # the scan boundary to byte zero.
+    transcript_path_at_paste: Path | None = None
+    transcript_file_identity_at_paste: tuple[int, int] | None = None
+    transcript_offset_at_paste: int | None = None
     # Non-zero only for turns delivered during the active post-fresh lineage.
     # A completion may end ``_fresh_context_respawn_grace_until`` only when
     # this epoch matches the session's active epoch.  This prevents an
@@ -1711,12 +1726,6 @@ def _inflight_replay_tail_cap() -> int:
         val = 20
     return max(0, val)
 
-
-# #1127 — idle-phantom consumption proof only needs the recent transcript.
-# Aged candidates are minutes old, so a bounded binary tail read avoids loading
-# long-lived multi-gigabyte JSONL histories while preserving their UTF-8 header
-# bytes exactly (JSON escapes only the prompt's later newline separators).
-_PHANTOM_TRANSCRIPT_TAIL_BYTES = 4 * 1024 * 1024
 
 # Issue #570 — wake-prompt readiness-gate timeout. ``_deliver_turn`` awaits
 # ``_session_ready_event`` for turns with ``internal=True and
@@ -4251,9 +4260,26 @@ class TmuxSession(TransportReplacementMixin):
                 await asyncio.gather(recovery_task, return_exceptions=True)
             self._wake_submission_recovery_task = None
 
-        # Fail and cancel scheduler-only delivery tasks before tearing down the
-        # ordinary worker/pane. A pane shutdown is a terminal non-receipt.
-        for turn in list(self._scheduler_pending_turns):
+        # Fail and cancel scheduler delivery before tearing down the ordinary
+        # worker/pane. Include turns whose idle recovery transferred ownership
+        # to the ordinary queue: pane shutdown is a terminal non-receipt, and a
+        # terminal receipt may not leave an executable queue alias behind.
+        scheduler_turns = list(self._scheduler_pending_turns)
+        if self.state != SessionState.RECONNECTING:
+            # A watchdog force-restart deliberately transfers an unaccepted
+            # scheduler head into the ordinary queue before entering
+            # RECONNECTING (#943). That queue occurrence owns the still-pending
+            # receipt across replacement-pane startup. Other disconnect modes
+            # are terminal and must retire queued scheduler replay.
+            scheduler_turns.extend(
+                turn
+                for turn in self._message_queue._queue  # type: ignore[attr-defined]
+                if turn.scheduler_serialized
+            )
+        unique_scheduler_turns: dict[int, _QueuedTurn] = {}
+        for turn in scheduler_turns:
+            unique_scheduler_turns.setdefault(id(turn), turn)
+        for turn in unique_scheduler_turns.values():
             delivery = turn.scheduler_delivery
             if delivery is not None and not delivery.done():
                 delivery.set_result(False)
@@ -4265,6 +4291,13 @@ class TmuxSession(TransportReplacementMixin):
             await asyncio.gather(*scheduler_tasks, return_exceptions=True)
         self._scheduler_delivery_tasks.clear()
         self._scheduler_pending_turns.clear()
+        removed_scheduler_replays = self._remove_terminal_scheduler_replays()
+        if removed_scheduler_replays:
+            _log(
+                f"tmux[{self.agent_name}]: removed "
+                f"{removed_scheduler_replays} terminal scheduler replay "
+                f"turn(s) during disconnect"
+            )
         self._pane_queue_operations.clear()
         self._pane_dequeued_turns.clear()
         self._wake_context_reload_guard = None
@@ -4299,10 +4332,11 @@ class TmuxSession(TransportReplacementMixin):
 
         # Drain the in-flight metadata deque (#560 replaces PR #496
         # round-2's single-dict clear). Scheduler turns resolve False so
-        # their durable owner redelivers; plain turns replay after a warm
-        # reconnect with completion/submission receipts still pending
-        # (#1127 parity with #561). Only a replay-cap drop unblocks a plain
-        # turn as definitively abandoned.
+        # their durable owner redelivers; unaccepted plain turns replay after a
+        # warm reconnect with completion/submission receipts still pending.
+        # Accepted plain turns retain #561's non-replay fence because they may
+        # already have performed side effects. Only an accepted disposition or
+        # replay-cap drop unblocks a plain turn as definitively abandoned.
         #
         # Also defends #496 round-1 Case 2: a straggler stop_hook_summary
         # read from a stale transcript on reconnect can't route a late
@@ -4315,6 +4349,7 @@ class TmuxSession(TransportReplacementMixin):
         self._inflight_tool_calls.clear()
         replay_cap = _inflight_replay_cap()
         replay: list[_QueuedTurn] = []
+        drained_turn_ids = {id(entry.turn) for entry in drained}
         for entry in drained:
             turn = entry.turn
             delivery = turn.scheduler_delivery
@@ -4329,9 +4364,20 @@ class TmuxSession(TransportReplacementMixin):
                 self._resolve_submission_receipt(turn, False)
                 continue
 
-            # #1127 parity with the watchdog's #561/#846 replay path. Plain
-            # pasted turns survive a warm disconnect on this retained session
-            # object, and their waiters stay pending until the replay completes.
+            # #561 accepted-head fence: exact transport acceptance outranks
+            # teardown replay. The pane may have executed side effects even if
+            # its Stop metadata never arrived, so replay would be unsafe.
+            if turn.transport_accepted:
+                if (
+                    entry.completion_event is not None
+                    and not entry.completion_event.is_set()
+                ):
+                    entry.completion_event.set()
+                continue
+
+            # #1127 parity with the watchdog's #561/#846 replay path. Only
+            # unaccepted pasted turns survive a warm disconnect on this
+            # retained session object; waiters remain pending until replay.
             turn.replay_count += 1
             if replay_cap and turn.replay_count > replay_cap:
                 header = turn.prompt.splitlines()[0] if turn.prompt else ""
@@ -4365,14 +4411,24 @@ class TmuxSession(TransportReplacementMixin):
         # ``wait_for_completion=True`` caller hangs forever when its
         # internal turn is interrupted pre-paste.
         if self._inflight_turn is not None:
-            evt = self._inflight_turn.completion_event
-            if evt is not None and not evt.is_set():
-                evt.set()
-            delivery = self._inflight_turn.scheduler_delivery
-            if delivery is not None and not delivery.done():
-                delivery.set_result(False)
-            self._resolve_submission_receipt(self._inflight_turn, False)
-            self._inflight_turn = None
+            in_hand = self._inflight_turn
+            if id(in_hand) in drained_turn_ids:
+                # Receipt-verified wakes can legitimately remain in-hand while
+                # their exact row also owns an inflight meta. The drained-meta
+                # disposition above is authoritative: replayed occurrences keep
+                # live receipts, while accepted/dropped ones are terminal. Do
+                # not terminalize the same object a second time through this
+                # pre-paste slot.
+                self._inflight_turn = None
+            else:
+                evt = in_hand.completion_event
+                if evt is not None and not evt.is_set():
+                    evt.set()
+                delivery = in_hand.scheduler_delivery
+                if delivery is not None and not delivery.done():
+                    delivery.set_result(False)
+                self._resolve_submission_receipt(in_hand, False)
+                self._inflight_turn = None
 
         # Stop the response tailer (PR8b). Tailer instance is retained
         # so stats/path persist; only the background task is cancelled.
@@ -4620,12 +4676,55 @@ class TmuxSession(TransportReplacementMixin):
         return True
 
     def _scheduler_receipt_done(self, turn: _QueuedTurn) -> None:
-        """Forget one receipt turn by identity, preserving equal duplicates."""
+        """Retire every scheduler ownership path for one terminal receipt."""
         self._scheduler_pending_turns[:] = [
             pending
             for pending in self._scheduler_pending_turns
             if pending is not turn
         ]
+        self._remove_queued_turn(turn)
+
+    @staticmethod
+    def _scheduler_receipt_terminal(turn: _QueuedTurn) -> bool:
+        receipt = turn.scheduler_delivery
+        return receipt is not None and receipt.done()
+
+    def _transfer_scheduler_replay_ownership(self, turn: _QueuedTurn) -> None:
+        """Move one scheduler occurrence exclusively to ordinary replay."""
+        if not turn.scheduler_serialized:
+            return
+        self._scheduler_pending_turns[:] = [
+            pending
+            for pending in self._scheduler_pending_turns
+            if pending is not turn
+        ]
+
+    def _remove_queued_turn(self, target: _QueuedTurn) -> int:
+        """Remove queued occurrences of ``target`` by identity, preserving FIFO."""
+        queued = self._message_queue._queue  # type: ignore[attr-defined]
+        retained = [turn for turn in queued if turn is not target]
+        removed = len(queued) - len(retained)
+        if removed:
+            queued.clear()
+            queued.extend(retained)
+        return removed
+
+    def _remove_terminal_scheduler_replays(self) -> int:
+        """Fence queued scheduler turns whose authoritative receipt ended."""
+        queued = self._message_queue._queue  # type: ignore[attr-defined]
+        retained = [
+            turn
+            for turn in queued
+            if not (
+                turn.scheduler_serialized
+                and self._scheduler_receipt_terminal(turn)
+            )
+        ]
+        removed = len(queued) - len(retained)
+        if removed:
+            queued.clear()
+            queued.extend(retained)
+        return removed
 
     def _scheduler_delivery_done(
         self, task: asyncio.Task, turn: _QueuedTurn
@@ -4653,7 +4752,7 @@ class TmuxSession(TransportReplacementMixin):
         try:
             async with self._scheduler_delivery_lock:
                 while self.state == SessionState.CONNECTED:
-                    if receipt is None or receipt.cancelled():
+                    if receipt is None or receipt.done():
                         return
                     try:
                         self._processing = True
@@ -7018,27 +7117,142 @@ class TmuxSession(TransportReplacementMixin):
         age = self._main_transcript_age(now)
         return age is not None and age < window
 
-    def _read_phantom_transcript_tail(self) -> bytes | None:
-        """Return a bounded transcript tail for idle-phantom consumption proof.
+    def _capture_transcript_occurrence_ticket(
+        self,
+    ) -> tuple[Path | None, tuple[int, int] | None, int | None]:
+        """Snapshot the active transcript identity and EOF before one paste.
 
-        ``None`` means the active tailer has no usable bound transcript.  The
-        caller preserves the historical drain verdict in that case, but logs
-        the missing proof distinctly.  Binary reads keep non-ASCII prompt
-        headers byte-exact and avoid JSON newline-escape mismatches (#1127).
+        The transcript user row can be written before ``paste_text`` returns,
+        so the boundary must be sampled immediately before the physical paste,
+        not during post-paste metadata recording. A missing-but-bound path is a
+        valid cold-start ticket at byte zero; the first materialized file then
+        scans from its beginning.
         """
         tailer = self._tailer
-        path = getattr(tailer, "transcript_path", None) if tailer else None
-        if not path:
-            return None
+        raw_path = getattr(tailer, "transcript_path", None) if tailer else None
+        if not raw_path:
+            return (None, None, None)
         try:
-            transcript = Path(path)
-            with transcript.open("rb") as handle:
-                handle.seek(0, os.SEEK_END)
-                size = handle.tell()
-                handle.seek(max(0, size - _PHANTOM_TRANSCRIPT_TAIL_BYTES))
-                return handle.read(_PHANTOM_TRANSCRIPT_TAIL_BYTES)
-        except (OSError, TypeError, ValueError):
-            return None
+            path = Path(raw_path)
+        except (TypeError, ValueError):
+            return (None, None, None)
+        try:
+            stat = path.stat()
+        except FileNotFoundError:
+            return (path, None, 0)
+        except OSError:
+            return (path, None, None)
+        return (path, (stat.st_dev, stat.st_ino), stat.st_size)
+
+    def _phantom_consumption_verdicts(
+        self, candidates: list[_InflightMeta]
+    ) -> list[bool | None]:
+        """Allocate complete post-paste user rows to candidates one-to-one.
+
+        ``True`` proves this exact occurrence was accepted, ``False`` means a
+        usable transcript contained no allocatable occurrence, and ``None``
+        means the transcript itself was unavailable (the historical fail-safe
+        drain remains in force for that case).
+
+        Already accepted candidates still participate in FIFO row allocation:
+        acceptance outranks a missing fallback row, but an earlier accepted
+        duplicate must claim its own row so that row cannot falsely certify a
+        later unaccepted duplicate.
+        """
+        # Per candidate: either a readable source key + scan boundary, False
+        # for a usable transcript without a paste ticket, or None when no
+        # transcript can be inspected at all.
+        sources: list[
+            tuple[tuple[Path, tuple[int, int]], int] | bool | None
+        ] = []
+        scan_starts: dict[tuple[Path, tuple[int, int]], int] = {}
+        for entry in candidates:
+            path = entry.transcript_path_at_paste
+            offset = entry.transcript_offset_at_paste
+            if path is None or offset is None:
+                tailer = self._tailer
+                raw_path = (
+                    getattr(tailer, "transcript_path", None) if tailer else None
+                )
+                try:
+                    usable = bool(raw_path) and Path(raw_path).is_file()
+                except (OSError, TypeError, ValueError):
+                    usable = False
+                sources.append(False if usable else None)
+                continue
+            try:
+                transcript = Path(path)
+                stat = transcript.stat()
+            except (OSError, TypeError, ValueError):
+                sources.append(None)
+                continue
+            current_identity = (stat.st_dev, stat.st_ino)
+            start = max(0, offset)
+            if (
+                entry.transcript_file_identity_at_paste != current_identity
+                or stat.st_size < start
+            ):
+                # A new/truncated file at the same path must not inherit the
+                # predecessor's stale EOF. Its occurrence namespace starts at 0.
+                start = 0
+            key = (transcript, current_identity)
+            sources.append((key, start))
+            scan_starts[key] = min(scan_starts.get(key, start), start)
+
+        rows: dict[
+            tuple[Path, tuple[int, int]], list[tuple[int, str]]
+        ] = {}
+        unreadable: set[tuple[Path, tuple[int, int]]] = set()
+        for key, start in scan_starts.items():
+            transcript, _identity = key
+            found: list[tuple[int, str]] = []
+            try:
+                with transcript.open("rb") as handle:
+                    handle.seek(start)
+                    while True:
+                        row_offset = handle.tell()
+                        raw = handle.readline()
+                        if not raw:
+                            break
+                        try:
+                            parsed = json.loads(raw)
+                        except (json.JSONDecodeError, UnicodeDecodeError):
+                            continue
+                        if not isinstance(parsed, dict) or parsed.get("type") != "user":
+                            continue
+                        prompt = self._transcript_user_text(parsed)
+                        if prompt is not None:
+                            found.append((row_offset, prompt))
+            except (OSError, TypeError, ValueError):
+                unreadable.add(key)
+            rows[key] = found
+
+        used: set[tuple[tuple[Path, tuple[int, int]], int]] = set()
+        verdicts: list[bool | None] = []
+        for entry, source in zip(candidates, sources, strict=True):
+            claimed = False
+            if isinstance(source, tuple):
+                key, start = source
+                if key not in unreadable:
+                    for row_offset, prompt in rows.get(key, []):
+                        occurrence = (key, row_offset)
+                        if (
+                            row_offset >= start
+                            and occurrence not in used
+                            and prompt == entry.turn.prompt
+                        ):
+                            used.add(occurrence)
+                            claimed = True
+                            break
+                else:
+                    source = None
+            if entry.turn.transport_accepted:
+                verdicts.append(True)
+            elif source is None:
+                verdicts.append(None)
+            else:
+                verdicts.append(claimed)
+        return verdicts
 
     def _background_task_recent_age(self, now: float, window: float) -> float | None:
         """Seconds since a background task last wrote a transcript, or None.
@@ -7611,41 +7825,66 @@ class TmuxSession(TransportReplacementMixin):
                     )
                     continue
                 if verdict == "idle":
-                    # #1127: an idle REPL proves there is no work running, but
-                    # not that every mechanically successful paste was ever
-                    # submitted.  Search each turn's single-line header in one
-                    # bounded transcript tail: present means a true phantom
-                    # stop-hook miss; absent means the REPL never consumed it.
+                    # #1127/#1128: an idle REPL proves there is no work running,
+                    # but not that every mechanically successful paste was ever
+                    # submitted. Allocate complete ``type=user`` rows from each
+                    # turn's post-paste transcript boundary, FIFO and one-to-one.
+                    # Existing exact acceptance remains authoritative, while an
+                    # older/equal prompt occurrence cannot certify a new paste.
                     candidates = list(self._inflight_metas)
+                    consumption_verdicts = self._phantom_consumption_verdicts(
+                        candidates
+                    )
                     self._inflight_metas.clear()
                     self._head_started_at = None
                     self._inflight_pane_ext_anchor = None
-                    transcript_tail = self._read_phantom_transcript_tail()
                     replay_cap = _inflight_replay_cap()
                     replay: list[_QueuedTurn] = []
                     drained_count = 0
                     dropped_count = 0
-                    if transcript_tail is None:
+                    terminal_fenced_count = 0
+                    unavailable_count = sum(
+                        consumed is None for consumed in consumption_verdicts
+                    )
+                    if unavailable_count:
                         _log(
                             f"tmux[{self.agent_name}]: "
                             f"PHANTOM_CONSUMPTION_PROBE_UNAVAILABLE "
+                            f"unavailable={unavailable_count} "
                             f"deque_depth={depth} head_age_s={age:.1f} — "
                             f"preserving legacy drain verdict"
                         )
 
-                    for entry in candidates:
+                    for entry, consumed in zip(
+                        candidates, consumption_verdicts, strict=True
+                    ):
                         turn = entry.turn
                         header = turn.prompt.splitlines()[0] if turn.prompt else ""
-                        try:
-                            consumed = (
-                                None
-                                if transcript_tail is None or not header
-                                else header.encode("utf-8") in transcript_tail
-                            )
-                        except UnicodeEncodeError:
-                            consumed = None
 
                         if consumed is False:
+                            if turn.scheduler_serialized:
+                                # The ordinary queue becomes the sole replay
+                                # owner before the turn is made visible there.
+                                # A receipt that ended during reconciliation
+                                # fences the occurrence instead of enqueueing it.
+                                self._transfer_scheduler_replay_ownership(turn)
+                                if self._scheduler_receipt_terminal(turn):
+                                    terminal_fenced_count += 1
+                                    ev = entry.completion_event
+                                    if ev is not None and not ev.is_set():
+                                        ev.set()
+                                    self._resolve_submission_receipt(turn, False)
+                                    log_watchdog_decision(
+                                        watchdog="inflight",
+                                        agent=self.agent_name,
+                                        decision="drop",
+                                        reason="phantom_scheduler_receipt_terminal",
+                                        state=self.state.value,
+                                        progress_stale_s=age,
+                                        inflight_turns=depth,
+                                        inflight_active=False,
+                                    )
+                                    continue
                             turn.replay_count += 1
                             if replay_cap and turn.replay_count > replay_cap:
                                 dropped_count += 1
@@ -7731,7 +7970,9 @@ class TmuxSession(TransportReplacementMixin):
                         f"tmux[{self.agent_name}]: inflight head aged {age:.1f}s "
                         f"but REPL is idle — reconciled {drained_count} phantom "
                         f"meta(s), requeued {len(replay)} unconsumed turn(s), "
-                        f"dropped {dropped_count} capped turn(s), NOT restarting "
+                        f"dropped {dropped_count} capped turn(s), fenced "
+                        f"{terminal_fenced_count} terminal scheduler turn(s), "
+                        f"NOT restarting "
                         f"(#118/#1127)"
                     )
                     if drained_count:
@@ -7973,6 +8214,18 @@ class TmuxSession(TransportReplacementMixin):
 
                 def _consider_replay(t: _QueuedTurn, *, kind: str) -> bool:
                     ev = t.completion_event
+                    if (
+                        t.scheduler_serialized
+                        and self._scheduler_receipt_terminal(t)
+                    ):
+                        self._transfer_scheduler_replay_ownership(t)
+                        if ev is not None and not ev.is_set():
+                            ev.set()
+                        _log(
+                            f"tmux[{self.agent_name}]: skipping replay of "
+                            f"terminal-receipt {kind} scheduler turn"
+                        )
+                        return False
                     if ev is not None and ev.is_set():
                         _log(
                             f"tmux[{self.agent_name}]: skipping replay of "
@@ -8024,11 +8277,7 @@ class TmuxSession(TransportReplacementMixin):
                     # replay candidate, while still waiting behind earlier
                     # work.
                     if head.turn.scheduler_serialized:
-                        self._scheduler_pending_turns[:] = [
-                            pending
-                            for pending in self._scheduler_pending_turns
-                            if pending is not head.turn
-                        ]
+                        self._transfer_scheduler_replay_ownership(head.turn)
                     # Any enqueue/dequeue evidence belonged to the killed pane.
                     # Re-arm exact matching for the replacement paste.
                     head.turn.pane_delivery_started = False
@@ -8140,18 +8389,14 @@ class TmuxSession(TransportReplacementMixin):
         if not turn.scheduler_serialized:
             return
 
+        if self._scheduler_receipt_terminal(turn):
+            raise _SchedulerDeliveryCancelled
         while self._scheduler_pane_busy(turn):
-            if (
-                turn.scheduler_delivery is not None
-                and turn.scheduler_delivery.cancelled()
-            ):
+            if self._scheduler_receipt_terminal(turn):
                 raise _SchedulerDeliveryCancelled
             await asyncio.sleep(0.25)
 
-        if (
-            turn.scheduler_delivery is not None
-            and turn.scheduler_delivery.cancelled()
-        ):
+        if self._scheduler_receipt_terminal(turn):
             raise _SchedulerDeliveryCancelled
 
     def _scheduler_pane_busy(
@@ -9230,8 +9475,7 @@ class TmuxSession(TransportReplacementMixin):
                 # instead.
                 if (
                     turn.scheduler_serialized
-                    and turn.scheduler_delivery is not None
-                    and turn.scheduler_delivery.cancelled()
+                    and self._scheduler_receipt_terminal(turn)
                 ):
                     raise _SchedulerDeliveryCancelled
                 # An ordinary send can win the REPL lock after the scheduler's
@@ -9244,6 +9488,11 @@ class TmuxSession(TransportReplacementMixin):
                     retry_scheduler_gate = True
                 else:
                     retry_scheduler_gate = False
+                    (
+                        turn.transcript_path_at_paste,
+                        turn.transcript_file_identity_at_paste,
+                        turn.transcript_offset_at_paste,
+                    ) = self._capture_transcript_occurrence_ticket()
                     turn.pane_delivery_started = True
                     result = await self._tmux.paste_text(
                         turn.prompt, enter=True
@@ -9363,6 +9612,11 @@ class TmuxSession(TransportReplacementMixin):
             turn=turn,
             transcript_mtime_at_paste=_tmtime_at_paste,
             paste_succeeded_at=_paste_succeeded_at,
+            transcript_path_at_paste=turn.transcript_path_at_paste,
+            transcript_file_identity_at_paste=(
+                turn.transcript_file_identity_at_paste
+            ),
+            transcript_offset_at_paste=turn.transcript_offset_at_paste,
             fresh_context_epoch=self._fresh_context_respawn_epoch,
         ))
         # Watchdog head-clock. If this entry just became the head (deque

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -7294,7 +7294,9 @@ class TmuxSession(TransportReplacementMixin):
         sources: list[_TranscriptCandidateSource | None] = []
         handles: dict[_TranscriptSourceKey, object] = {}
         scan_starts: dict[_TranscriptSourceKey, int] = {}
-        budget_remaining: dict[_TranscriptSourceKey, int] = {}
+        # One reconciliation gets one bounded synchronous-read budget across
+        # every physical transcript source, including boundary-anchor reads.
+        budget_remaining = _PHANTOM_TRANSCRIPT_SCAN_BYTES
         anchor_checks: dict[
             tuple[_TranscriptSourceKey, int, int, bytes],
             bool,
@@ -7339,9 +7341,6 @@ class TmuxSession(TransportReplacementMixin):
 
                 key = (opened.st_dev, opened.st_ino)
                 handles.setdefault(key, handle)
-                budget_remaining.setdefault(
-                    key, _PHANTOM_TRANSCRIPT_SCAN_BYTES
-                )
                 ticket_identity = entry.transcript_file_identity_at_paste
                 offset = entry.transcript_offset_at_paste
 
@@ -7374,7 +7373,7 @@ class TmuxSession(TransportReplacementMixin):
                         cached = anchor_checks.get(check_key)
                         if cached is not None:
                             epoch_stable = cached
-                        elif len(anchor) <= budget_remaining[key]:
+                        elif len(anchor) <= budget_remaining:
                             try:
                                 current_anchor = os.pread(
                                     descriptor,
@@ -7384,7 +7383,7 @@ class TmuxSession(TransportReplacementMixin):
                             except OSError:
                                 guard_valid = False
                             else:
-                                budget_remaining[key] -= len(current_anchor)
+                                budget_remaining -= len(current_anchor)
                                 epoch_stable = (
                                     len(current_anchor) == len(anchor)
                                     and current_anchor == anchor
@@ -7452,15 +7451,14 @@ class TmuxSession(TransportReplacementMixin):
             for key, start in scan_starts.items():
                 found: list[tuple[int, int, str, bytes]] = []
                 handle = handles[key]
-                remaining = budget_remaining[key]
                 try:
                     handle.seek(start)
-                    while remaining > 0:
+                    while budget_remaining > 0:
                         row_offset = handle.tell()
-                        raw = handle.readline(remaining)
+                        raw = handle.readline(budget_remaining)
                         if not raw:
                             break
-                        remaining -= len(raw)
+                        budget_remaining -= len(raw)
                         if not raw.endswith(b"\n"):
                             incomplete.add(key)
                             break
@@ -7525,13 +7523,24 @@ class TmuxSession(TransportReplacementMixin):
                         offset is not None
                         and anchor_start is not None
                         and anchor is not None
-                        and row_offset >= anchor_start
                         and row_end <= offset
                     ):
-                        relative_start = row_offset - anchor_start
-                        relative_end = row_end - anchor_start
-                        prior = anchor[relative_start:relative_end]
-                        paste_bound = len(prior) == len(raw) and prior != raw
+                        overlap_start = max(row_offset, anchor_start)
+                        overlap_end = min(row_end, offset)
+                        if overlap_start < overlap_end:
+                            prior_start = overlap_start - anchor_start
+                            prior_end = overlap_end - anchor_start
+                            current_start = overlap_start - row_offset
+                            current_end = overlap_end - row_offset
+                            prior = anchor[prior_start:prior_end]
+                            current = raw[current_start:current_end]
+                            # JSONL rows are atomic: any changed byte in the
+                            # captured extent proves a post-ticket rewrite.
+                            # An identical partial overlap remains non-positive
+                            # because the uncaptured prefix is unknowable.
+                            paste_bound = (
+                                len(prior) == len(current) and prior != current
+                            )
 
                 if entry.turn.transport_accepted:
                     verdicts.append(True)

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -95,6 +95,19 @@ def _seed_inflight(
     return entry
 
 
+def _bind_transcript_ticket(
+    entry: _InflightMeta,
+    transcript: Path,
+    *,
+    offset: int = 0,
+) -> None:
+    """Attach a production-shaped pre-paste transcript occurrence ticket."""
+    stat = transcript.stat()
+    entry.transcript_path_at_paste = transcript
+    entry.transcript_file_identity_at_paste = (stat.st_dev, stat.st_ino)
+    entry.transcript_offset_at_paste = offset
+
+
 def _ok() -> TmuxCommandResult:
     """Successful tmux command result."""
     return TmuxCommandResult(returncode=0, stdout="", stderr="")
@@ -5284,22 +5297,103 @@ def test_transcript_recently_grew(tmp_path) -> None:
     assert ss._transcript_recently_grew(now, 600.0) is False
 
 
-def test_phantom_consumption_probe_reads_only_bounded_tail(tmp_path) -> None:
-    """#1127: old matching text outside the 4 MiB window is not consumption."""
+def test_phantom_consumption_requires_post_paste_occurrence(tmp_path) -> None:
+    """A retained exact prompt before this paste boundary is not acceptance."""
     ss, _ = _make_session(state=SessionState.CONNECTED)
     transcript = tmp_path / "transcript.jsonl"
-    old_header = b"[agent | old-sender | internal | old]\n"
-    transcript.write_bytes(
-        old_header + b"x" * (tmux_session._PHANTOM_TRANSCRIPT_TAIL_BYTES + 1)
+    prompt = "Scheduled wake: heartbeat\nrun the recurring check"
+    transcript.write_text(
+        _json.dumps({"type": "user", "message": {"content": prompt}}) + "\n"
     )
     ss._tailer = MagicMock()
     ss._tailer.transcript_path = transcript
+    entry = _seed_inflight(ss, prompt=prompt, transport_accepted=False)
+    _bind_transcript_ticket(entry, transcript, offset=transcript.stat().st_size)
+    with transcript.open("a", encoding="utf-8") as handle:
+        handle.write('{"type":"system"}\n')
 
-    tail = ss._read_phantom_transcript_tail()
+    assert ss._phantom_consumption_verdicts([entry]) == [False]
 
-    assert tail is not None
-    assert len(tail) == tmux_session._PHANTOM_TRANSCRIPT_TAIL_BYTES
-    assert old_header.rstrip() not in tail
+
+def test_phantom_consumption_same_path_new_file_resets_stale_offset(
+    tmp_path,
+) -> None:
+    """A replacement file at the same path starts a new byte namespace."""
+    ss, _ = _make_session(state=SessionState.CONNECTED)
+    transcript = tmp_path / "transcript.jsonl"
+    transcript.write_text('{"type":"system"}\n' + "x" * 4096)
+    ss._tailer = MagicMock()
+    ss._tailer.transcript_path = transcript
+    prompt = "same-path replacement prompt"
+    entry = _seed_inflight(ss, prompt=prompt, transport_accepted=False)
+    old_identity = (transcript.stat().st_dev, transcript.stat().st_ino)
+    _bind_transcript_ticket(entry, transcript, offset=transcript.stat().st_size)
+
+    replacement = tmp_path / "replacement.jsonl"
+    replacement.write_text(
+        _json.dumps({"type": "user", "message": {"content": prompt}}) + "\n"
+    )
+    replacement.replace(transcript)
+    assert (transcript.stat().st_dev, transcript.stat().st_ino) != old_identity
+
+    assert ss._phantom_consumption_verdicts([entry]) == [True]
+
+
+def test_phantom_consumption_accepted_duplicate_claims_fifo_row(tmp_path) -> None:
+    """An accepted earlier duplicate cannot donate its row to a later paste."""
+    ss, _ = _make_session(state=SessionState.CONNECTED)
+    transcript = tmp_path / "transcript.jsonl"
+    prompt = "duplicate complete prompt"
+    transcript.write_text(
+        _json.dumps({"type": "user", "message": {"content": prompt}}) + "\n"
+    )
+    ss._tailer = MagicMock()
+    ss._tailer.transcript_path = transcript
+    accepted = _seed_inflight(ss, prompt=prompt, transport_accepted=True)
+    unaccepted = _seed_inflight(ss, prompt=prompt, transport_accepted=False)
+    _bind_transcript_ticket(accepted, transcript)
+    _bind_transcript_ticket(unaccepted, transcript)
+
+    assert ss._phantom_consumption_verdicts([accepted, unaccepted]) == [
+        True,
+        False,
+    ]
+
+
+@pytest.mark.asyncio
+async def test_deliver_turn_captures_occurrence_boundary_before_paste(
+    tmp_path,
+) -> None:
+    """The fallback ticket predates even a user row written during paste."""
+    transcript = tmp_path / "transcript.jsonl"
+    transcript.write_text('{"type":"system"}\n')
+    initial_size = transcript.stat().st_size
+    prompt = "prompt written before paste coroutine returns"
+    tmux = _make_mock_tmux()
+
+    async def paste_text(body: str, *, enter: bool = True) -> TmuxCommandResult:
+        assert body == prompt
+        assert enter is True
+        with transcript.open("a", encoding="utf-8") as handle:
+            handle.write(
+                _json.dumps({"type": "user", "message": {"content": body}})
+                + "\n"
+            )
+        return _ok()
+
+    tmux.paste_text = AsyncMock(side_effect=paste_text)
+    ss, _ = _make_session(state=SessionState.CONNECTED, tmux=tmux)
+    ss._tailer = MagicMock()
+    ss._tailer.transcript_path = transcript
+    ss._tailer.mark_active = MagicMock()
+    turn = _QueuedTurn(prompt=prompt)
+
+    await ss._deliver_turn(turn)
+
+    assert len(ss._inflight_metas) == 1
+    entry = ss._inflight_metas[0]
+    assert entry.transcript_offset_at_paste == initial_size
+    assert ss._phantom_consumption_verdicts([entry]) == [True]
 
 
 @pytest.mark.asyncio
@@ -5391,8 +5485,13 @@ async def test_idle_phantom_verified_consumed_resolves_scheduler_true(
     completion = asyncio.Event()
     delivery = asyncio.get_running_loop().create_future()
     durable_accept = MagicMock(return_value=True)
-    entry = _seed_inflight(ss, prompt=prompt, completion_event=completion)
-    entry.turn.transport_accepted = False
+    entry = _seed_inflight(
+        ss,
+        prompt=prompt,
+        completion_event=completion,
+        transport_accepted=False,
+    )
+    _bind_transcript_ticket(entry, transcript)
     entry.turn.scheduler_delivery = delivery
     entry.turn.scheduler_accept = durable_accept
     ss._head_started_at = _time.time() - 1.0
@@ -5428,8 +5527,12 @@ async def test_idle_phantom_unconsumed_requeues_at_front(monkeypatch, tmp_path) 
     completion = asyncio.Event()
     prompt = "[agent | sender | internal | 2026-08-19T06:01:00-07:00]\nbody"
     original = _seed_inflight(
-        ss, prompt=prompt, completion_event=completion,
-    ).turn
+        ss,
+        prompt=prompt,
+        completion_event=completion,
+        transport_accepted=False,
+    )
+    _bind_transcript_ticket(original, transcript)
     backlog = _QueuedTurn(prompt="later backlog")
     ss._message_queue.put_nowait(backlog)
     ss._head_started_at = _time.time() - 1.0
@@ -5437,8 +5540,8 @@ async def test_idle_phantom_unconsumed_requeues_at_front(monkeypatch, tmp_path) 
     await _run_idle_reconcile(ss)
 
     assert not completion.is_set()
-    assert original.replay_count == 1
-    assert ss._message_queue.get_nowait() is original
+    assert original.turn.replay_count == 1
+    assert ss._message_queue.get_nowait() is original.turn
     assert ss._message_queue.get_nowait() is backlog
     assert any(
         call.kwargs.get("reason") == "phantom_requeued_unconsumed"
@@ -5471,9 +5574,14 @@ async def test_idle_phantom_replay_cap_drops_loudly(
     completion = asyncio.Event()
     submission = asyncio.get_running_loop().create_future()
     header = "[agent | sender | internal | 2026-08-19T06:02:00-07:00]"
-    turn = _seed_inflight(
-        ss, prompt=f"{header}\nbody", completion_event=completion,
-    ).turn
+    entry = _seed_inflight(
+        ss,
+        prompt=f"{header}\nbody",
+        completion_event=completion,
+        transport_accepted=False,
+    )
+    _bind_transcript_ticket(entry, transcript)
+    turn = entry.turn
     turn.submission_receipt = submission
     turn.replay_count = 1
     ss._head_started_at = _time.time() - 1.0
@@ -5507,7 +5615,12 @@ async def test_idle_phantom_without_transcript_preserves_drain_with_audit(
     ss._transcript_recently_grew = lambda *_args: False
     ss._tailer = None
     completion = asyncio.Event()
-    _seed_inflight(ss, prompt="header\nbody", completion_event=completion)
+    _seed_inflight(
+        ss,
+        prompt="header\nbody",
+        completion_event=completion,
+        transport_accepted=False,
+    )
     ss._head_started_at = _time.time() - 1.0
 
     await _run_idle_reconcile(ss)
@@ -5550,12 +5663,20 @@ async def test_idle_phantom_mixed_deque_verdicts_per_meta(
     unconsumed_event = asyncio.Event()
     consumed_delivery = asyncio.get_running_loop().create_future()
     consumed = _seed_inflight(
-        ss, prompt=consumed_prompt, completion_event=consumed_event,
+        ss,
+        prompt=consumed_prompt,
+        completion_event=consumed_event,
+        transport_accepted=False,
     )
     consumed.turn.scheduler_delivery = consumed_delivery
     unconsumed = _seed_inflight(
-        ss, prompt=unconsumed_prompt, completion_event=unconsumed_event,
+        ss,
+        prompt=unconsumed_prompt,
+        completion_event=unconsumed_event,
+        transport_accepted=False,
     )
+    _bind_transcript_ticket(consumed, transcript)
+    _bind_transcript_ticket(unconsumed, transcript)
     ss._head_started_at = _time.time() - 1.0
 
     await _run_idle_reconcile(ss)
@@ -8859,13 +8980,21 @@ class TestInflightDequeConcurrentDispatch:
         event1 = asyncio.Event()
         event2 = asyncio.Event()
         turn1 = _seed_inflight(
-            ss, internal=True, completion_event=event1,
+            ss,
+            internal=True,
+            completion_event=event1,
+            transport_accepted=False,
         ).turn
         turn2 = _seed_inflight(
-            ss, meta={"platform": "t", "chat_id": "c", "message_id": "m"},
+            ss,
+            meta={"platform": "t", "chat_id": "c", "message_id": "m"},
+            transport_accepted=False,
         ).turn
         turn3 = _seed_inflight(
-            ss, internal=True, completion_event=event2,
+            ss,
+            internal=True,
+            completion_event=event2,
+            transport_accepted=False,
         ).turn
         assert len(ss._inflight_metas) == 3
 
@@ -8893,12 +9022,14 @@ class TestInflightDequeConcurrentDispatch:
             ss,
             prompt="plain prompt",
             completion_event=plain_event,
+            transport_accepted=False,
         ).turn
         plain.submission_receipt = plain_submission
         scheduler = _seed_inflight(
             ss,
             prompt="scheduler prompt",
             completion_event=scheduler_event,
+            transport_accepted=False,
         ).turn
         scheduler.scheduler_delivery = scheduler_delivery
 
@@ -8923,6 +9054,7 @@ class TestInflightDequeConcurrentDispatch:
             ss,
             prompt="capped plain prompt",
             completion_event=completion,
+            transport_accepted=False,
         ).turn
         turn.submission_receipt = submission
         turn.replay_count = 1

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -106,6 +106,13 @@ def _bind_transcript_ticket(
     entry.transcript_path_at_paste = transcript
     entry.transcript_file_identity_at_paste = (stat.st_dev, stat.st_ino)
     entry.transcript_offset_at_paste = offset
+    anchor_start = max(0, offset - 4096)
+    with transcript.open("rb") as handle:
+        handle.seek(anchor_start)
+        anchor = handle.read(offset - anchor_start)
+    entry.transcript_anchor_start_at_paste = anchor_start
+    entry.transcript_anchor_at_paste = anchor
+    entry.transcript_ticket_captured_at_ns = _time.time_ns()
 
 
 def _ok() -> TmuxCommandResult:
@@ -5318,7 +5325,7 @@ def test_phantom_consumption_requires_post_paste_occurrence(tmp_path) -> None:
 def test_phantom_consumption_same_path_new_file_resets_stale_offset(
     tmp_path,
 ) -> None:
-    """A replacement file at the same path starts a new byte namespace."""
+    """A replacement file reserves rows but cannot prove this paste."""
     ss, _ = _make_session(state=SessionState.CONNECTED)
     transcript = tmp_path / "transcript.jsonl"
     transcript.write_text('{"type":"system"}\n' + "x" * 4096)
@@ -5336,7 +5343,65 @@ def test_phantom_consumption_same_path_new_file_resets_stale_offset(
     replacement.replace(transcript)
     assert (transcript.stat().st_dev, transcript.stat().st_ino) != old_identity
 
-    assert ss._phantom_consumption_verdicts([entry]) == [True]
+    assert ss._phantom_consumption_verdicts([entry]) == [False]
+
+
+def test_phantom_consumption_same_inode_identical_old_row_is_not_proof(
+    tmp_path,
+) -> None:
+    """An epoch rewrite cannot promote a byte-identical retained occurrence."""
+    ss, _ = _make_session(state=SessionState.CONNECTED)
+    transcript = tmp_path / "transcript.jsonl"
+    prompt = "same-inode retained recurring prompt"
+    row = (
+        _json.dumps({"type": "user", "message": {"content": prompt}}) + "\n"
+    ).encode()
+    transcript.write_bytes(row + b"x" * 1024)
+    ss._tailer = MagicMock()
+    ss._tailer.transcript_path = transcript
+    entry = _seed_inflight(ss, prompt=prompt, transport_accepted=False)
+    before = transcript.stat()
+    _bind_transcript_ticket(entry, transcript, offset=before.st_size)
+
+    transcript.write_bytes(row + b" " * 2048)
+    after = transcript.stat()
+    assert (after.st_dev, after.st_ino) == (before.st_dev, before.st_ino)
+    assert after.st_size > before.st_size
+
+    assert ss._phantom_consumption_verdicts([entry]) == [False]
+
+
+def test_capture_occurrence_ticket_binds_opened_descriptor(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    """A path swap after stat binds the descriptor actually opened."""
+    ss, _ = _make_session(state=SessionState.CONNECTED)
+    transcript = tmp_path / "transcript.jsonl"
+    replacement = tmp_path / "replacement.jsonl"
+    transcript.write_bytes(b"old transcript")
+    replacement.write_bytes(b'{"type":"system"}\n')
+    ss._tailer = MagicMock()
+    ss._tailer.transcript_path = transcript
+    original_open = Path.open
+    swapped = False
+
+    def racing_open(path: Path, *args, **kwargs):
+        nonlocal swapped
+        mode = args[0] if args else kwargs.get("mode", "r")
+        if path == transcript and mode == "rb" and not swapped:
+            replacement.replace(transcript)
+            swapped = True
+        return original_open(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "open", racing_open)
+
+    ticket = ss._capture_transcript_occurrence_ticket()
+    identity = (transcript.stat().st_dev, transcript.stat().st_ino)
+    assert tuple(ticket) == (transcript, identity, transcript.stat().st_size)
+    assert ticket.anchor_start == 0
+    assert ticket.anchor == b'{"type":"system"}\n'
+    assert ticket.captured_at_ns is not None
 
 
 def test_phantom_consumption_accepted_duplicate_claims_fifo_row(tmp_path) -> None:
@@ -5358,6 +5423,32 @@ def test_phantom_consumption_accepted_duplicate_claims_fifo_row(tmp_path) -> Non
         True,
         False,
     ]
+
+
+def test_phantom_consumption_early_stop_respects_each_candidate_boundary(
+    tmp_path,
+) -> None:
+    """Rows before a later ticket do not satisfy its allocation demand."""
+    ss, _ = _make_session(state=SessionState.CONNECTED)
+    transcript = tmp_path / "transcript.jsonl"
+    transcript.touch()
+    ss._tailer = MagicMock()
+    ss._tailer.transcript_path = transcript
+    prompt = "duplicate prompt across distinct paste boundaries"
+    row = (
+        _json.dumps({"type": "user", "message": {"content": prompt}}) + "\n"
+    ).encode()
+    first = _seed_inflight(ss, prompt=prompt, transport_accepted=False)
+    _bind_transcript_ticket(first, transcript, offset=0)
+
+    transcript.write_bytes(row + row)
+    second_start = transcript.stat().st_size
+    second = _seed_inflight(ss, prompt=prompt, transport_accepted=False)
+    _bind_transcript_ticket(second, transcript, offset=second_start)
+    with transcript.open("ab") as handle:
+        handle.write(row)
+
+    assert ss._phantom_consumption_verdicts([first, second]) == [True, True]
 
 
 @pytest.mark.asyncio
@@ -5393,6 +5484,9 @@ async def test_deliver_turn_captures_occurrence_boundary_before_paste(
     assert len(ss._inflight_metas) == 1
     entry = ss._inflight_metas[0]
     assert entry.transcript_offset_at_paste == initial_size
+    assert entry.transcript_anchor_start_at_paste == 0
+    assert entry.transcript_anchor_at_paste == b'{"type":"system"}\n'
+    assert entry.transcript_ticket_captured_at_ns is not None
     assert ss._phantom_consumption_verdicts([entry]) == [True]
 
 

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -5284,6 +5284,24 @@ def test_transcript_recently_grew(tmp_path) -> None:
     assert ss._transcript_recently_grew(now, 600.0) is False
 
 
+def test_phantom_consumption_probe_reads_only_bounded_tail(tmp_path) -> None:
+    """#1127: old matching text outside the 4 MiB window is not consumption."""
+    ss, _ = _make_session(state=SessionState.CONNECTED)
+    transcript = tmp_path / "transcript.jsonl"
+    old_header = b"[agent | old-sender | internal | old]\n"
+    transcript.write_bytes(
+        old_header + b"x" * (tmux_session._PHANTOM_TRANSCRIPT_TAIL_BYTES + 1)
+    )
+    ss._tailer = MagicMock()
+    ss._tailer.transcript_path = transcript
+
+    tail = ss._read_phantom_transcript_tail()
+
+    assert tail is not None
+    assert len(tail) == tmux_session._PHANTOM_TRANSCRIPT_TAIL_BYTES
+    assert old_header.rstrip() not in tail
+
+
 @pytest.mark.asyncio
 async def test_inflight_watchdog_drains_phantom_when_repl_idle(monkeypatch) -> None:
     """#118 end-to-end: an aged-out head with a quiet transcript and an idle
@@ -5328,6 +5346,225 @@ async def test_inflight_watchdog_drains_phantom_when_repl_idle(monkeypatch) -> N
     assert restarted["v"] is False, "must NOT restart an idle REPL"
     assert len(ss._inflight_metas) == 0, "phantom meta must be drained"
     assert ss._head_started_at is None
+
+
+async def _run_idle_reconcile(ss: TmuxSession) -> None:
+    """Run the fast-clock watchdog until its idle verdict mutates the deque."""
+    task = asyncio.create_task(ss._inflight_watchdog())
+    try:
+        for _ in range(200):
+            if not ss._inflight_metas:
+                break
+            await asyncio.sleep(0.01)
+        else:
+            pytest.fail("watchdog did not reconcile the aged idle deque")
+    finally:
+        task.cancel()
+        await task
+
+
+@pytest.mark.asyncio
+async def test_idle_phantom_verified_consumed_resolves_scheduler_true(
+    monkeypatch, tmp_path, capsys,
+) -> None:
+    """#1127: transcript presence proves execution and suppresses wake replay."""
+    monkeypatch.setattr(tmux_session, "_TURN_DONE_TIMEOUT_SEC", 0.01)
+    monkeypatch.setattr(tmux_session, "_WATCHDOG_TICK_SEC", 0.01)
+
+    ss, _ = _make_session(state=SessionState.CONNECTED)
+    ss._config.live_status_fn = lambda: {
+        "status": "idle",
+        "last_updated": _time.time(),
+    }
+    ss._transcript_recently_grew = lambda *_args: False
+    header = "[agent | sender-猫 | internal | 2026-08-19T06:00:00-07:00]"
+    prompt = f"{header}\nverdict body"
+    transcript = tmp_path / "transcript.jsonl"
+    transcript.write_text(
+        _json.dumps({"type": "user", "message": {"content": prompt}}, ensure_ascii=False)
+        + "\n",
+        encoding="utf-8",
+    )
+    ss._tailer = MagicMock()
+    ss._tailer.transcript_path = transcript
+
+    completion = asyncio.Event()
+    delivery = asyncio.get_running_loop().create_future()
+    durable_accept = MagicMock(return_value=True)
+    entry = _seed_inflight(ss, prompt=prompt, completion_event=completion)
+    entry.turn.transport_accepted = False
+    entry.turn.scheduler_delivery = delivery
+    entry.turn.scheduler_accept = durable_accept
+    ss._head_started_at = _time.time() - 1.0
+
+    await _run_idle_reconcile(ss)
+
+    assert completion.is_set()
+    assert delivery.result() is True
+    durable_accept.assert_called_once_with()
+    assert header in capsys.readouterr().err
+    assert ss._message_queue.empty()
+
+
+@pytest.mark.asyncio
+async def test_idle_phantom_unconsumed_requeues_at_front(monkeypatch, tmp_path) -> None:
+    """#1127: a header absent from the transcript is replayed, not completed."""
+    monkeypatch.setattr(tmux_session, "_TURN_DONE_TIMEOUT_SEC", 0.01)
+    monkeypatch.setattr(tmux_session, "_WATCHDOG_TICK_SEC", 0.01)
+    decisions = MagicMock()
+    monkeypatch.setattr(tmux_session, "log_watchdog_decision", decisions)
+
+    ss, _ = _make_session(state=SessionState.CONNECTED)
+    ss._config.live_status_fn = lambda: {
+        "status": "idle",
+        "last_updated": _time.time(),
+    }
+    ss._transcript_recently_grew = lambda *_args: False
+    transcript = tmp_path / "transcript.jsonl"
+    transcript.write_text('{"type":"system"}\n')
+    ss._tailer = MagicMock()
+    ss._tailer.transcript_path = transcript
+
+    completion = asyncio.Event()
+    prompt = "[agent | sender | internal | 2026-08-19T06:01:00-07:00]\nbody"
+    original = _seed_inflight(
+        ss, prompt=prompt, completion_event=completion,
+    ).turn
+    backlog = _QueuedTurn(prompt="later backlog")
+    ss._message_queue.put_nowait(backlog)
+    ss._head_started_at = _time.time() - 1.0
+
+    await _run_idle_reconcile(ss)
+
+    assert not completion.is_set()
+    assert original.replay_count == 1
+    assert ss._message_queue.get_nowait() is original
+    assert ss._message_queue.get_nowait() is backlog
+    assert any(
+        call.kwargs.get("reason") == "phantom_requeued_unconsumed"
+        for call in decisions.call_args_list
+    )
+
+
+@pytest.mark.asyncio
+async def test_idle_phantom_replay_cap_drops_loudly(
+    monkeypatch, tmp_path, capsys,
+) -> None:
+    """#1127/#846: an absent prompt cannot replay forever."""
+    monkeypatch.setattr(tmux_session, "_TURN_DONE_TIMEOUT_SEC", 0.01)
+    monkeypatch.setattr(tmux_session, "_WATCHDOG_TICK_SEC", 0.01)
+    monkeypatch.setenv("PINKY_INFLIGHT_REPLAY_CAP", "1")
+    decisions = MagicMock()
+    monkeypatch.setattr(tmux_session, "log_watchdog_decision", decisions)
+
+    ss, _ = _make_session(state=SessionState.CONNECTED)
+    ss._config.live_status_fn = lambda: {
+        "status": "idle",
+        "last_updated": _time.time(),
+    }
+    ss._transcript_recently_grew = lambda *_args: False
+    transcript = tmp_path / "transcript.jsonl"
+    transcript.write_text('{"type":"system"}\n')
+    ss._tailer = MagicMock()
+    ss._tailer.transcript_path = transcript
+
+    completion = asyncio.Event()
+    submission = asyncio.get_running_loop().create_future()
+    header = "[agent | sender | internal | 2026-08-19T06:02:00-07:00]"
+    turn = _seed_inflight(
+        ss, prompt=f"{header}\nbody", completion_event=completion,
+    ).turn
+    turn.submission_receipt = submission
+    turn.replay_count = 1
+    ss._head_started_at = _time.time() - 1.0
+
+    await _run_idle_reconcile(ss)
+
+    assert turn.replay_count == 2
+    assert completion.is_set()
+    assert submission.result() is False
+    assert ss._message_queue.empty()
+    assert header in capsys.readouterr().err
+    assert any(
+        call.kwargs.get("reason") == "phantom_replay_cap_dropped"
+        for call in decisions.call_args_list
+    )
+
+
+@pytest.mark.asyncio
+async def test_idle_phantom_without_transcript_preserves_drain_with_audit(
+    monkeypatch, capsys,
+) -> None:
+    """#1127: an unavailable transcript is explicit, bounded fallback behavior."""
+    monkeypatch.setattr(tmux_session, "_TURN_DONE_TIMEOUT_SEC", 0.01)
+    monkeypatch.setattr(tmux_session, "_WATCHDOG_TICK_SEC", 0.01)
+
+    ss, _ = _make_session(state=SessionState.CONNECTED)
+    ss._config.live_status_fn = lambda: {
+        "status": "idle",
+        "last_updated": _time.time(),
+    }
+    ss._transcript_recently_grew = lambda *_args: False
+    ss._tailer = None
+    completion = asyncio.Event()
+    _seed_inflight(ss, prompt="header\nbody", completion_event=completion)
+    ss._head_started_at = _time.time() - 1.0
+
+    await _run_idle_reconcile(ss)
+
+    assert completion.is_set()
+    assert ss._message_queue.empty()
+    logs = capsys.readouterr().err
+    assert "PHANTOM_CONSUMPTION_PROBE_UNAVAILABLE" in logs
+    assert "deque_depth=1" in logs
+    assert "head_age_s=" in logs
+
+
+@pytest.mark.asyncio
+async def test_idle_phantom_mixed_deque_verdicts_per_meta(
+    monkeypatch, tmp_path,
+) -> None:
+    """#1127: a consumed head drains while an unconsumed tail replays."""
+    monkeypatch.setattr(tmux_session, "_TURN_DONE_TIMEOUT_SEC", 0.01)
+    monkeypatch.setattr(tmux_session, "_WATCHDOG_TICK_SEC", 0.01)
+
+    ss, _ = _make_session(state=SessionState.CONNECTED)
+    ss._config.live_status_fn = lambda: {
+        "status": "idle",
+        "last_updated": _time.time(),
+    }
+    ss._transcript_recently_grew = lambda *_args: False
+    consumed_header = "[agent | sender | internal | 2026-08-19T06:03:00-07:00]"
+    consumed_prompt = f"{consumed_header}\nconsumed"
+    unconsumed_prompt = (
+        "[agent | sender | internal | 2026-08-19T06:04:00-07:00]\nunconsumed"
+    )
+    transcript = tmp_path / "transcript.jsonl"
+    transcript.write_text(
+        _json.dumps({"type": "user", "message": {"content": consumed_prompt}}) + "\n"
+    )
+    ss._tailer = MagicMock()
+    ss._tailer.transcript_path = transcript
+
+    consumed_event = asyncio.Event()
+    unconsumed_event = asyncio.Event()
+    consumed_delivery = asyncio.get_running_loop().create_future()
+    consumed = _seed_inflight(
+        ss, prompt=consumed_prompt, completion_event=consumed_event,
+    )
+    consumed.turn.scheduler_delivery = consumed_delivery
+    unconsumed = _seed_inflight(
+        ss, prompt=unconsumed_prompt, completion_event=unconsumed_event,
+    )
+    ss._head_started_at = _time.time() - 1.0
+
+    await _run_idle_reconcile(ss)
+
+    assert consumed_event.is_set()
+    assert consumed_delivery.result() is True
+    assert not unconsumed_event.is_set()
+    assert unconsumed.turn.replay_count == 1
+    assert ss._message_queue.get_nowait() is unconsumed.turn
 
 
 # ──────────────────────────────────────────────────────────────────────────
@@ -8614,28 +8851,88 @@ class TestInflightDequeConcurrentDispatch:
         )
 
     @pytest.mark.asyncio
-    async def test_disconnect_unblocks_pending_completion_events(self):
-        """Disconnect drains ``_inflight_metas`` and sets every pending
-        ``completion_event`` so a ``wait_for_completion=True`` caller
-        doesn't hang on an abandoned turn (e.g. force_restart cycling
-        the pane mid-save). Murzik review point #2 — explicit."""
+    async def test_disconnect_requeues_pending_completion_events(self):
+        """#1127: plain inflight waiters remain pending across reconnect."""
         ss, _ = _make_session(state=SessionState.CONNECTED)
         await ss.connect()
 
         event1 = asyncio.Event()
         event2 = asyncio.Event()
-        _seed_inflight(ss, internal=True, completion_event=event1)
-        _seed_inflight(ss, meta={"platform": "t", "chat_id": "c", "message_id": "m"})
-        # No event on the second; the entry is external — disconnect
-        # still drains it, just doesn't have anything to signal.
-        _seed_inflight(ss, internal=True, completion_event=event2)
+        turn1 = _seed_inflight(
+            ss, internal=True, completion_event=event1,
+        ).turn
+        turn2 = _seed_inflight(
+            ss, meta={"platform": "t", "chat_id": "c", "message_id": "m"},
+        ).turn
+        turn3 = _seed_inflight(
+            ss, internal=True, completion_event=event2,
+        ).turn
         assert len(ss._inflight_metas) == 3
 
         await ss.disconnect()
 
         assert len(ss._inflight_metas) == 0
-        assert event1.is_set(), "disconnect must unblock event1"
-        assert event2.is_set(), "disconnect must unblock event2"
+        assert not event1.is_set(), "event1 waits for its replay"
+        assert not event2.is_set(), "event2 waits for its replay"
+        assert [ss._message_queue.get_nowait() for _ in range(3)] == [
+            turn1,
+            turn2,
+            turn3,
+        ]
+
+    @pytest.mark.asyncio
+    async def test_disconnect_requeues_plain_but_not_scheduler_meta(self):
+        """#1127: reconnect owns plain replay; scheduler owns wake redelivery."""
+        ss, _ = _make_session(state=SessionState.CONNECTED)
+        plain_event = asyncio.Event()
+        scheduler_event = asyncio.Event()
+        plain_submission = asyncio.get_running_loop().create_future()
+        scheduler_delivery = asyncio.get_running_loop().create_future()
+
+        plain = _seed_inflight(
+            ss,
+            prompt="plain prompt",
+            completion_event=plain_event,
+        ).turn
+        plain.submission_receipt = plain_submission
+        scheduler = _seed_inflight(
+            ss,
+            prompt="scheduler prompt",
+            completion_event=scheduler_event,
+        ).turn
+        scheduler.scheduler_delivery = scheduler_delivery
+
+        await ss.disconnect()
+
+        assert not plain_event.is_set()
+        assert not plain_submission.done()
+        assert plain.replay_count == 1
+        assert ss._message_queue.get_nowait() is plain
+        assert ss._message_queue.empty()
+        assert scheduler_event.is_set()
+        assert scheduler_delivery.result() is False
+
+    @pytest.mark.asyncio
+    async def test_disconnect_plain_replay_cap_resolves_drop(self, monkeypatch):
+        """#1127/#846: repeated reconnects cannot requeue one turn forever."""
+        monkeypatch.setenv("PINKY_INFLIGHT_REPLAY_CAP", "1")
+        ss, _ = _make_session(state=SessionState.CONNECTED)
+        completion = asyncio.Event()
+        submission = asyncio.get_running_loop().create_future()
+        turn = _seed_inflight(
+            ss,
+            prompt="capped plain prompt",
+            completion_event=completion,
+        ).turn
+        turn.submission_receipt = submission
+        turn.replay_count = 1
+
+        await ss.disconnect()
+
+        assert turn.replay_count == 2
+        assert completion.is_set()
+        assert submission.result() is False
+        assert ss._message_queue.empty()
 
     @pytest.mark.asyncio
     async def test_handle_turn_complete_with_empty_deque_logs_and_bails(self):

--- a/tests/test_tmux_session_pr1128_adversarial.py
+++ b/tests/test_tmux_session_pr1128_adversarial.py
@@ -1,0 +1,262 @@
+"""Independent adversarial probes for PR #1128 at 3bb8bcc2.
+
+Run from the pinned checkout root:
+
+    PYTHONPATH="$PWD/src" uv run pytest --rootdir="$PWD" \
+        -c pyproject.toml -q ../../pr1128_adversarial_test.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from contextlib import suppress
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from pinky_daemon import tmux_session
+from pinky_daemon.streaming_session import StreamingSessionConfig
+from pinky_daemon.tmux_session import (
+    TmuxCommandResult,
+    TmuxSession,
+    _InflightMeta,
+    _QueuedTurn,
+    _TmuxControl,
+)
+from pinky_daemon.transport_state import SessionState
+
+PINNED_HEAD = "3bb8bcc2f22a3164df870c133ebc777a4f643125"
+TAIL_BYTES = 4 * 1024 * 1024
+
+
+def _ok() -> TmuxCommandResult:
+    return TmuxCommandResult(returncode=0, stdout="", stderr="")
+
+
+def _session() -> TmuxSession:
+    control = MagicMock(spec=_TmuxControl)
+    control.session_name = "pinky-review"
+    control.kill_session = AsyncMock(return_value=_ok())
+    cfg = StreamingSessionConfig(
+        agent_name="review",
+        working_dir="/tmp/pr1128-review",
+    )
+    session = TmuxSession(cfg, tmux_control=control)
+    session._state_machine._state = SessionState.CONNECTED
+    return session
+
+
+def _seed(
+    session: TmuxSession,
+    turn: _QueuedTurn,
+    *,
+    completion: asyncio.Event | None = None,
+) -> _InflightMeta:
+    now = time.time()
+    turn.pane_delivery_started = True
+    turn.pane_delivery_recorded = True
+    entry = _InflightMeta(
+        meta={},
+        completion_event=completion,
+        internal=turn.internal,
+        dispatched_at=now,
+        turn=turn,
+        transcript_mtime_at_paste=now,
+        paste_succeeded_at=now,
+    )
+    session._inflight_metas.append(entry)
+    session._head_started_at = now - 1.0
+    return entry
+
+
+async def _reconcile(session: TmuxSession) -> None:
+    task = asyncio.create_task(session._inflight_watchdog())
+    try:
+        for _ in range(200):
+            if not session._inflight_metas:
+                return
+            await asyncio.sleep(0.01)
+        pytest.fail("idle watchdog did not reconcile the seeded meta")
+    finally:
+        task.cancel()
+        with suppress(asyncio.CancelledError):
+            await task
+
+
+def _arm_idle_probe(
+    monkeypatch: pytest.MonkeyPatch,
+    session: TmuxSession,
+    transcript,
+) -> None:
+    monkeypatch.setattr(tmux_session, "_TURN_DONE_TIMEOUT_SEC", 0.01)
+    monkeypatch.setattr(tmux_session, "_WATCHDOG_TICK_SEC", 0.01)
+    session._config.live_status_fn = lambda: {
+        "status": "idle",
+        "last_updated": time.time() + 1.0,
+    }
+    session._transcript_recently_grew = lambda *_args: False
+    session._tailer = MagicMock()
+    session._tailer.transcript_path = transcript
+    session._tailer.stop = AsyncMock()
+
+
+@pytest.mark.asyncio
+async def test_same_second_agent_header_does_not_prove_a_different_body_consumed(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    """One same-second agent turn must not provide proof for its sibling."""
+    session = _session()
+    header = "[agent | murzik | internal | 2026-08-19 06:00:00 UTC]"
+    consumed_prompt = f"{header}\nfirst verdict"
+    missing_prompt = f"{header}\nsecond verdict"
+    transcript = tmp_path / "transcript.jsonl"
+    transcript.write_text(
+        json.dumps(
+            {"type": "user", "message": {"content": consumed_prompt}},
+            ensure_ascii=False,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    _arm_idle_probe(monkeypatch, session, transcript)
+
+    completion = asyncio.Event()
+    missing = _QueuedTurn(prompt=missing_prompt, completion_event=completion)
+    _seed(session, missing, completion=completion)
+
+    await _reconcile(session)
+
+    assert not completion.is_set(), "unconsumed sibling must remain pending"
+    assert session._message_queue.get_nowait() is missing
+
+
+@pytest.mark.asyncio
+async def test_old_recurring_prompt_cannot_advance_current_scheduler_fire(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    """A retained prior occurrence is not acceptance of the current fire."""
+    session = _session()
+    recurring_prompt = "Scheduled wake: heartbeat\nrun the recurring check"
+    transcript = tmp_path / "transcript.jsonl"
+    transcript.write_text(
+        json.dumps({"type": "user", "message": {"content": recurring_prompt}})
+        + "\n",
+        encoding="utf-8",
+    )
+    _arm_idle_probe(monkeypatch, session, transcript)
+
+    delivery = asyncio.get_running_loop().create_future()
+    durable_accept = MagicMock(return_value=True)
+    current = _QueuedTurn(
+        prompt=recurring_prompt,
+        scheduler_delivery=delivery,
+        scheduler_accept=durable_accept,
+        scheduler_serialized=True,
+    )
+    _seed(session, current)
+
+    await _reconcile(session)
+
+    durable_accept.assert_not_called()
+    assert not delivery.done() or delivery.result() is False
+
+
+@pytest.mark.asyncio
+async def test_bounded_tail_miss_cannot_override_exact_acceptance(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    """A tail-window miss is weaker than the turn's exact user-row receipt."""
+    session = _session()
+    header = "accepted prompt"
+    transcript = tmp_path / "transcript.jsonl"
+    transcript.write_bytes(
+        header.encode()
+        + b"\n"
+        + b"x" * (TAIL_BYTES + 1)
+    )
+    _arm_idle_probe(monkeypatch, session, transcript)
+
+    completion = asyncio.Event()
+    accepted = _QueuedTurn(
+        prompt=f"{header}\nside effect already started",
+        completion_event=completion,
+        transport_accepted=True,
+    )
+    _seed(session, accepted, completion=completion)
+
+    await _reconcile(session)
+
+    assert completion.is_set(), "exactly accepted phantom should reconcile"
+    assert accepted not in list(session._message_queue._queue)
+
+
+@pytest.mark.asyncio
+async def test_disconnect_does_not_requeue_a_terminalized_wake_alias() -> None:
+    """The meta and worker in-hand slots can reference the same wake turn."""
+    session = _session()
+    completion = asyncio.Event()
+    submission = asyncio.get_running_loop().create_future()
+    wake = _QueuedTurn(
+        prompt="orientation wake",
+        internal=True,
+        reason="wake_resume",
+        completion_event=completion,
+        submission_receipt=submission,
+    )
+    _seed(session, wake, completion=completion)
+    # Production keeps a verified wake in-hand while awaiting its exact
+    # transcript receipt, so it simultaneously owns an inflight meta.
+    session._inflight_turn = wake
+
+    await session.disconnect()
+
+    queued = list(session._message_queue._queue)
+    assert wake not in queued or (
+        not completion.is_set() and not submission.done()
+    ), "disconnect must not enqueue a wake after terminalizing its receipts"
+
+
+@pytest.mark.asyncio
+async def test_disconnect_does_not_replay_a_verified_accepted_plain_turn() -> None:
+    """#561 parity abandons an accepted head to avoid duplicate side effects."""
+    session = _session()
+    accepted = _QueuedTurn(prompt="perform a side effect", transport_accepted=True)
+    _seed(session, accepted)
+
+    await session.disconnect()
+
+    assert accepted not in list(session._message_queue._queue)
+
+
+@pytest.mark.asyncio
+async def test_disconnect_does_not_leave_false_scheduler_replay_queued(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    """An idle-requeued scheduler turn cannot outlive its False owner receipt."""
+    session = _session()
+    transcript = tmp_path / "transcript.jsonl"
+    transcript.write_text('{"type":"system"}\n', encoding="utf-8")
+    _arm_idle_probe(monkeypatch, session, transcript)
+
+    receipt = asyncio.get_running_loop().create_future()
+    scheduler = _QueuedTurn(
+        prompt="scheduled current fire",
+        scheduler_delivery=receipt,
+        scheduler_accept=MagicMock(return_value=True),
+        scheduler_serialized=True,
+    )
+    session._scheduler_pending_turns.append(scheduler)
+    _seed(session, scheduler)
+
+    await _reconcile(session)
+    await session.disconnect()
+
+    assert not (
+        scheduler in list(session._message_queue._queue) and receipt.done()
+    ), "a terminal-False scheduler turn must not remain queued for execution"

--- a/tests/test_tmux_session_pr1128_r2_adversarial.py
+++ b/tests/test_tmux_session_pr1128_r2_adversarial.py
@@ -1,0 +1,351 @@
+"""Independent R2 adversarial probes for PR #1128 at 8d4a245d.
+
+Run from the pinned checkout root:
+
+    PYTHONPATH="$PWD/src" uv run pytest --rootdir="$PWD" \
+        -c pyproject.toml -q \
+        /Users/oleg/PinkyBot/data/agents/murzik/workspace/pr1128_r2_adversarial_test.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import time
+from contextlib import suppress
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from pinky_daemon import tmux_session
+from pinky_daemon.streaming_session import StreamingSessionConfig
+from pinky_daemon.tmux_session import (
+    TmuxCommandResult,
+    TmuxSession,
+    _InflightMeta,
+    _QueuedTurn,
+    _TmuxControl,
+)
+from pinky_daemon.transport_state import SessionState
+
+PINNED_HEAD = "8d4a245d73d014c9f84b555a4b63d954b1437ba4"
+MAX_EXPECTED_SCAN = 4 * 1024 * 1024
+
+
+def _ok() -> TmuxCommandResult:
+    return TmuxCommandResult(returncode=0, stdout="", stderr="")
+
+
+def _session(transcript: Path) -> TmuxSession:
+    control = MagicMock(spec=_TmuxControl)
+    control.session_name = "pinky-pr1128-r2-review"
+    control.kill_session = AsyncMock(return_value=_ok())
+    config = StreamingSessionConfig(
+        agent_name="review",
+        working_dir="/tmp/pr1128-r2-review",
+    )
+    session = TmuxSession(config, tmux_control=control)
+    session._state_machine._state = SessionState.CONNECTED
+    session._tailer = MagicMock()
+    session._tailer.transcript_path = transcript
+    return session
+
+
+def _entry(
+    prompt: str,
+    *,
+    path: Path | None,
+    identity: tuple[int, int] | None,
+    offset: int | None,
+) -> _InflightMeta:
+    turn = _QueuedTurn(prompt=prompt)
+    turn.pane_delivery_started = True
+    turn.pane_delivery_recorded = True
+    return _InflightMeta(
+        meta={},
+        completion_event=None,
+        internal=False,
+        dispatched_at=1.0,
+        turn=turn,
+        transcript_path_at_paste=path,
+        transcript_file_identity_at_paste=identity,
+        transcript_offset_at_paste=offset,
+    )
+
+
+def _user_row(prompt: str) -> bytes:
+    return (
+        json.dumps({"type": "user", "message": {"content": prompt}})
+        + "\n"
+    ).encode()
+
+
+def test_missing_paste_boundary_is_unavailable_not_definitively_unconsumed(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    """A transient pre-paste stat failure cannot justify a duplicate replay."""
+    prompt = "side effect already accepted while stat was unavailable"
+    transcript = tmp_path / "transcript.jsonl"
+    transcript.write_bytes(b'{"type":"system"}\n')
+    session = _session(transcript)
+    original_stat = Path.stat
+
+    def failing_stat(path: Path, *args, **kwargs):
+        if path == transcript:
+            raise PermissionError("transient pre-paste stat failure")
+        return original_stat(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "stat", failing_stat)
+    path, identity, offset = session._capture_transcript_occurrence_ticket()
+    monkeypatch.setattr(Path, "stat", original_stat)
+    assert (path, identity, offset) == (transcript, None, None)
+
+    with transcript.open("ab") as handle:
+        handle.write(_user_row(prompt))
+    entry = _entry(prompt, path=path, identity=identity, offset=offset)
+
+    assert session._phantom_consumption_verdicts([entry]) == [None]
+
+
+def test_accepted_duplicate_without_ticket_still_reserves_its_user_row(
+    tmp_path: Path,
+) -> None:
+    """An accepted occurrence cannot donate its row after ticket capture failed."""
+    prompt = "equal prompt pasted twice before the first user row"
+    transcript = tmp_path / "transcript.jsonl"
+    transcript.touch()
+    stat = transcript.stat()
+    first = _entry(prompt, path=transcript, identity=None, offset=None)
+    first.turn.transport_accepted = True
+    second = _entry(
+        prompt,
+        path=transcript,
+        identity=(stat.st_dev, stat.st_ino),
+        offset=0,
+    )
+    session = _session(transcript)
+
+    transcript.write_bytes(_user_row(prompt))
+
+    assert session._phantom_consumption_verdicts([first, second]) == [
+        True,
+        False,
+    ]
+
+
+def test_same_inode_truncate_and_regrow_does_not_hide_current_occurrence(
+    tmp_path: Path,
+) -> None:
+    """Net file size cannot detect copy-truncate once the file regrows."""
+    prompt = "current occurrence after in-place transcript reset"
+    transcript = tmp_path / "transcript.jsonl"
+    transcript.write_bytes(b"x" * 1024)
+    before = transcript.stat()
+    entry = _entry(
+        prompt,
+        path=transcript,
+        identity=(before.st_dev, before.st_ino),
+        offset=before.st_size,
+    )
+    session = _session(transcript)
+
+    # Opening with wb truncates in place, preserving device+inode. Regrow past
+    # the old EOF so a final-size-only test cannot see that the offset is stale.
+    transcript.write_bytes(_user_row(prompt) + b" " * 2048)
+    after = transcript.stat()
+    assert (after.st_dev, after.st_ino) == (before.st_dev, before.st_ino)
+    assert after.st_size > before.st_size
+
+    assert session._phantom_consumption_verdicts([entry]) == [True]
+
+
+@pytest.mark.asyncio
+async def test_replacement_file_cannot_advance_current_scheduler_from_old_row(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    """Identity reset must not promote a stale duplicate to durable acceptance."""
+    monkeypatch.setattr(tmux_session, "_TURN_DONE_TIMEOUT_SEC", 0.01)
+    monkeypatch.setattr(tmux_session, "_WATCHDOG_TICK_SEC", 0.01)
+    prompt = "recurring scheduler prompt"
+    transcript = tmp_path / "transcript.jsonl"
+    replacement = tmp_path / "replacement.jsonl"
+    replacement.write_bytes(_user_row(prompt))
+    transcript.write_bytes(b'{"type":"system"}\n')
+    before = transcript.stat()
+    entry = _entry(
+        prompt,
+        path=transcript,
+        identity=(before.st_dev, before.st_ino),
+        offset=before.st_size,
+    )
+    session = _session(transcript)
+    session._config.live_status_fn = lambda: {
+        "status": "idle",
+        "last_updated": time.time() + 1.0,
+    }
+    session._transcript_recently_grew = lambda *_args: False
+    delivery = asyncio.get_running_loop().create_future()
+    durable_accept = MagicMock(return_value=True)
+    entry.turn.scheduler_delivery = delivery
+    entry.turn.scheduler_accept = durable_accept
+    entry.turn.scheduler_serialized = True
+    session._scheduler_pending_turns.append(entry.turn)
+    session._inflight_metas.append(entry)
+    session._head_started_at = time.time() - 1.0
+
+    # The duplicate row predates the paste ticket, but is moved under the bound
+    # pathname afterward. Resetting the scan offset to zero must not accept it.
+    os.replace(replacement, transcript)
+
+    watchdog = asyncio.create_task(session._inflight_watchdog())
+    try:
+        for _ in range(200):
+            if not session._inflight_metas:
+                break
+            await asyncio.sleep(0.01)
+        else:
+            pytest.fail("idle watchdog did not reconcile the seeded meta")
+    finally:
+        watchdog.cancel()
+        with suppress(asyncio.CancelledError):
+            await watchdog
+
+    durable_accept.assert_not_called()
+    assert not delivery.done() or delivery.result() is False
+    assert entry.turn in list(session._message_queue._queue)
+
+
+def test_replacement_between_stat_and_open_loses_positive_provenance(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    """A newly opened inode cannot inherit an old offset or certify its rows."""
+    prompt = "current occurrence in file installed during the read race"
+    transcript = tmp_path / "transcript.jsonl"
+    replacement = tmp_path / "replacement.jsonl"
+    transcript.write_bytes(b"x" * 1024)
+    before = transcript.stat()
+    entry = _entry(
+        prompt,
+        path=transcript,
+        identity=(before.st_dev, before.st_ino),
+        offset=before.st_size,
+    )
+    session = _session(transcript)
+    replacement.write_bytes(_user_row(prompt))
+
+    original_open = Path.open
+    original_fstat = os.fstat
+    swapped = False
+    fstat_calls = 0
+
+    def racing_open(path: Path, *args, **kwargs):
+        nonlocal swapped
+        mode = args[0] if args else kwargs.get("mode", "r")
+        if path == transcript and mode == "rb" and not swapped:
+            os.replace(replacement, transcript)
+            swapped = True
+        return original_open(path, *args, **kwargs)
+
+    def tracking_fstat(fd: int):
+        nonlocal fstat_calls
+        fstat_calls += 1
+        return original_fstat(fd)
+
+    monkeypatch.setattr(Path, "open", racing_open)
+    monkeypatch.setattr(os, "fstat", tracking_fstat)
+
+    # Although this fixture creates the replacement after the ticket, that
+    # ordering is not observable by production code.  Once fstat reveals a
+    # different inode, its row is indistinguishable from the stale replacement
+    # in the preceding forgery case and is therefore allocation-only, never
+    # positive proof for this unaccepted candidate.
+    assert session._phantom_consumption_verdicts([entry]) == [False]
+    assert fstat_calls >= 1
+
+
+def test_one_physical_row_cannot_be_allocated_twice_through_path_aliases(
+    tmp_path: Path,
+) -> None:
+    """Occurrence identity is device+inode+offset, not pathname+offset."""
+    prompt = "duplicate prompt with one physical transcript row"
+    transcript = tmp_path / "transcript.jsonl"
+    alias = tmp_path / "transcript-alias.jsonl"
+    transcript.touch()
+    os.link(transcript, alias)
+    stat = transcript.stat()
+    identity = (stat.st_dev, stat.st_ino)
+    first = _entry(prompt, path=transcript, identity=identity, offset=0)
+    second = _entry(prompt, path=alias, identity=identity, offset=0)
+    session = _session(transcript)
+
+    transcript.write_bytes(_user_row(prompt))
+
+    assert session._phantom_consumption_verdicts([first, second]) == [
+        True,
+        False,
+    ]
+
+
+def test_occurrence_probe_does_not_scan_unbounded_output_after_early_match(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    """The watchdog must not synchronously scan arbitrary transcript growth."""
+    prompt = "prompt row appears immediately after the paste boundary"
+    transcript = tmp_path / "transcript.jsonl"
+    transcript.write_bytes(b'{"type":"system"}\n')
+    before = transcript.stat()
+    entry = _entry(
+        prompt,
+        path=transcript,
+        identity=(before.st_dev, before.st_ino),
+        offset=before.st_size,
+    )
+    session = _session(transcript)
+    assistant_row = b'{"type":"assistant","message":{"content":"x"}}\n'
+    with transcript.open("ab") as handle:
+        handle.write(_user_row(prompt))
+        repetitions = (MAX_EXPECTED_SCAN * 2) // len(assistant_row) + 100
+        handle.write(assistant_row * repetitions)
+
+    original_open = Path.open
+    observed = {"bytes": 0}
+
+    class CountingReader:
+        def __init__(self, wrapped):
+            self._wrapped = wrapped
+
+        def __enter__(self):
+            self._wrapped.__enter__()
+            return self
+
+        def __exit__(self, *args):
+            return self._wrapped.__exit__(*args)
+
+        def seek(self, *args):
+            return self._wrapped.seek(*args)
+
+        def tell(self):
+            return self._wrapped.tell()
+
+        def readline(self, *args):
+            raw = self._wrapped.readline(*args)
+            observed["bytes"] += len(raw)
+            return raw
+
+    def counting_open(path: Path, *args, **kwargs):
+        wrapped = original_open(path, *args, **kwargs)
+        mode = args[0] if args else kwargs.get("mode", "r")
+        if path == transcript and mode == "rb":
+            return CountingReader(wrapped)
+        return wrapped
+
+    monkeypatch.setattr(Path, "open", counting_open)
+
+    assert session._phantom_consumption_verdicts([entry]) == [True]
+    assert observed["bytes"] <= MAX_EXPECTED_SCAN

--- a/tests/test_tmux_session_pr1128_r3_additional_adversarial.py
+++ b/tests/test_tmux_session_pr1128_r3_additional_adversarial.py
@@ -1,0 +1,139 @@
+"""Additional exact-contract probes for PR #1128 R3.
+
+Run from the detached exact-head checkout with its ``src`` directory on
+``PYTHONPATH``.  These cases intentionally sit outside the committed suite.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from pinky_daemon.streaming_session import StreamingSessionConfig
+from pinky_daemon.tmux_session import (
+    TmuxSession,
+    _InflightMeta,
+    _QueuedTurn,
+    _TmuxControl,
+)
+
+MAX_SCAN = 4 * 1024 * 1024
+
+
+def _session(transcript: Path) -> TmuxSession:
+    control = MagicMock(spec=_TmuxControl)
+    control.session_name = "pinky-pr1128-r3-review"
+    session = TmuxSession(
+        StreamingSessionConfig(
+            agent_name="review",
+            working_dir="/tmp/pr1128-r3-review",
+        ),
+        tmux_control=control,
+    )
+    session._tailer = MagicMock()
+    session._tailer.transcript_path = transcript
+    return session
+
+
+def _entry(prompt: str, transcript: Path) -> _InflightMeta:
+    stat = transcript.stat()
+    return _InflightMeta(
+        meta={},
+        completion_event=None,
+        internal=False,
+        dispatched_at=1.0,
+        turn=_QueuedTurn(prompt=prompt),
+        transcript_path_at_paste=transcript,
+        transcript_file_identity_at_paste=(stat.st_dev, stat.st_ino),
+        transcript_offset_at_paste=stat.st_size,
+    )
+
+
+def _user_row(prompt: str) -> bytes:
+    return (
+        json.dumps({"type": "user", "message": {"content": prompt}}) + "\n"
+    ).encode()
+
+
+def test_changed_overlap_of_long_row_is_positive_same_inode_proof(
+    tmp_path: Path,
+) -> None:
+    """A changed captured-suffix overlap proves a same-inode row mutation."""
+    transcript = tmp_path / "transcript.jsonl"
+    old_prompt = "a" * 5000
+    current_prompt = "b" * 5000
+    old_row = _user_row(old_prompt)
+    current_row = _user_row(current_prompt)
+    assert len(old_row) == len(current_row) > 4096
+    transcript.write_bytes(old_row)
+    entry = _entry(current_prompt, transcript)
+    session = _session(transcript)
+
+    transcript.write_bytes(current_row)
+    assert transcript.stat().st_size == entry.transcript_offset_at_paste
+    assert entry.transcript_anchor_start_at_paste is not None
+    assert entry.transcript_anchor_start_at_paste > 0
+    assert current_row[entry.transcript_anchor_start_at_paste :] != (
+        entry.transcript_anchor_at_paste
+    )
+
+    # Commitment 3 permits positive proof when the row bytes differ from the
+    # captured exact suffix over their pre-send-boundary overlap.
+    assert session._phantom_consumption_verdicts([entry]) == [True]
+
+
+def test_scan_budget_is_cumulative_across_physical_sources(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    """One reconciliation must not synchronously read 4 MiB per old file."""
+    first_path = tmp_path / "first.jsonl"
+    second_path = tmp_path / "second.jsonl"
+    first_path.touch()
+    second_path.touch()
+    first = _entry("missing first prompt", first_path)
+    second = _entry("missing second prompt", second_path)
+    session = _session(first_path)
+    first_path.write_bytes(b"x" * (MAX_SCAN + 1024))
+    second_path.write_bytes(b"y" * (MAX_SCAN + 1024))
+
+    original_open = Path.open
+    observed = {"bytes": 0}
+
+    class CountingReader:
+        def __init__(self, wrapped):
+            self._wrapped = wrapped
+
+        def __enter__(self):
+            self._wrapped.__enter__()
+            return self
+
+        def __exit__(self, *args):
+            return self._wrapped.__exit__(*args)
+
+        def fileno(self):
+            return self._wrapped.fileno()
+
+        def seek(self, *args):
+            return self._wrapped.seek(*args)
+
+        def tell(self):
+            return self._wrapped.tell()
+
+        def readline(self, *args):
+            raw = self._wrapped.readline(*args)
+            observed["bytes"] += len(raw)
+            return raw
+
+    def counting_open(path: Path, *args, **kwargs):
+        wrapped = original_open(path, *args, **kwargs)
+        mode = args[0] if args else kwargs.get("mode", "r")
+        if path in {first_path, second_path} and mode == "rb":
+            return CountingReader(wrapped)
+        return wrapped
+
+    monkeypatch.setattr(Path, "open", counting_open)
+
+    session._phantom_consumption_verdicts([first, second])
+    assert observed["bytes"] <= MAX_SCAN


### PR DESCRIPTION
## Summary
- verify aged idle metas against a bounded transcript-tail header search
- replay unconsumed turns at queue front with the existing capped recovery policy
- resolve verified scheduler consumption positively and preserve plain turns across graceful reconnects

## Tests
- `uv run pytest tests/test_tmux_session.py -q`
- `uv run pytest tests/test_codex_tmux_session.py -q`
- `uv run ruff check src/pinky_daemon/tmux_session.py tests/test_tmux_session.py`
- `uv run python -m compileall -q src/pinky_daemon/tmux_session.py tests/test_tmux_session.py`

## Review focus
- duplicate-delivery tradeoff at the transcript-write boundary
- scheduler receipt semantics after verified consumption
- bounded tail reads and transcript rebinding
- single-owner scheduler replay during graceful teardown

This touches shared tmux transport recovery code and may overlap with other open transport work; no changes from those branches are included.

Closes #1127

🤖 Opened by Kuzya