### PR TITLE
Telegram pollers: hard poll deadline, dedicated executor, client recycle

### DIFF
--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -9474,10 +9474,22 @@ npm run build</pre>
     @app.get("/broker/status")
     async def broker_status():
         """Get message broker status."""
+        now = time.monotonic()
         return {
             "stats": broker.stats,
             "active_pollers": [
-                {"agent": p.agent_name, "polls": p.poll_count, "running": p.is_running}
+                {
+                    "agent": p.agent_name,
+                    "polls": p.poll_count,
+                    "running": p.is_running,
+                    # Watchdog-equipped pollers only (#1145); None elsewhere.
+                    "watchdog_fires": getattr(p, "watchdog_fires", None),
+                    "last_poll_ok_age_s": (
+                        round(now - p.last_poll_ok, 1)
+                        if getattr(p, "last_poll_ok", 0.0)
+                        else None
+                    ),
+                }
                 for p in _broker_pollers
             ],
         }

--- a/src/pinky_daemon/pollers.py
+++ b/src/pinky_daemon/pollers.py
@@ -12,6 +12,7 @@ import re
 import sys
 import time
 import unicodedata
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
@@ -82,7 +83,94 @@ if TYPE_CHECKING:
     from pinky_outreach.types import Chat
 
 
-class TelegramPoller:
+# Seconds past poll_timeout before a poll is declared stuck. Telegram's server
+# always answers a getUpdates long poll within poll_timeout, so anything this
+# far past it means the connection is dead and the read will never return.
+_POLL_WATCHDOG_GRACE = 30.0
+
+
+class _TelegramPollWatchdog:
+    """Deadline + recovery for blocking getUpdates calls (#1145).
+
+    The 2026-08-23 incident: a network blip left every Telegram poller's
+    long-poll blocked in ssl.read indefinitely — the httpx client-level read
+    timeout demonstrably did not fire — and because polls ran on the event
+    loop's DEFAULT executor, the stuck threads consumed most of that shared
+    pool and starved unrelated daemon work. Three structural changes:
+
+      * every poller owns a DEDICATED single-thread executor, so a stuck
+        poll can never starve anything beyond its own poller;
+      * each poll runs under an outer asyncio deadline that does not depend
+        on the HTTP stack honoring its own timeouts;
+      * on deadline the adapter's HTTP client is recycled (closing its pooled
+        sockets frees the stuck thread) and the executor is replaced, so
+        polling continues even if the old thread never exits.
+    """
+
+    def _init_watchdog(self, label: str, grace: float) -> None:
+        self._watchdog_label = label
+        self._watchdog_grace = grace
+        self._poll_executor = ThreadPoolExecutor(
+            max_workers=1, thread_name_prefix=label
+        )
+        self._watchdog_fires = 0
+        self._last_poll_ok = 0.0
+
+    async def _watched_poll(self, poll_fn):
+        """Run ``poll_fn`` on the dedicated executor under a hard deadline.
+
+        Returns the poll result, or ``[]`` after firing the watchdog — the
+        recovery is loud (log + counter) so the empty result never masks it.
+        """
+        loop = asyncio.get_running_loop()
+        fut = loop.run_in_executor(self._poll_executor, poll_fn)
+        deadline = self._poll_timeout + self._watchdog_grace
+        try:
+            result = await asyncio.wait_for(asyncio.shield(fut), timeout=deadline)
+        except TimeoutError:
+            # Consume the abandoned future's eventual error quietly — the
+            # recycle below closes its socket, which typically makes the
+            # stuck read raise moments later.
+            fut.add_done_callback(
+                lambda f: None if f.cancelled() else f.exception()
+            )
+            self._recycle_after_stuck_poll(deadline)
+            return []
+        self._last_poll_ok = time.monotonic()
+        return result
+
+    def _recycle_after_stuck_poll(self, deadline: float) -> None:
+        self._watchdog_fires += 1
+        age = time.monotonic() - self._last_poll_ok if self._last_poll_ok else -1.0
+        _log(
+            f"{self._watchdog_label}: WATCHDOG poll exceeded {deadline:.0f}s hard "
+            f"deadline (fire #{self._watchdog_fires}, last successful poll "
+            f"{age:.0f}s ago) — recycling HTTP client + poll thread"
+        )
+        try:
+            self._adapter.recycle()
+        except Exception as e:
+            _log(f"{self._watchdog_label}: adapter recycle failed: {e}")
+        old = self._poll_executor
+        self._poll_executor = ThreadPoolExecutor(
+            max_workers=1, thread_name_prefix=self._watchdog_label
+        )
+        old.shutdown(wait=False)
+
+    def _shutdown_watchdog(self) -> None:
+        self._poll_executor.shutdown(wait=False)
+
+    @property
+    def watchdog_fires(self) -> int:
+        return self._watchdog_fires
+
+    @property
+    def last_poll_ok(self) -> float:
+        """monotonic timestamp of the last completed poll (0.0 = never)."""
+        return self._last_poll_ok
+
+
+class TelegramPoller(_TelegramPollWatchdog):
     """Polls Telegram Bot API for new messages.
 
     Uses long polling (getUpdates) to receive messages in near-realtime.
@@ -98,6 +186,7 @@ class TelegramPoller:
         poll_interval: float = 1.0,
         allowed_chat_ids: list[str] | None = None,
         event_callback=None,
+        watchdog_grace: float = _POLL_WATCHDOG_GRACE,
     ) -> None:
         self._adapter = adapter
         self._handler = handler
@@ -107,6 +196,7 @@ class TelegramPoller:
         self._event_callback = event_callback  # async fn(platform, chat_id, sender, content)
         self._running = False
         self._poll_count = 0
+        self._init_watchdog("telegram-poller", watchdog_grace)
 
     async def start(self) -> None:
         """Start the polling loop."""
@@ -135,9 +225,9 @@ class TelegramPoller:
 
     async def _poll_once(self) -> None:
         """Single poll iteration."""
-        # Run blocking HTTP call in thread pool
-        messages = await asyncio.get_running_loop().run_in_executor(
-            None,
+        # Blocking HTTP call on the poller's OWN executor, under a hard
+        # deadline (#1145) — never the loop default pool.
+        messages = await self._watched_poll(
             lambda: self._adapter.get_updates(timeout=self._poll_timeout),
         )
 
@@ -186,6 +276,7 @@ class TelegramPoller:
     def stop(self) -> None:
         """Stop the polling loop."""
         self._running = False
+        self._shutdown_watchdog()
         _log("telegram-poller: stopping")
 
     @property
@@ -197,7 +288,7 @@ class TelegramPoller:
         return self._running
 
 
-class BrokerTelegramPoller:
+class BrokerTelegramPoller(_TelegramPollWatchdog):
     """Polls Telegram for a specific agent's bot token, routes through MessageBroker.
 
     Unlike TelegramPoller which uses a single handler, this poller:
@@ -216,6 +307,7 @@ class BrokerTelegramPoller:
         poll_timeout: int = 30,
         poll_interval: float = 1.0,
         event_callback=None,
+        watchdog_grace: float = _POLL_WATCHDOG_GRACE,
     ) -> None:
         from pinky_daemon.broker import BrokerMessage, MessageBroker
         self._BrokerMessage = BrokerMessage
@@ -230,6 +322,7 @@ class BrokerTelegramPoller:
         self._running = False
         self._poll_count = 0
         self._bot_username = ""
+        self._init_watchdog(f"broker-poller[{agent_name}]", watchdog_grace)
 
     async def start(self) -> None:
         """Start the polling loop."""
@@ -258,8 +351,9 @@ class BrokerTelegramPoller:
 
     async def _poll_once(self) -> None:
         """Single poll iteration — routes messages through broker."""
-        messages = await asyncio.get_running_loop().run_in_executor(
-            None,
+        # Blocking HTTP call on the poller's OWN executor, under a hard
+        # deadline (#1145) — never the loop default pool.
+        messages = await self._watched_poll(
             lambda: self._adapter.get_updates(timeout=self._poll_timeout),
         )
 
@@ -323,6 +417,7 @@ class BrokerTelegramPoller:
     def stop(self) -> None:
         """Stop the polling loop."""
         self._running = False
+        self._shutdown_watchdog()
         _log(f"broker-poller[{self._agent_name}]: stopping")
 
     @property

--- a/src/pinky_daemon/pollers.py
+++ b/src/pinky_daemon/pollers.py
@@ -105,6 +105,18 @@ class _TelegramPollWatchdog:
       * on deadline the adapter's HTTP client is recycled (closing its pooled
         sockets frees the stuck thread) and the executor is replaced, so
         polling continues even if the old thread never exits.
+
+    Host classes must define ``_poll_timeout``, ``_adapter`` (with
+    ``get_updates``/``recycle``) and ``_process_messages`` before calling
+    ``_init_watchdog``.
+
+    Tradeoffs, deliberately accepted: a thread the recycle cannot free (e.g.
+    wedged in DNS resolution before any pooled socket exists) accumulates
+    one non-daemon thread per fire — observable via ``watchdog_fires`` and
+    the loud log — and any still-stuck thread is joined at interpreter exit,
+    so a truly immortal one can hang daemon shutdown until the supervisor
+    kills the process. Both beat the alternative this replaces (silent
+    fleet-wide inbound death).
     """
 
     def _init_watchdog(self, label: str, grace: float) -> None:
@@ -121,6 +133,13 @@ class _TelegramPollWatchdog:
 
         Returns the poll result, or ``[]`` after firing the watchdog — the
         recovery is loud (log + counter) so the empty result never masks it.
+
+        A poll that completes AT or AFTER the deadline is never discarded:
+        its ``get_updates`` already advanced the offset, so the next poll
+        would confirm-and-drop those updates server-side — dropping the
+        result here would be silent, permanent message loss. Completed-at-
+        the-edge results are returned directly; genuinely late completions
+        are delivered through ``_process_messages`` when they arrive.
         """
         loop = asyncio.get_running_loop()
         fut = loop.run_in_executor(self._poll_executor, poll_fn)
@@ -128,16 +147,36 @@ class _TelegramPollWatchdog:
         try:
             result = await asyncio.wait_for(asyncio.shield(fut), timeout=deadline)
         except TimeoutError:
-            # Consume the abandoned future's eventual error quietly — the
-            # recycle below closes its socket, which typically makes the
-            # stuck read raise moments later.
-            fut.add_done_callback(
-                lambda f: None if f.cancelled() else f.exception()
-            )
+            if fut.done() and not fut.cancelled() and fut.exception() is None:
+                # Completed on the deadline edge (loop scheduled the timeout
+                # callback first) — a healthy poll, not a stuck one.
+                self._last_poll_ok = time.monotonic()
+                return fut.result()
+            fut.add_done_callback(self._on_abandoned_poll_done)
             self._recycle_after_stuck_poll(deadline)
             return []
         self._last_poll_ok = time.monotonic()
         return result
+
+    def _on_abandoned_poll_done(self, fut) -> None:
+        """An abandoned poll eventually finished (usually because the recycle
+        closed its socket). Consume the error quietly; deliver a late RESULT
+        — its updates are already offset-confirmed and exist nowhere else."""
+        if fut.cancelled():
+            return
+        if fut.exception() is not None:  # consumed: no "never retrieved" noise
+            return
+        late = fut.result()
+        if not late:
+            return
+        _log(
+            f"{self._watchdog_label}: abandoned poll completed late with "
+            f"{len(late)} update(s) — delivering (offset already advanced)"
+        )
+        _deliver_in_background(
+            self._process_messages(late),
+            f"{self._watchdog_label} late-delivery",
+        )
 
     def _recycle_after_stuck_poll(self, deadline: float) -> None:
         self._watchdog_fires += 1
@@ -203,11 +242,16 @@ class TelegramPoller(_TelegramPollWatchdog):
         self._running = True
         _log("telegram-poller: starting")
 
-        # Verify bot connection
+        # Verify bot connection — on the poller's executor, under a deadline,
+        # so a wedged network can't block the event loop or hang startup.
+        loop = asyncio.get_running_loop()
         try:
-            me = self._adapter.get_me()
+            me = await asyncio.wait_for(
+                loop.run_in_executor(self._poll_executor, self._adapter.get_me),
+                timeout=30,
+            )
             _log(f"telegram-poller: connected as @{me.get('username', '?')}")
-        except TelegramError as e:
+        except (TelegramError, TimeoutError) as e:
             _log(f"telegram-poller: failed to connect: {e}")
             return
 
@@ -233,6 +277,11 @@ class TelegramPoller(_TelegramPollWatchdog):
 
         self._poll_count += 1
 
+        await self._process_messages(messages)
+
+    async def _process_messages(self, messages) -> None:
+        """Route polled updates to the handler — also the watchdog's
+        late-delivery path for polls that complete after abandonment."""
         for msg in messages:
             # Filter by allowed chats
             if self._allowed_chats and msg.chat_id not in self._allowed_chats:
@@ -329,11 +378,17 @@ class BrokerTelegramPoller(_TelegramPollWatchdog):
         self._running = True
         _log(f"broker-poller[{self._agent_name}]: starting")
 
+        # On the poller's executor, under a deadline — a wedged network can't
+        # block the event loop or hang startup.
+        loop = asyncio.get_running_loop()
         try:
-            me = self._adapter.get_me()
+            me = await asyncio.wait_for(
+                loop.run_in_executor(self._poll_executor, self._adapter.get_me),
+                timeout=30,
+            )
             self._bot_username = me.get("username", "?")
             _log(f"broker-poller[{self._agent_name}]: connected as @{self._bot_username}")
-        except TelegramError as e:
+        except (TelegramError, TimeoutError) as e:
             _log(f"broker-poller[{self._agent_name}]: failed to connect: {e}")
             return
 
@@ -359,6 +414,11 @@ class BrokerTelegramPoller(_TelegramPollWatchdog):
 
         self._poll_count += 1
 
+        await self._process_messages(messages)
+
+    async def _process_messages(self, messages) -> None:
+        """Route polled updates through the broker — also the watchdog's
+        late-delivery path for polls that complete after abandonment."""
         for msg in messages:
             chat_type = msg.metadata.get("chat_type", "")
             is_group = chat_type in ("group", "supergroup")

--- a/src/pinky_daemon/pollers.py
+++ b/src/pinky_daemon/pollers.py
@@ -252,7 +252,7 @@ class TelegramPoller(_TelegramPollWatchdog):
             )
             _log(f"telegram-poller: connected as @{me.get('username', '?')}")
         except (TelegramError, TimeoutError) as e:
-            _log(f"telegram-poller: failed to connect: {e}")
+            _log(f"telegram-poller: failed to connect: {e!r}")
             return
 
         while self._running:
@@ -389,7 +389,7 @@ class BrokerTelegramPoller(_TelegramPollWatchdog):
             self._bot_username = me.get("username", "?")
             _log(f"broker-poller[{self._agent_name}]: connected as @{self._bot_username}")
         except (TelegramError, TimeoutError) as e:
-            _log(f"broker-poller[{self._agent_name}]: failed to connect: {e}")
+            _log(f"broker-poller[{self._agent_name}]: failed to connect: {e!r}")
             return
 
         while self._running:

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -4748,8 +4748,14 @@ class TmuxSession(TransportReplacementMixin):
                     self.id, "user", prompt,
                     platform=platform, chat_id=chat_id,
                 )
-            except Exception:
-                pass
+            except Exception as e:
+                # Loud, like the assistant-side append handler: a silently
+                # swallowed failure here is indistinguishable from a quiet
+                # day, which hid a fleet-wide store freeze (#1145).
+                _log(
+                    f"tmux[{self.agent_name}]: conversation_store.append "
+                    f"(user) raised: {e}"
+                )
 
         queued_prompt = prompt + agent_hint if agent_hint else prompt
         turn = _QueuedTurn(

--- a/src/pinky_outreach/telegram.py
+++ b/src/pinky_outreach/telegram.py
@@ -53,6 +53,8 @@ class TelegramAdapter:
         try:
             old.close()
         except Exception:
+            # Best-effort close: the old client is being discarded precisely
+            # because its connection is wedged, so close() may itself fail.
             pass
 
     def _request(self, method: str, **params) -> dict:

--- a/src/pinky_outreach/telegram.py
+++ b/src/pinky_outreach/telegram.py
@@ -31,11 +31,29 @@ class TelegramAdapter:
     def __init__(self, bot_token: str, *, timeout: float = 30.0) -> None:
         self._token = bot_token
         self._base = self.BASE_URL.format(token=bot_token)
+        self._timeout = timeout
         self._client = httpx.Client(timeout=timeout)
         self._last_update_id: int = 0
 
     def close(self) -> None:
         self._client.close()
+
+    def recycle(self) -> None:
+        """Replace the HTTP client, preserving the getUpdates offset.
+
+        Used by the poller watchdog (#1145) after a poll exceeds its hard
+        deadline: closing the old client tears down its pooled sockets, which
+        frees a worker thread stuck in a read on a dead connection. The
+        ``_last_update_id`` offset is deliberately kept so the fresh client
+        resumes exactly where the wedged one stopped — recreating the whole
+        adapter instead would replay up to 24h of queued updates.
+        """
+        old = self._client
+        self._client = httpx.Client(timeout=self._timeout)
+        try:
+            old.close()
+        except Exception:
+            pass
 
     def _request(self, method: str, **params) -> dict:
         """Make a Telegram Bot API request."""

--- a/tests/test_buzz_api.py
+++ b/tests/test_buzz_api.py
@@ -267,7 +267,14 @@ def test_one_step_bind_configures_inbound_gates_and_starts_native_poller(
         assert fetched.json()["principals"] == policy["principals"]
         status = client.get("/broker/status").json()
         assert status["active_pollers"] == [
-            {"agent": "barsik", "polls": 0, "running": True}
+            {
+                "agent": "barsik",
+                "polls": 0,
+                "running": True,
+                # Buzz pollers carry no telegram watchdog (#1145)
+                "watchdog_fires": None,
+                "last_poll_ok_age_s": None,
+            }
         ]
 
         disabled = client.post("/system/buzz-identities/barsik/disable")
@@ -405,7 +412,13 @@ def test_daemon_restart_resumes_configured_native_buzz_poller(
     app = _app(tmp_path)
     with TestClient(app) as client:
         assert client.get("/broker/status").json()["active_pollers"] == [
-            {"agent": "barsik", "polls": 0, "running": True}
+            {
+                "agent": "barsik",
+                "polls": 0,
+                "running": True,
+                "watchdog_fires": None,
+                "last_poll_ok_age_s": None,
+            }
         ]
         assert app.state.agents._db.execute(
             "SELECT claimed_at FROM buzz_inbound_events WHERE event_id=?",

--- a/tests/test_poller_watchdog.py
+++ b/tests/test_poller_watchdog.py
@@ -79,6 +79,80 @@ class FakeStuckAdapter:
         self._release.set()
 
 
+class FakeHardStuckAdapter:
+    """First poll wedges somewhere recycle() cannot reach (the DNS-resolution
+    case from the watchdog docstring): ``recycle()`` counts the call but does
+    NOT free the thread. Delivery must still resume — that is the
+    executor-replacement leg, and nothing else covers it.
+
+    ``release()`` is a test-teardown-only handle so the wedged non-daemon
+    thread doesn't hang the test process at exit.
+    """
+
+    def __init__(self) -> None:
+        self._release = threading.Event()
+        self._calls = 0
+        self.recycle_calls = 0
+        self._delivered = False
+
+    def get_me(self) -> dict:
+        return {"username": "hardstuck_test_bot"}
+
+    def get_updates(self, *, timeout: int = 0, limit: int = 100):
+        self._calls += 1
+        if self._calls == 1:
+            self._release.wait()  # recycle() will NOT free this
+            return []
+        if not self._delivered:
+            self._delivered = True
+            return [_fake_msg("post-stuck")]
+        return []
+
+    def recycle(self) -> None:
+        self.recycle_calls += 1  # deliberately does NOT release the thread
+
+    def release(self) -> None:
+        self._release.set()
+
+    def close(self) -> None:
+        self._release.set()
+
+
+class FakeLateCompletionAdapter:
+    """First poll blocks until ``release()``, then returns a REAL message —
+    the genuinely-late-completion leg. Telegram has already advanced the
+    offset for that batch, so dropping it would be permanent loss; the
+    watchdog must hand it to ``_process_messages`` when it finally lands.
+
+    ``recycle()`` does not free the thread, so the test controls exactly
+    when the abandoned poll completes.
+    """
+
+    def __init__(self) -> None:
+        self._release = threading.Event()
+        self._calls = 0
+        self.recycle_calls = 0
+
+    def get_me(self) -> dict:
+        return {"username": "late_test_bot"}
+
+    def get_updates(self, *, timeout: int = 0, limit: int = 100):
+        self._calls += 1
+        if self._calls == 1:
+            self._release.wait()
+            return [_fake_msg("late-hello")]
+        return []
+
+    def recycle(self) -> None:
+        self.recycle_calls += 1
+
+    def release(self) -> None:
+        self._release.set()
+
+    def close(self) -> None:
+        self._release.set()
+
+
 class FakeHandler:
     def __init__(self) -> None:
         self.received: list = []
@@ -114,13 +188,16 @@ class TestWatchdogRecyclesStuckPoll:
         task = asyncio.create_task(poller.start())
         try:
             await asyncio.wait_for(handler.delivered.wait(), timeout=10)
+            # Captured BEFORE teardown's own recycle() — this pins that the
+            # WATCHDOG recycled the client, not the finally block below.
+            recycles_at_delivery = adapter.recycle_calls
         finally:
             adapter.recycle()  # belt-and-suspenders: never leave the thread stuck
             poller.stop()
             await asyncio.wait_for(task, timeout=5)
 
         assert poller.watchdog_fires == 1
-        assert adapter.recycle_calls >= 1
+        assert recycles_at_delivery >= 1
         assert handler.received[0].content == "hello"
         assert poller.last_poll_ok > 0.0
         err = capsys.readouterr().err
@@ -142,13 +219,75 @@ class TestWatchdogRecyclesStuckPoll:
         task = asyncio.create_task(poller.start())
         try:
             await asyncio.wait_for(broker.delivered.wait(), timeout=10)
+            recycles_at_delivery = adapter.recycle_calls
         finally:
             adapter.recycle()
             poller.stop()
             await asyncio.wait_for(task, timeout=5)
 
         assert poller.watchdog_fires == 1
+        assert recycles_at_delivery >= 1
         assert broker.received[0].content == "hello"
+
+    @pytest.mark.asyncio
+    async def test_delivery_resumes_even_when_recycle_cannot_free_thread(self):
+        """Executor-replacement leg: when the recycle can't free the wedged
+        thread (DNS-style wedge), polling must continue on a fresh thread
+        anyway. With executor replacement removed this times out RED —
+        the replacement is the only thing keeping the poller alive here."""
+        adapter = FakeHardStuckAdapter()
+        handler = FakeHandler()
+        poller = TelegramPoller(
+            adapter,
+            handler,
+            poll_timeout=0,
+            poll_interval=0.01,
+            watchdog_grace=0.3,
+        )
+        task = asyncio.create_task(poller.start())
+        try:
+            await asyncio.wait_for(handler.delivered.wait(), timeout=10)
+            fires_at_delivery = poller.watchdog_fires
+            recycles_at_delivery = adapter.recycle_calls
+        finally:
+            adapter.release()  # free the wedged non-daemon thread for exit
+            poller.stop()
+            await asyncio.wait_for(task, timeout=5)
+
+        assert fires_at_delivery == 1
+        assert recycles_at_delivery >= 1
+        assert handler.received[0].content == "post-stuck"
+
+    @pytest.mark.asyncio
+    async def test_late_completing_abandoned_poll_is_delivered_not_lost(self):
+        """An abandoned poll that later completes WITH updates must deliver
+        them (#1146 must-fix): getUpdates already confirmed the offset
+        server-side, so a drop here is silent, permanent message loss."""
+        adapter = FakeLateCompletionAdapter()
+        handler = FakeHandler()
+        poller = TelegramPoller(
+            adapter,
+            handler,
+            poll_timeout=0,
+            poll_interval=0.01,
+            watchdog_grace=0.3,
+        )
+        task = asyncio.create_task(poller.start())
+        try:
+            deadline = time.monotonic() + 10
+            while poller.watchdog_fires == 0:
+                assert time.monotonic() < deadline, "watchdog never fired"
+                await asyncio.sleep(0.01)
+            # Poll #1 is now abandoned. Complete it — with a message.
+            adapter.release()
+            await asyncio.wait_for(handler.delivered.wait(), timeout=10)
+        finally:
+            adapter.release()
+            poller.stop()
+            await asyncio.wait_for(task, timeout=5)
+
+        assert handler.received[0].content == "late-hello"
+        assert poller.watchdog_fires == 1
 
     @pytest.mark.asyncio
     async def test_healthy_poll_never_fires_watchdog(self):

--- a/tests/test_poller_watchdog.py
+++ b/tests/test_poller_watchdog.py
@@ -1,0 +1,210 @@
+"""Tests for the Telegram poller watchdog (#1145).
+
+The 2026-08-23 incident: a network blip left every Telegram poller's
+getUpdates long-poll blocked in ssl.read indefinitely — the httpx
+client-level read timeout demonstrably did not fire — and the stuck polls
+consumed the event loop's default executor, starving unrelated daemon work.
+
+These tests pin the three-part recovery contract:
+  * a poll that exceeds its hard deadline fires the watchdog instead of
+    hanging the poller forever;
+  * the watchdog recycles the adapter's HTTP client (which is what frees
+    the stuck read in production) and replaces the poll thread;
+  * polling then CONTINUES and delivers messages — the poller survives.
+
+The delivery assertions are the non-vacuity proof: with the watchdog
+removed, the first stuck poll never returns and the test times out RED.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import socket
+import threading
+import time
+from types import SimpleNamespace
+
+import httpx
+import pytest
+
+from pinky_daemon.pollers import BrokerTelegramPoller, TelegramPoller
+from pinky_outreach.telegram import TelegramAdapter
+
+
+def _fake_msg(content: str = "hello") -> SimpleNamespace:
+    return SimpleNamespace(
+        chat_id="12345",
+        sender="tester",
+        content=content,
+        timestamp=time.time(),
+        message_id="m1",
+        reply_to="",
+        metadata={},
+    )
+
+
+class FakeStuckAdapter:
+    """First poll blocks forever (the dead-connection read); after recycle()
+    the next poll returns one message, then empties.
+
+    ``recycle()`` releases the blocked thread — mirroring production, where
+    closing the httpx client's sockets is what frees the stuck read. It also
+    keeps the test process from hanging on a non-daemon executor thread.
+    """
+
+    def __init__(self) -> None:
+        self._release = threading.Event()
+        self._calls = 0
+        self.recycle_calls = 0
+        self._delivered = False
+
+    def get_me(self) -> dict:
+        return {"username": "watchdog_test_bot"}
+
+    def get_updates(self, *, timeout: int = 0, limit: int = 100):
+        self._calls += 1
+        if self._calls == 1:
+            self._release.wait()  # dead connection: never returns on its own
+            return []
+        if not self._delivered:
+            self._delivered = True
+            return [_fake_msg()]
+        return []
+
+    def recycle(self) -> None:
+        self.recycle_calls += 1
+        self._release.set()
+
+    def close(self) -> None:
+        self._release.set()
+
+
+class FakeHandler:
+    def __init__(self) -> None:
+        self.received: list = []
+        self.delivered = asyncio.Event()
+
+    async def handle(self, inbound) -> None:
+        self.received.append(inbound)
+        self.delivered.set()
+
+
+class FakeBroker:
+    def __init__(self) -> None:
+        self.received: list = []
+        self.delivered = asyncio.Event()
+
+    async def handle_inbound(self, msg) -> None:
+        self.received.append(msg)
+        self.delivered.set()
+
+
+class TestWatchdogRecyclesStuckPoll:
+    @pytest.mark.asyncio
+    async def test_poller_survives_stuck_poll_and_delivers(self, capsys):
+        adapter = FakeStuckAdapter()
+        handler = FakeHandler()
+        poller = TelegramPoller(
+            adapter,
+            handler,
+            poll_timeout=0,
+            poll_interval=0.01,
+            watchdog_grace=0.3,
+        )
+        task = asyncio.create_task(poller.start())
+        try:
+            await asyncio.wait_for(handler.delivered.wait(), timeout=10)
+        finally:
+            adapter.recycle()  # belt-and-suspenders: never leave the thread stuck
+            poller.stop()
+            await asyncio.wait_for(task, timeout=5)
+
+        assert poller.watchdog_fires == 1
+        assert adapter.recycle_calls >= 1
+        assert handler.received[0].content == "hello"
+        assert poller.last_poll_ok > 0.0
+        err = capsys.readouterr().err
+        assert "WATCHDOG" in err
+        assert "recycling HTTP client" in err
+
+    @pytest.mark.asyncio
+    async def test_broker_poller_survives_stuck_poll(self):
+        adapter = FakeStuckAdapter()
+        broker = FakeBroker()
+        poller = BrokerTelegramPoller(
+            adapter,
+            "watchdog-test-agent",
+            broker,
+            poll_timeout=0,
+            poll_interval=0.01,
+            watchdog_grace=0.3,
+        )
+        task = asyncio.create_task(poller.start())
+        try:
+            await asyncio.wait_for(broker.delivered.wait(), timeout=10)
+        finally:
+            adapter.recycle()
+            poller.stop()
+            await asyncio.wait_for(task, timeout=5)
+
+        assert poller.watchdog_fires == 1
+        assert broker.received[0].content == "hello"
+
+    @pytest.mark.asyncio
+    async def test_healthy_poll_never_fires_watchdog(self):
+        adapter = FakeStuckAdapter()
+        adapter._calls = 1  # skip the stuck first call entirely
+        handler = FakeHandler()
+        poller = TelegramPoller(
+            adapter,
+            handler,
+            poll_timeout=0,
+            poll_interval=0.01,
+            watchdog_grace=0.3,
+        )
+        task = asyncio.create_task(poller.start())
+        try:
+            await asyncio.wait_for(handler.delivered.wait(), timeout=10)
+        finally:
+            poller.stop()
+            await asyncio.wait_for(task, timeout=5)
+
+        assert poller.watchdog_fires == 0
+        assert adapter.recycle_calls == 0
+
+
+class TestAdapterRecycle:
+    def test_recycle_preserves_update_offset_and_swaps_client(self):
+        adapter = TelegramAdapter("test-token", timeout=7.0)
+        adapter._last_update_id = 42
+        old_client = adapter._client
+
+        adapter.recycle()
+
+        assert adapter._last_update_id == 42, "offset loss would replay updates"
+        assert adapter._client is not old_client
+        assert old_client.is_closed
+        assert not adapter._client.is_closed
+        adapter.close()
+
+
+class TestReadTimeoutFiresOnBlackhole:
+    def test_get_updates_raises_instead_of_hanging(self):
+        """The 'provably fires' regression from #1145: against a connection
+        that accepts and never responds, the adapter-level read timeout must
+        raise — a hang here is exactly the incident signature."""
+        srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        srv.bind(("127.0.0.1", 0))
+        srv.listen(1)  # never accept()ed: handshake completes, reads starve
+        port = srv.getsockname()[1]
+        try:
+            adapter = TelegramAdapter("x", timeout=1.0)
+            adapter._base = f"http://127.0.0.1:{port}/botx"
+            t0 = time.monotonic()
+            with pytest.raises(httpx.TimeoutException):
+                adapter.get_updates(timeout=0)
+            elapsed = time.monotonic() - t0
+            assert elapsed < 6, f"read timeout took {elapsed:.1f}s to fire"
+            adapter.close()
+        finally:
+            srv.close()


### PR DESCRIPTION
Fixes the poller half of #1145.

## Problem
A network blip can leave a Telegram getUpdates long-poll blocked in `ssl.read` forever — the httpx client-level read timeout demonstrably did not fire in production — and because polls ran on the event loop's **default** executor, the stuck threads consumed most of that shared pool (`min(32, cpus+4)`) and starved unrelated daemon work. Outbound sends and scheduler wakes kept working, so the inbound outage was masked for hours. Full incident anatomy in #1145.

## Fix (structural, not another library timeout)
- Every Telegram poller owns a **dedicated single-thread executor** — a stuck poll can never starve anything beyond its own poller.
- Each poll runs under an **outer asyncio deadline** (`poll_timeout + 30s grace`) that does not depend on the HTTP stack honoring its own timeouts.
- On deadline: loud `WATCHDOG` log + counter, the adapter's HTTP client is **recycled** (closing its pooled sockets is what actually frees the stuck read; `_last_update_id` is preserved so no update replay), and the executor is replaced so polling continues even if the old thread never exits.
- `last_poll_ok` / `watchdog_fires` exposed for a future health surface (follow-up in #1145).
- tmux transport: user-side `conversation_store.append` no longer swallows exceptions silently.

## Evidence
- 5 new tests, incl. stuck-poll survival for both poller classes and a blackhole regression proving the adapter read timeout raises instead of hanging.
- Non-vacuity verified: with the deadline removed (neuter experiment), the stuck-poll tests hang and fail RED at their 10s delivery ceiling — the exact incident signature.
- Full suite green locally; no behavior change on the healthy path (dedicated executor + same call shape).

No UI change — no screenshot (daemon internals only).

Follow-ups tracked in #1145: health-surface wiring, same treatment for REST pollers (Discord), `get_me` startup call still runs on the loop.

🤖 Opened by barsik

🤖 Generated with [Claude Code](https://claude.com/claude-code)