### PR TITLE
feat(#358): registra update_research_status, il tool citato dalla directive ma mai esistito

### DIFF
--- a/src/pinky_self/server.py
+++ b/src/pinky_self/server.py
@@ -38,6 +38,7 @@ from datetime import datetime, timezone
 from mcp.server.fastmcp import FastMCP
 
 from pinky_daemon.auth import build_internal_auth_headers, resolve_request_signing_secret
+from pinky_daemon.research_store import VALID_TOPIC_STATUSES
 from pinky_daemon.shared_mcp import (
     LazyAgentName,
     record_mcp_success,
@@ -1389,6 +1390,25 @@ def create_server(
             if "error" in result:
                 return f"Failed to claim topic: {result['error']}"
             return f"Claimed topic [{topic_id}] '{result.get('title', '')}'. Status: {result.get('status', 'assigned')}. Start researching!"
+
+        @mcp.tool()
+        def update_research_status(topic_id: int, status: str) -> str:
+            """Move a research topic through its lifecycle.
+
+            status: open | assigned | researching | in_review | revising |
+            published | cancelled. Set "researching" when you start working on
+            a topic, "in_review" when the brief is ready for peer review.
+            """
+            if status not in VALID_TOPIC_STATUSES:
+                valid = ", ".join(VALID_TOPIC_STATUSES)
+                return f"Invalid status '{status}'. Valid statuses: {valid}"
+            result = _api("PUT", f"/research/{topic_id}", {"status": status})
+            if "error" in result:
+                return f"Failed to update status: {result['error']}"
+            return (
+                f"Topic [{topic_id}] '{result.get('title', '')}' "
+                f"is now: {result.get('status', status)}"
+            )
 
         @mcp.tool()
         def create_research_topic(

--- a/tests/test_pinky_self_tools.py
+++ b/tests/test_pinky_self_tools.py
@@ -2111,6 +2111,49 @@ class TestResearchPipeline:
             result = _tools(srv)["get_my_research_assignments"]()
         assert "Failed" in result
 
+    def test_update_research_status_sends_put_with_status(self, srv):
+        """The RESEARCH LIFECYCLE directive tells agents to call this tool."""
+        calls = []
+
+        def _urlopen(req, timeout=30):
+            calls.append((req.method, req.full_url, json.loads(req.data)))
+            body = json.dumps({"id": 7, "title": "MiCA", "status": "researching"}).encode()
+            resp = MagicMock()
+            resp.read.return_value = body
+            resp.__enter__ = lambda s: s
+            resp.__exit__ = MagicMock(return_value=False)
+            return resp
+
+        with patch("urllib.request.urlopen", side_effect=_urlopen):
+            result = _tools(srv)["update_research_status"](topic_id=7, status="researching")
+
+        assert calls, "no HTTP call was made"
+        method, url, body = calls[0]
+        assert method == "PUT"
+        assert url.endswith("/research/7")
+        assert body == {"status": "researching"}
+        assert "researching" in result
+
+    def test_update_research_status_rejects_invalid_status(self, srv):
+        """An unknown status must fail fast, without touching the API."""
+        calls = []
+
+        def _urlopen(req, timeout=30):
+            calls.append(req.full_url)
+            raise AssertionError("API must not be called for an invalid status")
+
+        with patch("urllib.request.urlopen", side_effect=_urlopen):
+            result = _tools(srv)["update_research_status"](topic_id=7, status="banana")
+
+        assert not calls
+        assert "banana" in result
+        assert "researching" in result, "the error should list the valid statuses"
+
+    def test_update_research_status_error(self, srv):
+        with _ok({"error": "Topic not found"}):
+            result = _tools(srv)["update_research_status"](topic_id=999, status="in_review")
+        assert "Failed" in result
+
 
 # ── render_pdf ────────────────────────────────────────────────────────────────
 
@@ -2281,13 +2324,14 @@ class TestToolGates:
         tools = {t.name for t in srv._tool_manager.list_tools()}
         assert tools == CORE_TOOLS
 
-    def test_all_gates_has_72_tools(self):
+    def test_all_gates_has_73_tools(self):
         """All gates → full tool set.
 
         +1 in #145 with ``register_agent`` (admin gate) → 69, then +1 in #663
         with the core ``mcp_probe`` tool → 70. (Had dropped 69→68 in #552 with
         the removal of ``request_sleep``.) #924 adds ``update_wake_schedule``
-        → 71; #984 adds sanctioned pending-wake discard → 72.
+        → 71; #984 adds sanctioned pending-wake discard → 72; #358 adds
+        ``update_research_status`` (research gate) → 73.
         """
         all_gates = [
             "extras", "kb", "research", "presentations", "triggers",
@@ -2295,7 +2339,7 @@ class TestToolGates:
         ]
         srv = create_server(agent_name="test", tool_gates=all_gates)
         tools = srv._tool_manager.list_tools()
-        assert len(tools) == 72
+        assert len(tools) == 73
 
     def test_extras_gate_adds_extras_tools(self):
         """Enabling 'extras' gate adds get_attribution, render_pdf, etc."""


### PR DESCRIPTION
Chiude #358.

## Problema
La directive RESEARCH LIFECYCLE istruisce gli agenti a chiamare `update_research_status()` quando iniziano a lavorare su un topic, ma il tool non esisteva in nessun punto del codice: la chiamata falliva e il passo veniva saltato in silenzio.

## Scelta: registrare il tool, non correggere la directive
- `researching` e' uno stato legittimo, gia' previsto da `VALID_TOPIC_STATUSES` in `research_store.py`
- l'endpoint `PUT /research/{topic_id}` esiste gia' e accetta `status`: il tool e' un wrapper sottile, nessuna rotta nuova
- senza questo tool nessun percorso di codice porta un topic a `in_review` (`submit_brief` non tocca lo stato del topic), ed e' esattamente il gate su cui la peer review si e' fermata: 0 review su 71 topic

La validazione riusa `VALID_TOPIC_STATUSES` invece di duplicare la lista e fallisce fast senza toccare l'API — utile anche perche' `update_topic()` oggi accetta qualunque stringa come status.

## Fuori scope
Dipendono da 3 decisioni ancora aperte con l'owner: transizione automatica a `in_review`, assegnazione dei reviewer, destino dei 14 brief orfani.

## Verifica
204 test verdi sul branch (incluso l'aggiornamento del gate sul conteggio tool: 72 → 73), ruff pulito.

🤖 Opened by Engineer