### PR TITLE
scripts: guard tooling against in-place opens of live SQLite stores (#1126)

### DIFF
--- a/scripts/_safe_db.py
+++ b/scripts/_safe_db.py
@@ -1,67 +1,101 @@
 """Guard against opening live daemon/MCP-held SQLite stores in place.
 
 The PinkyBot daemon keeps ~40 WAL-mode stores under ``data/`` open for its
-whole lifetime, and each agent's pinky-memory MCP keeps that agent's
-``memory.db`` open. Opening one of those files in place from an external
-process (a bare ``sqlite3`` CLI, a backfill/migration script) recreates the
-``-wal``/``-shm`` sidecars, orphaning the holder's open fd: the holder then
-commits into an unlinked WAL that no path-linked reader sees, and the on-disk
-main file silently freezes. Recovered from exactly this on 2026-08-19 (root
-cause of #1126); see notes/wal-orphan-tooling-audit-641.md.
+whole lifetime. Agent ``memory.db`` stores are held either by the shared-MCP
+memory pool running *inside the daemon process itself* (current topology) or
+by a legacy per-agent stdio ``pinky_memory`` process. Opening one of those
+files in place from an external process (a bare ``sqlite3`` CLI, a
+backfill/migration script) recreates the ``-wal``/``-shm`` sidecars,
+orphaning the holder's open fd: the holder then commits into an unlinked WAL
+that no path-linked reader sees, and the on-disk main file silently freezes.
+Recovered from exactly this on 2026-08-19 (root cause of #1126).
 
-A raw *byte* copy (``shutil.copy2`` / cp / rsync) is safe: it never opens the
-file as a database, so it never recreates the sidecars.
+Call ``refuse_if_live_store(path, write=...)`` before any direct
+``sqlite3.connect()`` on a file under ``data/``. It fails loud (SystemExit)
+when a live holder may have the store open — including when holder detection
+itself fails, because an unknown holder is not an absent holder.
 
-Use this instead of a bare ``sqlite3.connect()`` on anything under ``data/``:
+Safe alternatives to an in-place open of a live store:
 
-- ``refuse_if_live_store(path, write=...)`` -- FAIL LOUD before an in-place open
-  of a store whose holder process is running. For a *registered* store prefer
-  the daemon-owned verified snapshot (``scripts/store_snapshot.py``).
-- ``snapshot_ro(path)`` -- raw-copy db (+ -wal/-shm) to a temp file and return a
-  read-only connection to the copy; safe against a live holder.
+- daemon-catalog store (``data/*.db``): ``scripts/store_snapshot.py`` asks the
+  daemon for a verified point-in-time snapshot without opening the file.
+- agent ``memory.db``: read through the pinky-memory MCP tools; there is no
+  external snapshot path while a holder runs.
+- write/migration: stop the holder process first, then re-run.
+
+A raw byte copy of db+wal is NOT a safe snapshot: it cannot orphan the
+holder's WAL (it never opens the database), but it is not
+transaction-consistent — under rollback-journal cache spill it captures
+uncommitted pages that look committed and pass ``integrity_check``.
 """
 
 from __future__ import annotations
 
-import shutil
-import sqlite3
 import subprocess
-import tempfile
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parent.parent
 DATA_DIR = (REPO / "data").resolve()
 
 
+class HolderDetectionError(RuntimeError):
+    """Process detection failed: liveness of a potential holder is unknown."""
+
+
 def _proc_running(pattern: str) -> bool:
-    """True if any process command line matches ``pattern`` (pgrep -f)."""
+    """True if any process command line matches ``pattern`` (pgrep -f).
+
+    Only pgrep exit status 1 proves "no match". Execution failure, timeout,
+    or any other exit status leaves holder liveness unknown and raises
+    HolderDetectionError so callers fail closed instead of authorizing the
+    open.
+    """
     try:
         out = subprocess.run(
             ["pgrep", "-f", pattern], capture_output=True, text=True, timeout=5
         )
-        return out.returncode == 0 and out.stdout.strip() != ""
-    except Exception:
-        # Detection failure only: the snapshot_ro copy path is always safe
-        # regardless, and refuse_if_live_store treats "unknown" conservatively.
+    except Exception as exc:
+        raise HolderDetectionError(f"pgrep -f {pattern!r}: {exc}") from exc
+    if out.returncode == 0:
+        return True
+    if out.returncode == 1:
         return False
+    raise HolderDetectionError(
+        f"pgrep -f {pattern!r} exited {out.returncode}: "
+        f"{out.stderr.strip() or 'no stderr'}"
+    )
 
 
 def _holder(path) -> str | None:
-    """Return a human label for the live holder of ``path``, or None.
+    """Return a human label for a live holder of ``path``, or None.
 
-    Covers the two external-open vectors: a main-daemon store (``data/*.db``)
-    and an agent's pinky-memory ``memory.db``.
+    Raises HolderDetectionError when a check that could clear the path fails.
+    Covers both memory-store topologies: the shared-MCP pool inside the
+    daemon process (current) and a legacy stdio ``pinky_memory`` process.
+    The daemon pattern is deliberately broad ("pinky_daemon", any mode): a
+    false positive only refuses an open, never authorizes one.
     """
     p = Path(path).resolve()
     # Main daemon store: a *.db directly in the daemon's data/ dir.
     if p.suffix == ".db" and p.parent == DATA_DIR:
-        if _proc_running("pinky_daemon --mode api"):
+        if _proc_running("pinky_daemon"):
             return "the PinkyBot daemon"
-    # Per-agent memory store held by that agent's pinky-memory MCP.
+    # Per-agent memory store: the daemon's shared-MCP memory pool opens these
+    # in-process, so the daemon itself is a holder even with no separate
+    # pinky_memory process running.
     if p.name == "memory.db" and "agents" in p.parts and DATA_DIR in p.parents:
+        if _proc_running("pinky_daemon"):
+            return "the PinkyBot daemon (shared-MCP memory pool)"
         if _proc_running("pinky_memory"):
             return "a pinky-memory MCP"
     return None
+
+
+_ALTERNATIVES = (
+    "  - daemon-catalog store: scripts/store_snapshot.py (daemon-owned, verified)\n"
+    "  - agent memory.db:      read via the pinky-memory MCP tools\n"
+    "  - write/migration:      stop the holder process first, then re-run."
+)
 
 
 def refuse_if_live_store(path, *, write: bool) -> None:
@@ -69,33 +103,21 @@ def refuse_if_live_store(path, *, write: bool) -> None:
 
     Refuses both write and read in-place opens while the holder runs: a read
     open in the default journal mode still recreates the sidecars and orphans
-    the holder's WAL. Stop the holder first, or use the safe alternatives.
+    the holder's WAL. Also refuses when holder detection fails — the guard
+    must not authorize an open it cannot prove safe.
     """
-    holder = _holder(path)
+    kind = "write" if write else "read"
+    try:
+        holder = _holder(path)
+    except HolderDetectionError as exc:
+        raise SystemExit(
+            f"REFUSED (fail closed): cannot determine whether a live holder has "
+            f"{path} open ({exc}); an unknown holder is not an absent holder.\n"
+            f"{_ALTERNATIVES}"
+        ) from exc
     if holder is not None:
-        kind = "write" if write else "read"
         raise SystemExit(
             f"REFUSED: in-place {kind} open of {path} while {holder} holds it open "
             f"would orphan its WAL and silently freeze the on-disk file (#1126).\n"
-            f"  - registered store: use scripts/store_snapshot.py (daemon-owned, verified)\n"
-            f"  - ad-hoc read:      use _safe_db.snapshot_ro(path)\n"
-            f"  - write/migration:  stop the holder process first, then re-run."
+            f"{_ALTERNATIVES}"
         )
-
-
-def snapshot_ro(path) -> sqlite3.Connection:
-    """Raw-copy ``path`` (+ -wal/-shm) to a temp file; return a RO connection.
-
-    Safe against a live holder -- reads a point-in-time byte copy, never the
-    live file. The caller owns closing the connection; the temp copy is left in
-    the system temp dir for the caller to discard.
-    """
-    src = Path(path)
-    tmpdir = Path(tempfile.mkdtemp(prefix="safe_db_"))
-    dst = tmpdir / src.name
-    shutil.copy2(src, dst)
-    for ext in ("-wal", "-shm"):
-        sidecar = Path(str(src) + ext)
-        if sidecar.exists():
-            shutil.copy2(sidecar, str(dst) + ext)
-    return sqlite3.connect(f"file:{dst}?mode=ro", uri=True)

--- a/scripts/_safe_db.py
+++ b/scripts/_safe_db.py
@@ -1,0 +1,101 @@
+"""Guard against opening live daemon/MCP-held SQLite stores in place.
+
+The PinkyBot daemon keeps ~40 WAL-mode stores under ``data/`` open for its
+whole lifetime, and each agent's pinky-memory MCP keeps that agent's
+``memory.db`` open. Opening one of those files in place from an external
+process (a bare ``sqlite3`` CLI, a backfill/migration script) recreates the
+``-wal``/``-shm`` sidecars, orphaning the holder's open fd: the holder then
+commits into an unlinked WAL that no path-linked reader sees, and the on-disk
+main file silently freezes. Recovered from exactly this on 2026-08-19 (root
+cause of #1126); see notes/wal-orphan-tooling-audit-641.md.
+
+A raw *byte* copy (``shutil.copy2`` / cp / rsync) is safe: it never opens the
+file as a database, so it never recreates the sidecars.
+
+Use this instead of a bare ``sqlite3.connect()`` on anything under ``data/``:
+
+- ``refuse_if_live_store(path, write=...)`` -- FAIL LOUD before an in-place open
+  of a store whose holder process is running. For a *registered* store prefer
+  the daemon-owned verified snapshot (``scripts/store_snapshot.py``).
+- ``snapshot_ro(path)`` -- raw-copy db (+ -wal/-shm) to a temp file and return a
+  read-only connection to the copy; safe against a live holder.
+"""
+
+from __future__ import annotations
+
+import shutil
+import sqlite3
+import subprocess
+import tempfile
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+DATA_DIR = (REPO / "data").resolve()
+
+
+def _proc_running(pattern: str) -> bool:
+    """True if any process command line matches ``pattern`` (pgrep -f)."""
+    try:
+        out = subprocess.run(
+            ["pgrep", "-f", pattern], capture_output=True, text=True, timeout=5
+        )
+        return out.returncode == 0 and out.stdout.strip() != ""
+    except Exception:
+        # Detection failure only: the snapshot_ro copy path is always safe
+        # regardless, and refuse_if_live_store treats "unknown" conservatively.
+        return False
+
+
+def _holder(path) -> str | None:
+    """Return a human label for the live holder of ``path``, or None.
+
+    Covers the two external-open vectors: a main-daemon store (``data/*.db``)
+    and an agent's pinky-memory ``memory.db``.
+    """
+    p = Path(path).resolve()
+    # Main daemon store: a *.db directly in the daemon's data/ dir.
+    if p.suffix == ".db" and p.parent == DATA_DIR:
+        if _proc_running("pinky_daemon --mode api"):
+            return "the PinkyBot daemon"
+    # Per-agent memory store held by that agent's pinky-memory MCP.
+    if p.name == "memory.db" and "agents" in p.parts and DATA_DIR in p.parents:
+        if _proc_running("pinky_memory"):
+            return "a pinky-memory MCP"
+    return None
+
+
+def refuse_if_live_store(path, *, write: bool) -> None:
+    """Abort (SystemExit) before an in-place open of a live daemon/MCP store.
+
+    Refuses both write and read in-place opens while the holder runs: a read
+    open in the default journal mode still recreates the sidecars and orphans
+    the holder's WAL. Stop the holder first, or use the safe alternatives.
+    """
+    holder = _holder(path)
+    if holder is not None:
+        kind = "write" if write else "read"
+        raise SystemExit(
+            f"REFUSED: in-place {kind} open of {path} while {holder} holds it open "
+            f"would orphan its WAL and silently freeze the on-disk file (#1126).\n"
+            f"  - registered store: use scripts/store_snapshot.py (daemon-owned, verified)\n"
+            f"  - ad-hoc read:      use _safe_db.snapshot_ro(path)\n"
+            f"  - write/migration:  stop the holder process first, then re-run."
+        )
+
+
+def snapshot_ro(path) -> sqlite3.Connection:
+    """Raw-copy ``path`` (+ -wal/-shm) to a temp file; return a RO connection.
+
+    Safe against a live holder -- reads a point-in-time byte copy, never the
+    live file. The caller owns closing the connection; the temp copy is left in
+    the system temp dir for the caller to discard.
+    """
+    src = Path(path)
+    tmpdir = Path(tempfile.mkdtemp(prefix="safe_db_"))
+    dst = tmpdir / src.name
+    shutil.copy2(src, dst)
+    for ext in ("-wal", "-shm"):
+        sidecar = Path(str(src) + ext)
+        if sidecar.exists():
+            shutil.copy2(sidecar, str(dst) + ext)
+    return sqlite3.connect(f"file:{dst}?mode=ro", uri=True)

--- a/scripts/backfill_codex_runtime.py
+++ b/scripts/backfill_codex_runtime.py
@@ -7,13 +7,16 @@ Dry-run by default. Pass --apply to update matching rows.
 from __future__ import annotations
 
 import argparse
+import os
 import sqlite3
 import sys
 import time
 from pathlib import Path
 from typing import Any
 
-from _safe_db import refuse_if_live_store
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))  # scripts/ for _safe_db
+
+from _safe_db import refuse_if_live_store  # noqa: E402
 
 DEFAULT_DB_PATH = Path("data/pinky_agents.db")
 

--- a/scripts/backfill_codex_runtime.py
+++ b/scripts/backfill_codex_runtime.py
@@ -13,6 +13,8 @@ import time
 from pathlib import Path
 from typing import Any
 
+from _safe_db import refuse_if_live_store
+
 DEFAULT_DB_PATH = Path("data/pinky_agents.db")
 
 MATCH_QUERY = """
@@ -36,6 +38,8 @@ UPDATE_QUERY = """
 def _connect(db_path: Path) -> sqlite3.Connection:
     if not db_path.exists():
         raise FileNotFoundError(f"agents database not found: {db_path}")
+    # Never open a live daemon store in place (#1126): stop the daemon first.
+    refuse_if_live_store(db_path, write=True)
     conn = sqlite3.connect(str(db_path))
     conn.row_factory = sqlite3.Row
     return conn

--- a/scripts/backfill_embeddings.py
+++ b/scripts/backfill_embeddings.py
@@ -13,8 +13,11 @@ Safety:
   * Idempotent: only touches rows whose embedding is empty (``length<=2``,
     i.e. the ``'[]'`` default) AND have non-empty content. Never overwrites an
     existing real embedding, never touches content.
-  * Per-batch transactions with a busy timeout so it cooperates with the live
-    daemon's WAL connections.
+  * Per-batch transactions with a busy timeout (handles LOCK contention). NOTE:
+    busy_timeout does NOT make an in-place open safe against a live holder — an
+    external open still recreates the -wal/-shm sidecars and orphans the
+    holder's WAL (#1126). Run with the daemon + pinky-memory MCPs stopped; the
+    _safe_db guard refuses otherwise.
   * The OpenAI key is read from system_settings (same source the fix uses);
     nothing is printed.
 
@@ -33,7 +36,10 @@ import sqlite3
 import sys
 
 REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))  # scripts/ for _safe_db
 sys.path.insert(0, os.path.join(REPO, "src"))
+
+from _safe_db import refuse_if_live_store  # noqa: E402
 
 SETTINGS_DB = os.path.join(REPO, "data", "conversations_agents.db")
 BATCH = 100
@@ -42,6 +48,7 @@ BATCH = 100
 def resolve_openai_key() -> str:
     """Read OPENAI_API_KEY from system_settings, else env. No printing."""
     try:
+        refuse_if_live_store(SETTINGS_DB, write=False)
         conn = sqlite3.connect(SETTINGS_DB)
         row = conn.execute(
             "SELECT value FROM system_settings WHERE key='OPENAI_API_KEY'"
@@ -63,6 +70,7 @@ def discover_dbs(agent: str = "") -> list[str]:
     dbs = []
     for p in sorted(glob.glob(pat)):
         try:
+            refuse_if_live_store(p, write=False)
             c = sqlite3.connect(p)
             has = c.execute(
                 "SELECT name FROM sqlite_master WHERE type='table' AND name='reflections'"
@@ -77,6 +85,7 @@ def discover_dbs(agent: str = "") -> list[str]:
 
 def backfill_db(path: str, embedder, apply: bool) -> tuple[int, int]:
     """Returns (rows_needing_backfill, rows_written)."""
+    refuse_if_live_store(path, write=apply)
     conn = sqlite3.connect(path, timeout=30.0)
     conn.execute("PRAGMA busy_timeout=30000")
     rows = conn.execute(

--- a/scripts/kg_ephemeral_sweep.py
+++ b/scripts/kg_ephemeral_sweep.py
@@ -41,6 +41,9 @@ from datetime import datetime, timezone
 # runs this cron.
 from pinky_memory.ephemeral_guard import is_ephemeral
 
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))  # scripts/ for _safe_db
+from _safe_db import refuse_if_live_store  # noqa: E402
+
 
 def find_candidates(conn):
     rows = conn.execute("SELECT id, name, type FROM kg_entities").fetchall()
@@ -85,6 +88,9 @@ def main():
         print(f"ERROR: db not found: {db}")
         sys.exit(2)
 
+    # Never open a live memory.db in place (#1126): stop the agent's MCP first.
+    # (busy_timeout below handles lock contention, NOT WAL-sidecar orphaning.)
+    refuse_if_live_store(db, write=True)
     conn = sqlite3.connect(db, timeout=10)
     conn.execute("PRAGMA busy_timeout = 8000")
 

--- a/tests/test_safe_db_guard.py
+++ b/tests/test_safe_db_guard.py
@@ -1,0 +1,160 @@
+"""Tests for scripts/_safe_db.py — the live-store in-place-open guard.
+
+Covers holder detection for both memory-store topologies (shared-MCP pool
+inside the daemon process, legacy stdio pinky_memory), fail-closed behavior
+on detection failure, and the no-holder / non-candidate allow paths.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+import _safe_db  # noqa: E402
+
+
+@pytest.fixture()
+def stores(tmp_path, monkeypatch):
+    """Scratch data/ root with one main store and one agent memory store."""
+    data_dir = (tmp_path / "data").resolve()
+    main_db = data_dir / "conversations.db"
+    mem_db = data_dir / "agents" / "tabby" / "data" / "memory.db"
+    mem_db.parent.mkdir(parents=True)
+    mem_db.touch()
+    main_db.touch()
+    monkeypatch.setattr(_safe_db, "DATA_DIR", data_dir)
+    return SimpleNamespace(data=data_dir, main=main_db, memory=mem_db)
+
+
+def _patch_topology(monkeypatch, *, daemon: bool, pinky_memory: bool) -> list[str]:
+    """Replace _proc_running with a deterministic process topology."""
+    calls: list[str] = []
+    running = {"pinky_daemon": daemon, "pinky_memory": pinky_memory}
+
+    def fake(pattern: str) -> bool:
+        calls.append(pattern)
+        assert pattern in running, f"unexpected pgrep pattern {pattern!r}"
+        return running[pattern]
+
+    monkeypatch.setattr(_safe_db, "_proc_running", fake)
+    return calls
+
+
+def _completed(returncode: int, stdout: str = "", stderr: str = ""):
+    return subprocess.CompletedProcess(
+        args=["pgrep"], returncode=returncode, stdout=stdout, stderr=stderr
+    )
+
+
+# ---------------------------------------------------------------- holders
+
+
+def test_main_store_refused_while_daemon_runs(stores, monkeypatch):
+    _patch_topology(monkeypatch, daemon=True, pinky_memory=False)
+    for write in (True, False):
+        with pytest.raises(SystemExit) as exc:
+            _safe_db.refuse_if_live_store(stores.main, write=write)
+        assert "REFUSED" in str(exc.value)
+        assert "store_snapshot.py" in str(exc.value)
+
+
+def test_memory_store_refused_in_shared_mcp_topology(stores, monkeypatch):
+    """The production topology: no pinky_memory process, pool inside daemon."""
+    _patch_topology(monkeypatch, daemon=True, pinky_memory=False)
+    with pytest.raises(SystemExit) as exc:
+        _safe_db.refuse_if_live_store(stores.memory, write=False)
+    assert "shared-MCP memory pool" in str(exc.value)
+
+
+def test_memory_store_refused_in_stdio_topology(stores, monkeypatch):
+    _patch_topology(monkeypatch, daemon=False, pinky_memory=True)
+    with pytest.raises(SystemExit) as exc:
+        _safe_db.refuse_if_live_store(stores.memory, write=True)
+    assert "pinky-memory MCP" in str(exc.value)
+
+
+def test_no_holder_allows_open(stores, monkeypatch):
+    _patch_topology(monkeypatch, daemon=False, pinky_memory=False)
+    _safe_db.refuse_if_live_store(stores.main, write=True)
+    _safe_db.refuse_if_live_store(stores.memory, write=True)
+
+
+def test_non_candidate_paths_never_probe_processes(stores, tmp_path, monkeypatch):
+    calls = _patch_topology(monkeypatch, daemon=True, pinky_memory=True)
+    outside = tmp_path / "elsewhere.db"
+    outside.touch()
+    nested_non_memory = stores.data / "agents" / "tabby" / "data" / "notes.db"
+    nested_non_memory.touch()
+    _safe_db.refuse_if_live_store(outside, write=True)
+    _safe_db.refuse_if_live_store(nested_non_memory, write=True)
+    assert calls == []
+
+
+def test_snapshot_pointer_resolves():
+    """The refusal text points at store_snapshot.py; it must exist."""
+    assert (SCRIPTS_DIR / "store_snapshot.py").is_file()
+
+
+# ------------------------------------------------- fail-closed detection
+
+
+@pytest.mark.parametrize(
+    "failure",
+    [
+        FileNotFoundError("pgrep unavailable"),
+        subprocess.TimeoutExpired(cmd=["pgrep"], timeout=5),
+    ],
+    ids=["pgrep-missing", "pgrep-timeout"],
+)
+def test_detection_failure_refuses_protected_paths(stores, monkeypatch, failure):
+    def raising_run(*args, **kwargs):
+        raise failure
+
+    monkeypatch.setattr(_safe_db.subprocess, "run", raising_run)
+    for path in (stores.main, stores.memory):
+        with pytest.raises(SystemExit) as exc:
+            _safe_db.refuse_if_live_store(path, write=False)
+        assert "fail closed" in str(exc.value)
+
+
+def test_pgrep_error_status_refuses(stores, monkeypatch):
+    monkeypatch.setattr(
+        _safe_db.subprocess,
+        "run",
+        lambda *a, **k: _completed(2, stderr="pgrep: invalid option"),
+    )
+    with pytest.raises(SystemExit) as exc:
+        _safe_db.refuse_if_live_store(stores.main, write=True)
+    assert "fail closed" in str(exc.value)
+
+
+def test_pgrep_no_match_is_the_only_allow(stores, monkeypatch):
+    monkeypatch.setattr(_safe_db.subprocess, "run", lambda *a, **k: _completed(1))
+    _safe_db.refuse_if_live_store(stores.main, write=True)
+
+
+def test_pgrep_match_refuses_even_with_empty_stdout(stores, monkeypatch):
+    monkeypatch.setattr(
+        _safe_db.subprocess, "run", lambda *a, **k: _completed(0, stdout="")
+    )
+    with pytest.raises(SystemExit):
+        _safe_db.refuse_if_live_store(stores.main, write=True)
+
+
+def test_proc_running_maps_statuses(monkeypatch):
+    monkeypatch.setattr(
+        _safe_db.subprocess, "run", lambda *a, **k: _completed(0, stdout="123\n")
+    )
+    assert _safe_db._proc_running("x") is True
+    monkeypatch.setattr(_safe_db.subprocess, "run", lambda *a, **k: _completed(1))
+    assert _safe_db._proc_running("x") is False
+    monkeypatch.setattr(_safe_db.subprocess, "run", lambda *a, **k: _completed(3))
+    with pytest.raises(_safe_db.HolderDetectionError):
+        _safe_db._proc_running("x")


### PR DESCRIPTION
## Problem (#1126)
The daemon keeps ~40 WAL-mode stores under `data/` open for its whole lifetime. Agent `memory.db` stores are held either by the shared-MCP memory pool running **inside the daemon process** (current topology) or by a legacy per-agent stdio `pinky_memory` process. Opening one of those files **in place** from an external process (a bare `sqlite3` CLI, a backfill/migration script) recreates the `-wal`/`-shm` sidecars on close/checkpoint, orphaning the holder's open fd. The holder then commits into an unlinked WAL that no path-linked reader sees, and the on-disk main file **silently freezes** for outside readers. (Recovered from exactly this on 2026-08-19: several stores had frozen while the daemon kept committing into orphaned WALs; only the graceful close-time checkpoint flushed the deltas back.)

## Change
- **New `scripts/_safe_db.py`**: `refuse_if_live_store(path, write=...)` fails loud (SystemExit) before an in-place open of a live store:
  - `data/*.db` → held by the daemon.
  - `data/agents/*/data/memory.db` → held by the daemon (shared-MCP memory pool) **or** a legacy stdio `pinky_memory` process — both topologies are checked.
  - **Fail-closed detection**: only pgrep exit status 1 proves "no match". Execution failure, timeout, or any other status raises `HolderDetectionError` and the open is refused — an unknown holder is not an absent holder.
  - Refusal guidance points at the sanctioned alternatives: `scripts/store_snapshot.py` (daemon-owned, verified, online-backup-API) for catalog stores; the pinky-memory MCP tools for memory reads; stopping the holder for writes/migrations.
- **No ad-hoc snapshot helper.** An earlier revision shipped a raw db+wal byte-copy reader; raw copies are *not* transaction-consistent (under rollback-journal cache spill the copy captures uncommitted pages that pass `integrity_check`), so it was removed rather than reimplemented — the sanctioned point-in-time path already exists in `store_snapshot.py`.
- **Wire the backfill/sweep scripts** (`backfill_codex_runtime`, `backfill_embeddings`, `kg_ephemeral_sweep`) to call the guard at their open sites, so a run against a live store aborts with the safe alternative instead of orphaning it.
- **Doc fix** in `backfill_embeddings`: `busy_timeout` handles lock contention, **not** WAL-sidecar orphaning.

## Verification
- `tests/test_safe_db_guard.py` (new, 12 tests): both memory-store topologies refuse; fail-closed on missing pgrep / timeout / error status; pgrep status mapping; no-holder allow; non-candidate paths never probe processes; the snapshot pointer resolves.
- `ruff check` + `py_compile` clean on all changed files.
- Functional (daemon running): `refuse_if_live_store('data/conversations_tasks.db', write=True)` → detects the daemon holder and refuses; a non-store tempfile is allowed (no false positive).

No UI (tooling/guard change) — no screenshot applicable.

🤖 Opened by barsik
