### PR TITLE
fix(#486): widen the sqlite-vec kNN window instead of silently returning fewer results

### DIFF
--- a/src/pinky_memory/store.py
+++ b/src/pinky_memory/store.py
@@ -826,37 +826,7 @@ class ReflectionStore:
         type_exclude: list[ReflectionType] | None = None,
     ) -> list[tuple[float, Reflection]]:
         """sqlite-vec indexed vector search (cosine distance)."""
-        # Fetch more candidates than needed so post-filtering still returns enough
-        fetch_k = limit * 5
         query_blob = self._embedding_to_blob(query_embedding)
-
-        try:
-            vec_rows = self._conn.execute(
-                "SELECT rowid, distance FROM reflections_vec "
-                "WHERE embedding MATCH ? AND k = ? ORDER BY distance",
-                (query_blob, fetch_k),
-            ).fetchall()
-        except Exception as exc:
-            # Fall back to numpy on any vec query failure. Log loudly —
-            # silent degradation here previously meant slower, differently
-            # ordered search with no signal that vec was broken.
-            self._vec_fallback_count += 1
-            logger.warning(
-                "sqlite-vec query failed (%s: %s) — falling back to numpy "
-                "scan (fallback #%d this process)",
-                type(exc).__name__,
-                exc,
-                self._vec_fallback_count,
-            )
-            return self._search_by_numpy(
-                query_embedding, limit, active_only,
-                type_filter, project_filter, min_weight,
-                recency_factor, access_boost, entity_filter,
-                type_exclude,
-            )
-
-        if not vec_rows:
-            return []
 
         # Build filter conditions for the main table
         where_clauses = []
@@ -883,33 +853,75 @@ class ReflectionStore:
         # Always exclude no_recall reflections from search
         where_clauses.append("no_recall = 0")
 
-        candidates = []
+        filter_sql = " AND ".join(where_clauses) if where_clauses else "1=1"
         now_dt = datetime.now(timezone.utc)
         now = now_dt.isoformat()
-        touch_ids = []
+        candidates: list[tuple[float, Reflection]] = []
+        touch_ids: list[str] = []
 
-        for rowid, distance in vec_rows:
-            similarity = 1.0 - distance  # cosine distance → cosine similarity
-            # Fetch the full reflection row and apply filters
-            filter_sql = " AND ".join(where_clauses) if where_clauses else "1=1"
-            row = self._conn.execute(
-                f"SELECT * FROM reflections WHERE rowid = ? AND {filter_sql}",
-                [rowid, *params],
-            ).fetchone()
-            if row is None:
-                continue
-            ref = self._row_to_reflection(row)
-            touch_ids.append(ref.id)
+        # The kNN window is filtered (active / no_recall / project / entity)
+        # only AFTER the search, so rows the filters discard can fill it
+        # entirely — recall then returned fewer than `limit` results, or none,
+        # with no error at all. Widen the window until it yields enough
+        # survivors or the index is exhausted. #486
+        fetch_k = max(limit * 5, 16)
+        while True:
+            try:
+                vec_rows = self._conn.execute(
+                    "SELECT rowid, distance FROM reflections_vec "
+                    "WHERE embedding MATCH ? AND k = ? ORDER BY distance",
+                    (query_blob, fetch_k),
+                ).fetchall()
+            except Exception as exc:
+                # Fall back to numpy on any vec query failure. Log loudly —
+                # silent degradation here previously meant slower, differently
+                # ordered search with no signal that vec was broken.
+                self._vec_fallback_count += 1
+                logger.warning(
+                    "sqlite-vec query failed (%s: %s) — falling back to numpy "
+                    "scan (fallback #%d this process)",
+                    type(exc).__name__,
+                    exc,
+                    self._vec_fallback_count,
+                )
+                return self._search_by_numpy(
+                    query_embedding, limit, active_only,
+                    type_filter, project_filter, min_weight,
+                    recency_factor, access_boost, entity_filter,
+                    type_exclude,
+                )
 
-            # Apply retrieval-time recency scoring
-            if recency_factor > 0:
-                hours_since = max(0, (now_dt - ref.accessed_at).total_seconds() / 3600)
-                recency_boost = recency_factor ** hours_since
-                final_score = similarity * ref.weight * recency_boost
-            else:
-                final_score = similarity
+            if not vec_rows:
+                return []
 
-            candidates.append((final_score, ref))
+            candidates = []
+            touch_ids = []
+            for rowid, distance in vec_rows:
+                similarity = 1.0 - distance  # cosine distance → cosine similarity
+                # Fetch the full reflection row and apply filters
+                row = self._conn.execute(
+                    f"SELECT * FROM reflections WHERE rowid = ? AND {filter_sql}",
+                    [rowid, *params],
+                ).fetchone()
+                if row is None:
+                    continue
+                ref = self._row_to_reflection(row)
+                touch_ids.append(ref.id)
+
+                # Apply retrieval-time recency scoring
+                if recency_factor > 0:
+                    hours_since = max(0, (now_dt - ref.accessed_at).total_seconds() / 3600)
+                    recency_boost = recency_factor ** hours_since
+                    final_score = similarity * ref.weight * recency_boost
+                else:
+                    final_score = similarity
+
+                candidates.append((final_score, ref))
+
+            # Enough survivors, or the index has nothing left to give.
+            if len(candidates) >= limit or len(vec_rows) < fetch_k:
+                break
+            fetch_k *= 4
 
         # Re-sort by final score and take top-limit
         candidates.sort(key=lambda x: x[0], reverse=True)

--- a/src/pinky_memory/store.py
+++ b/src/pinky_memory/store.py
@@ -1401,30 +1401,42 @@ class ReflectionStore:
         query_blob = self._embedding_to_blob(embedding)
         max_distance = 1.0 - threshold  # cosine distance threshold
 
-        try:
-            # Fetch top-5 candidates — we just need the best match above threshold
-            vec_rows = self._conn.execute(
-                "SELECT rowid, distance FROM reflections_vec "
-                "WHERE embedding MATCH ? AND k = 5 ORDER BY distance",
-                (query_blob,),
-            ).fetchall()
-        except sqlite3.OperationalError as e:
-            # vec query failed — fall back to numpy near-duplicate scan. #295
-            logger.debug("vec near-dup query failed, using numpy: %s", e)
-            return self._find_near_duplicate_numpy(embedding, threshold, active_only)
+        where_sql = "rowid = ? AND active = 1" if active_only else "rowid = ?"
 
-        for rowid, distance in vec_rows:
-            if distance > max_distance:
-                break  # results are ordered by distance — no more matches
-            where_sql = "rowid = ? AND active = 1" if active_only else "rowid = ?"
-            row = self._conn.execute(
-                f"SELECT * FROM reflections WHERE {where_sql}", (rowid,)
-            ).fetchone()
-            if row is not None:
-                similarity = 1.0 - distance
-                return (similarity, self._row_to_reflection(row))
+        # The kNN window is filtered by `active` only AFTER the search, so a
+        # fixed k can be filled entirely by superseded versions of this very
+        # reflection — its nearest neighbours in absolute terms — and hide the
+        # active duplicate behind them. Widen the window until it reaches past
+        # the distance threshold (or the whole table), so every candidate that
+        # could match is examined. #486
+        k = 16
+        while True:
+            try:
+                vec_rows = self._conn.execute(
+                    "SELECT rowid, distance FROM reflections_vec "
+                    "WHERE embedding MATCH ? AND k = ? ORDER BY distance",
+                    (query_blob, k),
+                ).fetchall()
+            except sqlite3.OperationalError as e:
+                # vec query failed — fall back to numpy near-duplicate scan. #295
+                logger.debug("vec near-dup query failed, using numpy: %s", e)
+                return self._find_near_duplicate_numpy(embedding, threshold, active_only)
 
-        return None
+            for rowid, distance in vec_rows:
+                if distance > max_distance:
+                    return None  # ordered by distance — nothing else can match
+                row = self._conn.execute(
+                    f"SELECT * FROM reflections WHERE {where_sql}", (rowid,)
+                ).fetchone()
+                if row is not None:
+                    similarity = 1.0 - distance
+                    return (similarity, self._row_to_reflection(row))
+
+            # Window exhausted without crossing the threshold: if it was not
+            # full, we have already seen every indexed row.
+            if len(vec_rows) < k:
+                return None
+            k *= 4
 
     def _find_near_duplicate_numpy(
         self,

--- a/src/pinky_memory/store.py
+++ b/src/pinky_memory/store.py
@@ -1833,36 +1833,45 @@ class ReflectionStore:
     ) -> list[tuple[float, Reflection]]:
         """sqlite-vec based k-NN for consolidation."""
         query_blob = self._embedding_to_blob(ref.embedding)
-        fetch_k = k * 3  # over-fetch for filtering
 
-        try:
-            vec_rows = self._conn.execute(
-                "SELECT rowid, distance FROM reflections_vec "
-                "WHERE embedding MATCH ? AND k = ? ORDER BY distance",
-                (query_blob, fetch_k),
-            ).fetchall()
-        except sqlite3.OperationalError as e:
-            # vec query failed during consolidation — use numpy k-NN. #295
-            logger.debug("vec k-NN failed, using numpy: %s", e)
-            return self._knn_numpy(ref, k, exclude)
+        # The kNN window is filtered (active / self / exclude set) only AFTER
+        # the search, so rows the filters discard can fill it entirely and
+        # consolidation then sees fewer than `k` neighbours — or none — with
+        # no error. Widen the window until it yields enough survivors or the
+        # index is exhausted. #486
+        fetch_k = max(k * 3, 16)
+        while True:
+            try:
+                vec_rows = self._conn.execute(
+                    "SELECT rowid, distance FROM reflections_vec "
+                    "WHERE embedding MATCH ? AND k = ? ORDER BY distance",
+                    (query_blob, fetch_k),
+                ).fetchall()
+            except sqlite3.OperationalError as e:
+                # vec query failed during consolidation — use numpy k-NN. #295
+                logger.debug("vec k-NN failed, using numpy: %s", e)
+                return self._knn_numpy(ref, k, exclude)
 
-        results = []
-        for rowid, distance in vec_rows:
-            if len(results) >= k:
-                break
-            similarity = 1.0 - distance
-            row = self._conn.execute(
-                "SELECT * FROM reflections WHERE rowid = ? AND active = 1",
-                (rowid,),
-            ).fetchone()
-            if row is None:
-                continue
-            candidate = self._row_to_reflection(row)
-            if candidate.id == ref.id or candidate.id in exclude:
-                continue
-            results.append((similarity, candidate))
+            results = []
+            for rowid, distance in vec_rows:
+                if len(results) >= k:
+                    break
+                similarity = 1.0 - distance
+                row = self._conn.execute(
+                    "SELECT * FROM reflections WHERE rowid = ? AND active = 1",
+                    (rowid,),
+                ).fetchone()
+                if row is None:
+                    continue
+                candidate = self._row_to_reflection(row)
+                if candidate.id == ref.id or candidate.id in exclude:
+                    continue
+                results.append((similarity, candidate))
 
-        return results
+            # Enough neighbours, or the index has nothing left to give.
+            if len(results) >= k or len(vec_rows) < fetch_k:
+                return results
+            fetch_k *= 4
 
     def _knn_numpy(
         self,

--- a/tests/test_memory_knn_consolidation_window.py
+++ b/tests/test_memory_knn_consolidation_window.py
@@ -1,0 +1,115 @@
+"""k-NN for consolidation on the sqlite-vec path (#486 difetto 3).
+
+_knn_vec fetched a FIXED window (fetch_k = k * 3) and only afterwards dropped
+inactive rows, the reference itself and the caller's exclude set. Rows removed
+by those filters can fill the whole window, so consolidation sees fewer than
+`k` neighbours — or none — while eligible ones exist just past the window.
+"""
+from __future__ import annotations
+
+from pinky_memory.store import ReflectionStore
+from pinky_memory.types import Reflection
+
+
+def _store(tmp_path) -> ReflectionStore:
+    return ReflectionStore(db_path=str(tmp_path / "reflections.db"))
+
+
+def test_neighbours_found_behind_a_window_of_inactive_rows(tmp_path):
+    """Inactive rows nearer than the neighbours must not starve the result."""
+    store = _store(tmp_path)
+
+    # 20 inactive rows, all nearer to the probe than the active ones.
+    # With k=3 the old window was fetch_k=9 — entirely filled by these.
+    for i in range(20):
+        store.insert(
+            Reflection(
+                content=f"inactive {i}",
+                embedding=[1.0, 0.0001 * (i + 1), 0.0, 0.0],
+                active=False,
+            )
+        )
+
+    active_ids = []
+    for i in range(3):
+        ref = store.insert(
+            Reflection(
+                content=f"active {i}",
+                embedding=[1.0, 0.1 * (i + 1), 0.0, 0.0],
+                active=True,
+            )
+        )
+        active_ids.append(ref.id)
+
+    probe = Reflection(content="probe", embedding=[1.0, 0.0, 0.0, 0.0], active=True)
+
+    # Guard: the defect only exists on the vec path.
+    assert store._vec_available is True
+    assert store._vec_dimensions == len(probe.embedding)
+
+    results = store._knn_for_consolidation(probe, k=3)
+
+    assert len(results) == 3, f"knn returned {len(results)} of 3 available neighbours"
+    assert {ref.id for _, ref in results} == set(active_ids)
+
+    store.close()
+
+
+def test_excluded_ids_do_not_starve_the_window(tmp_path):
+    """The caller's exclude set is applied post-kNN and must not eat the window."""
+    store = _store(tmp_path)
+
+    excluded = []
+    for i in range(20):
+        ref = store.insert(
+            Reflection(
+                content=f"excluded {i}",
+                embedding=[1.0, 0.0001 * (i + 1), 0.0, 0.0],
+                active=True,
+            )
+        )
+        excluded.append(ref.id)
+
+    wanted = []
+    for i in range(2):
+        ref = store.insert(
+            Reflection(
+                content=f"wanted {i}",
+                embedding=[1.0, 0.1 * (i + 1), 0.0, 0.0],
+                active=True,
+            )
+        )
+        wanted.append(ref.id)
+
+    probe = Reflection(content="probe", embedding=[1.0, 0.0, 0.0, 0.0], active=True)
+    assert store._vec_available is True
+
+    results = store._knn_for_consolidation(probe, k=2, exclude_ids=set(excluded))
+
+    assert len(results) == 2, f"knn returned {len(results)} of 2 eligible neighbours"
+    assert {ref.id for _, ref in results} == set(wanted)
+
+    store.close()
+
+
+def test_window_stops_when_index_is_exhausted(tmp_path):
+    """Fewer eligible rows than k must terminate, not loop forever."""
+    store = _store(tmp_path)
+    for i in range(4):
+        store.insert(
+            Reflection(
+                content=f"inactive {i}",
+                embedding=[1.0, 0.0001 * (i + 1), 0.0, 0.0],
+                active=False,
+            )
+        )
+    only = store.insert(
+        Reflection(content="only active", embedding=[1.0, 0.2, 0.0, 0.0], active=True)
+    )
+
+    probe = Reflection(content="probe", embedding=[1.0, 0.0, 0.0, 0.0], active=True)
+    results = store._knn_for_consolidation(probe, k=5)
+
+    assert [ref.id for _, ref in results] == [only.id]
+
+    store.close()

--- a/tests/test_memory_near_duplicate.py
+++ b/tests/test_memory_near_duplicate.py
@@ -1,0 +1,62 @@
+"""Near-duplicate detection on the sqlite-vec path (#486 difetto 2).
+
+The vec path fetches a FIXED window of neighbours (k) and only afterwards
+filters by `active = 1`. Superseded versions of a reflection are its nearest
+neighbours in absolute terms, so they can fill the whole window and make
+find_near_duplicate() return None — the duplicate then gets written again.
+"""
+from __future__ import annotations
+
+from pinky_memory.store import ReflectionStore
+from pinky_memory.types import Reflection
+
+
+def _store(tmp_path) -> ReflectionStore:
+    return ReflectionStore(db_path=str(tmp_path / "reflections.db"))
+
+
+def _insert(store: ReflectionStore, content: str, embedding: list[float], active: bool):
+    return store.insert(
+        Reflection(content=content, embedding=embedding, active=active)
+    )
+
+
+def test_active_duplicate_found_behind_a_window_of_superseded_neighbours(tmp_path):
+    """An active duplicate must be found even when many inactive rows are closer."""
+    store = _store(tmp_path)
+    query = [1.0, 0.0, 0.0, 0.0]
+
+    # Six superseded (inactive) versions, all nearer to the query than the
+    # active duplicate — enough to fill any small fixed kNN window.
+    for i in range(6):
+        _insert(store, f"superseded v{i}", [1.0, 0.0001 * (i + 1), 0.0, 0.0], False)
+
+    # The active near-duplicate: cosine similarity ≈ 0.98, above threshold.
+    active = _insert(store, "active duplicate", [1.0, 0.2, 0.0, 0.0], True)
+
+    # Guard: the bug only exists on the vec path — make sure we exercise it.
+    assert store._vec_available is True
+    assert store._vec_dimensions == len(query)
+
+    result = store.find_near_duplicate(query, threshold=0.90, active_only=True)
+
+    assert result is not None, "active duplicate hidden behind superseded neighbours"
+    similarity, found = result
+    assert found.id == active.id
+    assert similarity > 0.90
+
+    store.close()
+
+
+def test_returns_none_when_no_active_row_is_above_threshold(tmp_path):
+    """No false positives: a distant active row must not be reported."""
+    store = _store(tmp_path)
+    query = [1.0, 0.0, 0.0, 0.0]
+
+    _insert(store, "orthogonal", [0.0, 1.0, 0.0, 0.0], True)
+
+    assert store._vec_available is True
+
+    assert store.find_near_duplicate(query, threshold=0.90, active_only=True) is None
+
+    store.close()

--- a/tests/test_memory_vec_search_window.py
+++ b/tests/test_memory_vec_search_window.py
@@ -1,0 +1,104 @@
+"""Vector recall on the sqlite-vec path (#486 difetto 1).
+
+_search_by_vec fetches a FIXED window (fetch_k = limit * 5) and only afterwards
+applies the active / no_recall / project / entity filters. Rows excluded by
+those filters can fill the whole window, so recall() silently returns fewer
+than `limit` results — or none at all — while matching rows exist.
+"""
+from __future__ import annotations
+
+from pinky_memory.store import ReflectionStore
+from pinky_memory.types import Reflection
+
+
+def _store(tmp_path) -> ReflectionStore:
+    return ReflectionStore(db_path=str(tmp_path / "reflections.db"))
+
+
+def test_active_rows_found_behind_a_window_of_inactive_neighbours(tmp_path):
+    """Inactive rows nearer than the matches must not starve the result set."""
+    store = _store(tmp_path)
+    query = [1.0, 0.0, 0.0, 0.0]
+
+    # 20 inactive rows, all nearer to the query than the active ones.
+    # With limit=3 the old window was k=15 — entirely filled by these.
+    for i in range(20):
+        store.insert(
+            Reflection(
+                content=f"inactive {i}",
+                embedding=[1.0, 0.0001 * (i + 1), 0.0, 0.0],
+                active=False,
+            )
+        )
+
+    active_ids = []
+    for i in range(3):
+        ref = store.insert(
+            Reflection(
+                content=f"active {i}",
+                embedding=[1.0, 0.1 * (i + 1), 0.0, 0.0],
+                active=True,
+            )
+        )
+        active_ids.append(ref.id)
+
+    # Guard: the defect only exists on the vec path.
+    assert store._vec_available is True
+    assert store._vec_dimensions == len(query)
+
+    results = store.search_by_embedding_scored(query, limit=3, active_only=True)
+
+    assert len(results) == 3, f"recall returned {len(results)} of 3 available matches"
+    assert {ref.id for _, ref in results} == set(active_ids)
+
+    store.close()
+
+
+def test_no_recall_rows_do_not_starve_the_window(tmp_path):
+    """no_recall rows are excluded post-kNN and must not eat the window either."""
+    store = _store(tmp_path)
+    query = [1.0, 0.0, 0.0, 0.0]
+
+    for i in range(20):
+        store.insert(
+            Reflection(
+                content=f"hidden {i}",
+                embedding=[1.0, 0.0001 * (i + 1), 0.0, 0.0],
+                active=True,
+                no_recall=True,
+            )
+        )
+
+    wanted = store.insert(
+        Reflection(content="wanted", embedding=[1.0, 0.2, 0.0, 0.0], active=True)
+    )
+
+    assert store._vec_available is True
+
+    results = store.search_by_embedding_scored(query, limit=2, active_only=True)
+
+    assert [ref.id for _, ref in results] == [wanted.id]
+
+    store.close()
+
+
+def test_limit_is_still_respected_when_everything_matches(tmp_path):
+    """Widening the window must not return more than `limit`."""
+    store = _store(tmp_path)
+    query = [1.0, 0.0, 0.0, 0.0]
+
+    for i in range(10):
+        store.insert(
+            Reflection(
+                content=f"match {i}",
+                embedding=[1.0, 0.01 * (i + 1), 0.0, 0.0],
+                active=True,
+            )
+        )
+
+    assert store._vec_available is True
+
+    results = store.search_by_embedding_scored(query, limit=4, active_only=True)
+    assert len(results) == 4
+
+    store.close()


### PR DESCRIPTION
Fixes the three vector-search paths in `pinky_memory/store.py` that fetched a **fixed** kNN window and only applied their filters *afterwards*. When the discarded rows filled the window, the caller got fewer results than asked for — or none — with no error at all.

### The defect

`reflections_vec` is a standalone `vec0` table keyed by rowid: it has no notion of `active`, `no_recall`, project or entity (unlike `reflections_fts`, which is FTS5 external content). So each path took the first *k* rowids and then dropped the ineligible ones, never re-querying.

| path | old window | effect |
|---|---|---|
| `_search_by_vec` | `limit * 5` | `recall(limit=10)` returned 0 where the numpy fallback returned 5 correct rows |
| `_find_near_duplicate_vec` | `k = 5`, fixed | returned `None` for a near-exact duplicate → a duplicate got inserted |
| `_knn_vec` | `k * 3` | consolidation saw 0 of 3 eligible neighbours |

Measured on live stores (read-only): 2–12% of queries on the larger agents returned fewer rows than the limit, worst case 3 of 10.

### The fix

Escalate the window instead of accepting a short result: if the filtered survivors are fewer than needed **and** the returned window was full, re-query with a larger `k`. Stop when there are enough survivors or when the window comes back short — which proves the index is exhausted, so the loop always terminates.

`_find_near_duplicate_vec` also loses its fixed `k = 5` and now widens until it reaches past the distance threshold, at which point the distance ordering proves nothing further can match.

### Tests

TDD — each test was written first and reproduces the defect against the unfixed code:

- `tests/test_memory_vec_search_window.py` — active and `no_recall` rows starved behind a window of nearer inactive rows
- `tests/test_memory_near_duplicate.py` — duplicate hidden behind superseded versions of itself
- `tests/test_memory_knn_consolidation_window.py` — neighbours starved by inactive rows and by the caller's exclude set, plus an exhaustion case that must terminate

Each test asserts it is exercising the vec path (`_vec_available is True`), so it cannot pass by silently falling through to numpy.

### Verification

- 8 targeted tests: pass
- `pytest -k memory` — 238 passed, 1 skipped
- `ruff check src/pinky_memory/`: clean

🤖 Opened by Engineer