### PR TITLE
fix(#889): safe_db_read tier-1 snapshots via the sanctioned reader + online backup API

### DIFF
--- a/scripts/safe_db_read.py
+++ b/scripts/safe_db_read.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Safe read access to a LIVE daemon SQLite DB — never poison its WAL (#889).
+
+WHY THIS EXISTS
+---------------
+Opening a live WAL-mode daemon DB with a plain/RW client (the classic
+``sqlite3 data/conversations.db "SELECT ..."`` one-liner, or a bare
+``sqlite3.connect(path)``) is dangerous: when that client closes, SQLite runs a
+checkpoint-on-last-close and UNLINKS the ``-wal``/``-shm`` files. Because POSIX
+advisory locks are per-process, the client can be the effective "last connection"
+while the daemon's own connection is idle between transactions — so the WAL is
+deleted out from under the daemon's open fd. No data is lost immediately, but the
+daemon now holds a fd to a DELETED inode, and on the next restart the un-replayed
+WAL is gone and the main DB can be left header-corrupt (the #889 family: 6+
+user_profiles malformations + multi-instance outages).
+
+SAFE TIERS
+----------
+1. BEST (default here): snapshot the DB into a temp file via SQLite's ONLINE
+   BACKUP API, reading the source through the daemon's sanctioned live-DB reader
+   (``BoundSQLiteFile``, #619: open-once ``O_RDONLY|O_NOFOLLOW`` + ``mode=ro`` on
+   the pinned fd), then read the COPY. The backup runs inside a real read
+   transaction, so the snapshot is transaction-consistent (only COMMITTED rows) —
+   a raw byte copy is NOT: in rollback-journal mode a mid-transaction writer
+   spills dirty UNCOMMITTED pages into the main file, so a byte copy captures
+   phantoms (#889 follow-up). Zero write-touch on the live file. Use for anything.
+2. OK for rough reads: ``mode=ro&immutable=1`` — immutable=1 tells SQLite the file
+   won't change, so it never creates/opens -wal/-shm and never checkpoints/unlinks.
+   Caveat: reads can be TORN on a live, actively-written DB (you may see a
+   partially-updated page view). Fine for quick "latest row / schema" peeks.
+   NB: ``mode=ro`` ALONE (a bare ad-hoc connect) re-creates -shm on a WAL source
+   (#932) — that is why tier 1 goes through ``BoundSQLiteFile`` and not a raw
+   ``mode=ro`` open of its own.
+3. NEVER: raw ``sqlite3 <live-db>`` / plain ``sqlite3.connect(path)`` / ``mode=ro``
+   without ``immutable=1``.
+
+USAGE
+-----
+    # tier 1 (safe snapshot):
+    python3 scripts/safe_db_read.py data/conversations.db \
+        "SELECT id, datetime(timestamp,'unixepoch'), substr(content,1,80) \
+         FROM messages ORDER BY id DESC LIMIT 5"
+
+    # tier 2 (fast, may tear):
+    python3 scripts/safe_db_read.py --immutable data/conversations.db "SELECT count(*) FROM messages"
+
+    # importable:
+    from scripts.safe_db_read import safe_connect, snapshot_query
+    for row in snapshot_query("data/conversations.db", "SELECT ..."):
+        ...
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import shutil
+import sqlite3
+import sys
+import tempfile
+from collections.abc import Iterator
+from pathlib import Path
+
+# Tier 1 opens the live source through the daemon's sanctioned live-DB reader
+# (BoundSQLiteFile, #619): one open-once O_RDONLY|O_NOFOLLOW fd, journal mode read
+# from the raw header bytes, mode=ro over that pinned descriptor — so there is ONE
+# read discipline, not a parallel mode=ro path. scripts/ is not under src/, so make
+# pinky_daemon importable for standalone CLI use too.
+_REPO_SRC = Path(__file__).resolve().parent.parent / "src"
+if _REPO_SRC.is_dir() and str(_REPO_SRC) not in sys.path:
+    sys.path.insert(0, str(_REPO_SRC))
+from pinky_daemon.store_catalog import BoundSQLiteFile  # noqa: E402
+
+
+def immutable_connect(db_path: str) -> sqlite3.Connection:
+    """Tier 2: read-only + immutable=1 URI connection. Never touches -wal/-shm.
+    May read torn pages on a live DB — use only for rough/quick reads."""
+    uri = f"file:{Path(db_path).resolve()}?mode=ro&immutable=1"
+    return sqlite3.connect(uri, uri=True)
+
+
+@contextlib.contextmanager
+def snapshot_connect(db_path: str) -> Iterator[sqlite3.Connection]:
+    """Tier 1: snapshot the live DB into a fresh temp DB via SQLite's ONLINE
+    BACKUP API, then connect to the COPY. Yields a connection to a
+    transaction-consistent copy; zero *write* touch on the live file.
+
+    Why the backup API and NOT ``shutil.copy2`` (the #889 follow-up caught in review):
+    a raw byte copy of the main DB file is not transaction-consistent. The churn
+    stores run in ROLLBACK-journal mode (DELETE/TRUNCATE), and there a writer
+    flushes DIRTY, UNCOMMITTED pages straight into the *main* file mid-transaction
+    whenever its page cache spills — the undo image lives in the ``-journal``
+    sidecar, which the old code did not even copy. So ``shutil.copy2`` of the main
+    file alone captured phantom, never-committed rows (probe: 2494/2500 uncommitted
+    rows visible through the snapshot). The backup API instead reads the source
+    through a proper SQLite read transaction, so it only ever sees the last
+    COMMITTED state: in WAL mode it folds in committed WAL frames; in rollback mode
+    it takes a SHARED lock, which blocks behind the writer's EXCLUSIVE lock until
+    that transaction commits or rolls back, so spilled dirty pages are never read.
+
+    Still #889-safe, and now on the SANCTIONED read path: the source is opened via
+    ``BoundSQLiteFile`` (the daemon-owned live-DB reader, #619) — open-once
+    ``O_RDONLY|O_NOFOLLOW``, journal mode read from the raw header bytes, then a
+    ``mode=ro`` connection over that one pinned descriptor. A read-only connection
+    never checkpoints, so it never unlinks the live ``-wal``/``-shm``; and reusing
+    the one reader avoids a parallel raw ``mode=ro`` open (which alone re-creates
+    ``-shm`` on a WAL source, #932). ``connect_read_only``'s ``timeout`` waits out
+    the brief window a writer holds the rollback-mode EXCLUSIVE lock, so the
+    snapshot WAITS for the commit/rollback rather than racing it (the phantom bug).
+    """
+    src = Path(db_path).resolve()
+    tmpdir = Path(tempfile.mkdtemp(prefix="safe_db_read_"))
+    try:
+        # Open the source through the sanctioned reader: one open-once
+        # O_RDONLY|O_NOFOLLOW fd, mode=ro over that pinned descriptor. timeout waits
+        # out (does not race) a writer briefly holding the rollback-mode lock.
+        with BoundSQLiteFile.open(src) as bound:
+            src_conn = bound.connect_read_only(timeout=30)
+            try:
+                dst_path = tmpdir / src.name
+                dst_conn = sqlite3.connect(str(dst_path))
+                try:
+                    src_conn.backup(dst_conn)
+                    src_conn.close()
+                    yield dst_conn
+                finally:
+                    dst_conn.close()
+            finally:
+                with contextlib.suppress(Exception):
+                    src_conn.close()
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+def safe_connect(db_path: str, *, immutable: bool = False):
+    """Return a safe connection. Default = tier-1 snapshot (context manager);
+    immutable=True = tier-2 immutable RO connection (plain, caller closes)."""
+    if immutable:
+        return immutable_connect(db_path)
+    return snapshot_connect(db_path)
+
+
+def snapshot_query(db_path: str, sql: str, params: tuple = ()) -> list:
+    """Convenience: run a query against a tier-1 snapshot and return all rows."""
+    with snapshot_connect(db_path) as conn:
+        return conn.execute(sql, params).fetchall()
+
+
+def _main(argv: list[str]) -> int:
+    ap = argparse.ArgumentParser(description="Safe read of a live daemon SQLite DB (#889).")
+    ap.add_argument("db_path")
+    ap.add_argument("sql")
+    ap.add_argument(
+        "--immutable",
+        action="store_true",
+        help="tier 2: mode=ro&immutable=1 (fast, may read torn pages). Default = tier-1 copy-and-read.",
+    )
+    ap.add_argument("-separator", "--separator", default="|", dest="sep")
+    args = ap.parse_args(argv)
+    try:
+        if args.immutable:
+            conn = immutable_connect(args.db_path)
+            try:
+                rows = conn.execute(args.sql).fetchall()
+            finally:
+                conn.close()
+        else:
+            rows = snapshot_query(args.db_path, args.sql)
+    except sqlite3.Error as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    for row in rows:
+        print(args.sep.join("" if v is None else str(v) for v in row))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main(sys.argv[1:]))

--- a/tests/test_safe_db_read.py
+++ b/tests/test_safe_db_read.py
@@ -1,0 +1,136 @@
+"""Regression tests for scripts/safe_db_read.py — the #889 tier-1 snapshot.
+
+The acute bug (found in review of PR #1107): tier-1 ``snapshot_connect`` used
+``shutil.copy2`` of the main DB file. The high-churn stores run in ROLLBACK-journal
+mode (DELETE/TRUNCATE), where an ``UPDATE`` rewrites existing rows *in place*; when
+the writer's page cache spills it flushes those DIRTY, UNCOMMITTED pages straight
+into the main file (the pre-image undo lives in the ``-journal`` sidecar, which the
+old code did not copy). The row count is unchanged, so the DB header does not
+shield the reader: a raw byte copy reads the in-place dirty pages and returns
+uncommitted, transactionally-impossible rows.
+
+The fix reads the source through the sanctioned reader (``BoundSQLiteFile``) and
+SQLite's online backup API: it runs inside a real read transaction, blocks behind
+the writer's lock, and returns only the last COMMITTED state.
+
+Determinism (no wall-clock sync): the writer holds an uncommitted, spilled UPDATE;
+the snapshot signals ``backup_started`` and then blocks in ``backup()``; the main
+thread releases only after that. Both threads append to a shared ordered trace, and
+the test asserts ``backup_returned`` lands AFTER ``writer_release`` — which can only
+happen if the backup genuinely blocked on the lock. A non-contending/trivial read
+fails that ordering (fail-closed), so the test cannot pass by accident.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sqlite3
+import threading
+import time
+from pathlib import Path
+
+_SAFE_DB_READ_PATH = Path(__file__).resolve().parents[1] / "scripts" / "safe_db_read.py"
+_spec = importlib.util.spec_from_file_location("safe_db_read", _SAFE_DB_READ_PATH)
+safe_db_read = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(safe_db_read)
+
+N_ROWS = 2500
+PAD = 500  # fat rows so a tiny cache is forced to spill dirty pages to disk
+OLD = "old" + "O" * PAD
+NEW = "new" + "N" * PAD
+
+
+def _make_rollback_db(path: Path, n_rows: int) -> None:
+    con = sqlite3.connect(path)
+    try:
+        con.execute("PRAGMA journal_mode=TRUNCATE")  # rollback-family, not WAL
+        con.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT)")
+        con.executemany(
+            "INSERT INTO t(id, v) VALUES(?, ?)",
+            [(i, OLD) for i in range(1, n_rows + 1)],
+        )
+        con.commit()
+    finally:
+        con.close()
+
+
+def _tag_counts(conn: sqlite3.Connection) -> dict:
+    return dict(conn.execute("SELECT substr(v, 1, 3), count(*) FROM t GROUP BY 1").fetchall())
+
+
+def test_snapshot_shows_pre_txn_state_not_dirty_rows(tmp_path):
+    """A snapshot taken while a writer holds an open, uncommitted rollback-mode
+    UPDATE (dirty pages already spilled to the main file) must return the
+    PRE-transaction committed state — and the operation trace must prove the
+    backup blocked on the writer's lock rather than racing it."""
+    db = tmp_path / "churn.db"
+    _make_rollback_db(db, N_ROWS)
+
+    writer = sqlite3.connect(db)
+    writer.execute("PRAGMA journal_mode=TRUNCATE")
+    writer.execute("PRAGMA cache_size=10")  # tiny => dirty pages flush in-place to main file
+    writer.execute("BEGIN")
+    writer.execute("UPDATE t SET v = ?", (NEW,))
+    # NOT committed: 'new' rows sit in the main DB file (in-place) and the writer
+    # holds the rollback-mode EXCLUSIVE lock. A raw byte copy would read them.
+
+    trace: list[str] = []
+    trace_lock = threading.Lock()
+    backup_started = threading.Event()
+    result: dict = {}
+
+    def _snapshot():
+        try:
+            backup_started.set()  # about to enter the (blocking) snapshot
+            with safe_db_read.snapshot_connect(str(db)) as snap:
+                with trace_lock:
+                    trace.append("backup_returned")
+                result["counts"] = _tag_counts(snap)
+        except Exception as exc:  # noqa: BLE001 - surfaced to the assertion
+            with trace_lock:
+                trace.append("backup_error")
+            result["error"] = exc
+
+    th = threading.Thread(target=_snapshot)
+    th.start()
+
+    assert backup_started.wait(timeout=5), "snapshot thread never started"
+    # Minimal nudge so the C backup_step engages the lock-wait before we release.
+    # The trace-ordering assertion below is the real proof, not this sleep.
+    time.sleep(0.3)
+    with trace_lock:
+        trace.append("writer_release")
+    writer.rollback()  # release the lock; main file restored to committed state
+    writer.close()
+
+    th.join(timeout=35)
+    assert not th.is_alive(), "snapshot did not complete (deadlock?)"
+    assert "error" not in result, f"snapshot raised: {result.get('error')!r}"
+    assert result["counts"] == {"old": N_ROWS}, (
+        f"expected {N_ROWS} committed 'old' rows, got {result['counts']} "
+        "(uncommitted 'new' rows leaked into the snapshot)"
+    )
+    # Proof it actually blocked: the backup returned only after the writer released.
+    assert "writer_release" in trace and "backup_returned" in trace, trace
+    assert trace.index("backup_returned") > trace.index("writer_release"), (
+        f"backup returned before the writer released ({trace}) — it did not block "
+        "on the lock, so the snapshot raced the writer instead of waiting it out"
+    )
+
+
+def test_snapshot_is_a_detached_copy(tmp_path):
+    """The yielded connection is a copy: writes to it never touch the live file,
+    and the live file is intact after the snapshot context exits."""
+    db = tmp_path / "plain.db"
+    _make_rollback_db(db, 40)
+
+    with safe_db_read.snapshot_connect(str(db)) as snap:
+        assert snap.execute("SELECT count(*) FROM t").fetchone()[0] == 40
+        snap.execute("INSERT INTO t(v) VALUES('local-only')")
+        snap.commit()
+
+    live = sqlite3.connect(db)
+    try:
+        assert live.execute("SELECT count(*) FROM t").fetchone()[0] == 40
+    finally:
+        live.close()

--- a/tests/test_store_snapshot.py
+++ b/tests/test_store_snapshot.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import ast
 import importlib
 import json
-import os
 import sqlite3
 import threading
 from pathlib import Path
@@ -830,7 +829,6 @@ def test_cli_is_endpoint_only_and_requires_explicit_signing_identity() -> None:
     assert "--as-agent" in source
     assert "PINKY_AGENT_NAME" in source
     assert source.index("PINKY_AGENT_KEY") < source.index("PINKY_SESSION_SECRET")
-    assert not os.path.exists(script.with_name("safe_db_read.py"))
 
 
 def test_cli_signs_endpoint_request_and_prints_only_returned_copy_path(


### PR DESCRIPTION
Reinstates `scripts/safe_db_read.py` with a **journal-mode-agnostic** implementation, replacing the tier-1 helper dropped in #1107.

## Why
The old tier-1 helper byte-copied the main DB with `shutil.copy2`. For the high-churn stores now in rollback (DELETE/TRUNCATE) journal mode, an in-place UPDATE spills dirty, uncommitted pages into the main file when the page cache overflows — the undo pre-image lives in the `-journal` sidecar, which `copy2` never took. The row count is unchanged so the header doesn't shield the reader: the byte copy returned uncommitted, transactionally-impossible rows (review probe on #1107 measured ~2494/2500 rows carrying a never-committed value, `integrity_check=ok`). That false 'consistent snapshot' claim is why #1107 removed the helper rather than ship it.

## What
`snapshot_connect` now opens the source through **`BoundSQLiteFile`** (the #619 daemon-owned live-DB reader: open-once `O_RDONLY|O_NOFOLLOW`, journal mode read from the raw header bytes, `mode=ro` over the pinned fd) and copies via **SQLite's online backup API** inside a real read transaction. The backup returns only committed state regardless of journal mode, and a read-only connection never checkpoints/unlinks the live `-wal`/`-shm` — closing the original #889 hazard. Reusing the one sanctioned reader avoids a parallel raw `mode=ro` open, which alone re-creates `-shm` on a WAL source (#932).

This is exactly the sanctioned safe-read path that would have prevented the WAL-orphan incident filed as #1126 (an ad-hoc `glob(data/*.db)` + `sqlite3.connect` sweep against live stores).

## Tests
`tests/test_safe_db_read.py`: rollback-mode regression holding an uncommitted, spilled UPDATE and asserting the snapshot returns the pre-txn committed state. Determinism is by operation trace, not wall-clock (#1094 idiom): the snapshot signals `backup_started` then blocks in `backup()`; the writer releases only after; the test asserts `backup_returned` lands after `writer_release`, so a non-blocking/racing read fails closed. Fails on the old copy2 path; passes here. Local: 2 passed.

## Provenance / scope
Authored by Angel (TOD fleet); verified applies clean to current main (`BoundSQLiteFile` present) with the test green. The handoff had stalled un-PR'd across several pushes — filing now so it doesn't silently fall through. **Rides the next release, not tonight's already-cut 26.08.027.** Complementary to (not conflicting with) the #968 journal-mode work — this is the reader helper, journal-mode-agnostic by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)