### PR TITLE
test(#446): copertura del rifiuto dei cron a 6 campi su POST/PATCH schedules

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -5249,6 +5249,49 @@ class TestAgentScheduleEndpoints:
         ).json()["schedules"]
         assert schedules[0]["cron"] == "0 8 * * *"
 
+    def test_create_schedule_rejects_six_field_cron(self):
+        # A 6-field expression parses as "seconds first" elsewhere but the
+        # scheduler only matches 5 fields, so it would be stored and never
+        # fire — or fire at an unintended hour (#446).
+        client = self._make_client()
+        self._register(client, "alice")
+
+        response = self._create_schedule(client, cron="0 21 * * * *")
+
+        assert response.status_code == 400
+        assert "five fields" in response.json()["detail"]
+        assert client.get(
+            "/agents/alice/schedules",
+            params={"enabled_only": False},
+        ).json()["count"] == 0
+
+    def test_patch_schedule_rejects_six_field_cron_without_mutating(self):
+        client = self._make_client()
+        self._register(client, "alice")
+        created = self._create_schedule(client).json()
+
+        response = client.patch(
+            f"/agents/alice/schedules/{created['id']}",
+            json={"cron": "30 22 * * * *"},
+        )
+
+        assert response.status_code == 400
+        assert "five fields" in response.json()["detail"]
+        schedules = client.get(
+            "/agents/alice/schedules",
+            params={"enabled_only": False},
+        ).json()["schedules"]
+        assert schedules[0]["cron"] == "0 8 * * *"
+
+    def test_create_schedule_accepts_valid_cron(self):
+        client = self._make_client()
+        self._register(client, "alice")
+
+        response = self._create_schedule(client, cron="*/30 * * * *")
+
+        assert response.status_code == 200
+        assert response.json()["cron"] == "*/30 * * * *"
+
     def test_create_schedule_rejects_enabled_duplicate_name(self):
         client = self._make_client()
         self._register(client, "alice")


### PR DESCRIPTION
Chiude #446.

## Contesto
`_validate_schedule_cron` esiste gia' e riusa `_field_matches`, lo stesso helper del matcher runtime. Il caso reale di #446 — un'espressione a 6 campi come `0 21 * * * *` — non era pero' coperto da alcun test, e il path POST non aveva copertura di validazione affatto.

## Cosa cambia
Solo test: 43 righe in `tests/test_api.py` che coprono il rifiuto dei cron a 6 campi su POST e su PATCH `/schedules`.

## Verifica
195 test verdi sul branch, ruff pulito.

🤖 Opened by Engineer