### PR TITLE
pinky-memory: holder-side KG ephemeral sweep tool

### DIFF
--- a/src/pinky_memory/server.py
+++ b/src/pinky_memory/server.py
@@ -827,22 +827,20 @@ def create_server(
         return json.dumps({"count": len(result), "contradictions": result})
 
     @mcp.tool()
-    def kg_sweep_ephemeral(
-        apply: bool = False, log_path: str = "", backup_dir: str = ""
-    ) -> str:
+    def kg_sweep_ephemeral(apply: bool = False) -> str:
         """Sweep pure-ID ephemeral nodes from the knowledge graph (#153 step 1).
         The holder-side replacement for scripts/kg_ephemeral_sweep.py (#654):
         runs inside the store owner, so no external process opens the live DB.
         n_candidates per run = ephemeral regrowth since the previous sweep.
         Dry-run by default; apply=True backs the DB up (SQLite backup API,
         transaction-consistent) then deletes candidates + their edges in one
-        transaction. Every run appends a JSONL record to log_path (default:
-        kg_sweep_log.jsonl next to the DB).
+        transaction (rolled back wholesale on failure). Each run appends a
+        JSONL record to kg_sweep_log.jsonl next to the DB. No path inputs:
+        the store may run in the daemon process, so log/backup destinations
+        are fixed to the store's own directory.
         """
         s = _get_store()
-        result = s.kg_sweep_ephemeral(
-            apply=apply, log_path=log_path, backup_dir=backup_dir
-        )
+        result = s.kg_sweep_ephemeral(apply=apply)
         _log(
             f"kg_sweep_ephemeral: {result['n_candidates']} candidate(s), "
             f"{result['n_edges']} edge(s), applied={result['applied']}"

--- a/src/pinky_memory/server.py
+++ b/src/pinky_memory/server.py
@@ -827,6 +827,29 @@ def create_server(
         return json.dumps({"count": len(result), "contradictions": result})
 
     @mcp.tool()
+    def kg_sweep_ephemeral(
+        apply: bool = False, log_path: str = "", backup_dir: str = ""
+    ) -> str:
+        """Sweep pure-ID ephemeral nodes from the knowledge graph (#153 step 1).
+        The holder-side replacement for scripts/kg_ephemeral_sweep.py (#654):
+        runs inside the store owner, so no external process opens the live DB.
+        n_candidates per run = ephemeral regrowth since the previous sweep.
+        Dry-run by default; apply=True backs the DB up (SQLite backup API,
+        transaction-consistent) then deletes candidates + their edges in one
+        transaction. Every run appends a JSONL record to log_path (default:
+        kg_sweep_log.jsonl next to the DB).
+        """
+        s = _get_store()
+        result = s.kg_sweep_ephemeral(
+            apply=apply, log_path=log_path, backup_dir=backup_dir
+        )
+        _log(
+            f"kg_sweep_ephemeral: {result['n_candidates']} candidate(s), "
+            f"{result['n_edges']} edge(s), applied={result['applied']}"
+        )
+        return json.dumps(result)
+
+    @mcp.tool()
     def kg_stats() -> str:
         """Get knowledge graph statistics — entity count, triple count, predicates."""
         s = _get_store()

--- a/src/pinky_memory/store.py
+++ b/src/pinky_memory/store.py
@@ -3102,12 +3102,37 @@ class ReflectionStore:
         previous sweep — the instrument that decides write-guard urgency.
 
         Dry-run by default. ``apply=True`` deletes each candidate entity and
-        every edge touching it, in one transaction, after a transaction-
-        consistent backup via the SQLite backup API. Every run appends one
-        JSONL record to ``log_path`` (default: ``kg_sweep_log.jsonl`` next to
-        the DB) so the regrowth series stays measurable and deletions stay
-        auditable.
+        every edge touching it, in one transaction (rolled back wholesale on
+        any failure — never a partial sweep), after a transaction-consistent
+        backup via the SQLite backup API. Every run appends one JSONL record
+        to ``log_path`` (default: ``kg_sweep_log.jsonl`` next to the DB) so
+        the regrowth series stays measurable and deletions stay auditable.
+
+        ``log_path`` and ``backup_dir`` must resolve under the DB's own
+        directory: the store can run inside the daemon process, so an
+        unconstrained path here would be a cross-boundary write primitive
+        for an isolated tenant (#149).
         """
+        db_root = Path(self._db_path).resolve().parent
+
+        def _under_db_root(raw: str, what: str) -> Path:
+            p = Path(raw).resolve()
+            if not p.is_relative_to(db_root):
+                raise ValueError(
+                    f"kg_sweep_ephemeral: {what} must resolve under the "
+                    f"store's own directory ({db_root}), got: {raw}"
+                )
+            return p
+
+        log_file = (
+            _under_db_root(log_path, "log_path")
+            if log_path else db_root / "kg_sweep_log.jsonl"
+        )
+        backup_root = (
+            _under_db_root(backup_dir, "backup_dir")
+            if backup_dir else db_root
+        )
+
         rows = self._conn.execute("SELECT id, name, type FROM kg_entities").fetchall()
         candidates = [
             (r["id"], r["name"], r["type"])
@@ -3132,10 +3157,12 @@ class ReflectionStore:
 
         backup_path: str | None = None
         applied = False
+        apply_error: str | None = None
         if apply and candidates:
-            ts = datetime.now(timezone.utc).strftime("%Y-%m-%d_%H%M%S")
-            base_dir = Path(backup_dir) if backup_dir else Path(self._db_path).parent
-            dest_dir = base_dir / f"{ts}_sweep"
+            # Microsecond granularity: a same-second double apply must never
+            # overwrite the previous run's only pre-delete backup.
+            ts = datetime.now(timezone.utc).strftime("%Y-%m-%d_%H%M%S_%f")
+            dest_dir = backup_root / f"{ts}_sweep"
             dest_dir.mkdir(parents=True, exist_ok=True)
             dest = dest_dir / Path(self._db_path).name
             with self._lock:
@@ -3147,24 +3174,37 @@ class ReflectionStore:
                 finally:
                     dst.close()
                 backup_path = str(dest)
-                for _eid, name, _etype in candidates:
-                    self._conn.execute(
-                        "DELETE FROM kg_triples WHERE subject = ? OR object = ?",
-                        (name, name),
+                try:
+                    for _eid, name, _etype in candidates:
+                        self._conn.execute(
+                            "DELETE FROM kg_triples WHERE subject = ? OR object = ?",
+                            (name, name),
+                        )
+                        self._conn.execute(
+                            "DELETE FROM kg_entities WHERE name = ?", (name,)
+                        )
+                    self._conn.commit()
+                    applied = True
+                except Exception as e:
+                    # All-or-nothing: a partial sweep left in an open
+                    # transaction would be silently committed by the next
+                    # unrelated write. Roll back and report.
+                    try:
+                        self._conn.rollback()
+                    except sqlite3.Error:
+                        pass
+                    apply_error = str(e)
+                    logging.getLogger(__name__).error(
+                        "kg_sweep_ephemeral: apply failed, rolled back: %s", e
                     )
-                    self._conn.execute(
-                        "DELETE FROM kg_entities WHERE name = ?", (name,)
-                    )
-                self._conn.commit()
-                applied = True
 
         record = {
             "ts": datetime.now(timezone.utc).isoformat(),
             "db": self._db_path,
+            # Bare name strings — parity with scripts/kg_ephemeral_sweep.py so
+            # one consumer can read the whole regrowth series.
             "n_candidates": len(candidates),
-            "candidates": [
-                {"name": n, "type": t} for _i, n, t in candidates
-            ],
+            "candidates": [n for _i, n, _t in candidates],
             "n_edges": len(deleted_edges),
             "n_active_edges": sum(1 for e in deleted_edges if e["active"]),
             "deleted_edges": deleted_edges if applied else [],
@@ -3172,9 +3212,8 @@ class ReflectionStore:
             "backup": backup_path,
             "runner": "store",
         }
-        log_file = Path(log_path) if log_path else (
-            Path(self._db_path).parent / "kg_sweep_log.jsonl"
-        )
+        if apply_error is not None:
+            record["apply_error"] = apply_error
         try:
             log_file.parent.mkdir(parents=True, exist_ok=True)
             with open(log_file, "a", encoding="utf-8") as f:
@@ -3195,6 +3234,7 @@ class ReflectionStore:
             "applied": applied,
             "backup": backup_path,
             "log": str(log_file),
+            **({"apply_error": apply_error} if apply_error is not None else {}),
             **(
                 {"log_error": record["log_error"]}
                 if "log_error" in record else {}

--- a/src/pinky_memory/store.py
+++ b/src/pinky_memory/store.py
@@ -3084,6 +3084,123 @@ class ReflectionStore:
             "predicates": {r["predicate"]: r["cnt"] for r in predicates},
         }
 
+    def kg_sweep_ephemeral(
+        self,
+        apply: bool = False,
+        log_path: str = "",
+        backup_dir: str = "",
+    ) -> dict:
+        """Holder-side pure-ID ephemeral sweep (#153 step-1 instrument; #654).
+
+        Mirrors ``scripts/kg_ephemeral_sweep.py`` — same detector
+        (``ephemeral_guard.is_ephemeral_entity``, the write-guard's own
+        regexes), same JSONL record shape, same backup-before-delete
+        discipline — but runs INSIDE the store owner, so no external process
+        ever opens the live DB (storage-authority #619 drives the direct-open
+        allowlist to zero; the script now refuses in-place opens while the
+        holder runs, #1132). ``n_candidates`` per run = regrowth since the
+        previous sweep — the instrument that decides write-guard urgency.
+
+        Dry-run by default. ``apply=True`` deletes each candidate entity and
+        every edge touching it, in one transaction, after a transaction-
+        consistent backup via the SQLite backup API. Every run appends one
+        JSONL record to ``log_path`` (default: ``kg_sweep_log.jsonl`` next to
+        the DB) so the regrowth series stays measurable and deletions stay
+        auditable.
+        """
+        rows = self._conn.execute("SELECT id, name, type FROM kg_entities").fetchall()
+        candidates = [
+            (r["id"], r["name"], r["type"])
+            for r in rows
+            if is_ephemeral_entity(r["name"])
+        ]
+
+        deleted_edges: list[dict] = []
+        for _eid, name, _etype in candidates:
+            for e in self._conn.execute(
+                "SELECT id, subject, predicate, object, valid_to FROM kg_triples "
+                "WHERE subject = ? OR object = ?",
+                (name, name),
+            ).fetchall():
+                deleted_edges.append(
+                    {
+                        "triple_id": e["id"], "subject": e["subject"],
+                        "predicate": e["predicate"], "object": e["object"],
+                        "active": e["valid_to"] is None, "via": name,
+                    }
+                )
+
+        backup_path: str | None = None
+        applied = False
+        if apply and candidates:
+            ts = datetime.now(timezone.utc).strftime("%Y-%m-%d_%H%M%S")
+            base_dir = Path(backup_dir) if backup_dir else Path(self._db_path).parent
+            dest_dir = base_dir / f"{ts}_sweep"
+            dest_dir.mkdir(parents=True, exist_ok=True)
+            dest = dest_dir / Path(self._db_path).name
+            with self._lock:
+                # Backup API, not file copy: transaction-consistent even with
+                # WAL frames not yet checkpointed.
+                dst = sqlite3.connect(str(dest))
+                try:
+                    self._conn.backup(dst)
+                finally:
+                    dst.close()
+                backup_path = str(dest)
+                for _eid, name, _etype in candidates:
+                    self._conn.execute(
+                        "DELETE FROM kg_triples WHERE subject = ? OR object = ?",
+                        (name, name),
+                    )
+                    self._conn.execute(
+                        "DELETE FROM kg_entities WHERE name = ?", (name,)
+                    )
+                self._conn.commit()
+                applied = True
+
+        record = {
+            "ts": datetime.now(timezone.utc).isoformat(),
+            "db": self._db_path,
+            "n_candidates": len(candidates),
+            "candidates": [
+                {"name": n, "type": t} for _i, n, t in candidates
+            ],
+            "n_edges": len(deleted_edges),
+            "n_active_edges": sum(1 for e in deleted_edges if e["active"]),
+            "deleted_edges": deleted_edges if applied else [],
+            "applied": applied,
+            "backup": backup_path,
+            "runner": "store",
+        }
+        log_file = Path(log_path) if log_path else (
+            Path(self._db_path).parent / "kg_sweep_log.jsonl"
+        )
+        try:
+            log_file.parent.mkdir(parents=True, exist_ok=True)
+            with open(log_file, "a", encoding="utf-8") as f:
+                f.write(json.dumps(record, ensure_ascii=True) + "\n")
+        except OSError as e:
+            # The sweep result is still returned; a log-write failure must be
+            # visible, not silent (the log IS the regrowth instrument).
+            record["log_error"] = str(e)
+            logging.getLogger(__name__).error(
+                "kg_sweep_ephemeral: regrowth log append failed: %s", e
+            )
+
+        return {
+            "n_candidates": len(candidates),
+            "candidates": [n for _i, n, _t in candidates],
+            "n_edges": len(deleted_edges),
+            "n_active_edges": record["n_active_edges"],
+            "applied": applied,
+            "backup": backup_path,
+            "log": str(log_file),
+            **(
+                {"log_error": record["log_error"]}
+                if "log_error" in record else {}
+            ),
+        }
+
     # ── KG Extraction Tracking ────────────────────────────────
 
     def kg_get_unprocessed_reflections(

--- a/tests/test_kg_sweep_store.py
+++ b/tests/test_kg_sweep_store.py
@@ -4,8 +4,9 @@ The sweep used to be an external script opening the live memory.db directly;
 storage-authority (#619/#1118/#1132) drives such direct opens to zero, so the
 sweep now runs INSIDE the store owner as ``ReflectionStore.kg_sweep_ephemeral``.
 These tests pin the contract the script provided: same detector as the
-write-guard, dry-run by default, backup-before-delete, and one JSONL regrowth
-record per run.
+write-guard, dry-run by default, backup-before-delete, all-or-nothing apply,
+and one JSONL regrowth record per run — plus the boundary the tool adds:
+log/backup paths can never escape the store's own directory.
 """
 
 from __future__ import annotations
@@ -22,6 +23,7 @@ from pinky_memory.store import ReflectionStore
 EPHEMERAL_NAME = "PR #124"
 EPHEMERAL_STAMP = "26.08.027"
 DURABLE_NAME = "Brad"
+DURABLE_NAME_2 = "SQLite"
 
 
 @pytest.fixture
@@ -49,10 +51,14 @@ def _seed_edge(store: ReflectionStore, subject: str, obj: str) -> None:
 
 
 def _seed_graph(store: ReflectionStore) -> None:
+    """One ephemeral node with two edges, plus a durable-durable edge that a
+    correct sweep must NEVER touch (guards against over-broad deletes)."""
     _seed_entity(store, EPHEMERAL_NAME)
     _seed_entity(store, DURABLE_NAME, "person")
+    _seed_entity(store, DURABLE_NAME_2, "tool")
     _seed_edge(store, EPHEMERAL_NAME, DURABLE_NAME)
     _seed_edge(store, DURABLE_NAME, EPHEMERAL_NAME)
+    _seed_edge(store, DURABLE_NAME, DURABLE_NAME_2)
 
 
 def test_seed_names_are_what_they_claim():
@@ -61,10 +67,11 @@ def test_seed_names_are_what_they_claim():
     assert is_ephemeral_entity(EPHEMERAL_NAME)
     assert is_ephemeral_entity(EPHEMERAL_STAMP)
     assert not is_ephemeral_entity(DURABLE_NAME)
+    assert not is_ephemeral_entity(DURABLE_NAME_2)
 
 
 class TestDryRun:
-    def test_detects_but_does_not_delete(self, store, tmp_path):
+    def test_detects_but_does_not_delete(self, store):
         _seed_graph(store)
         result = store.kg_sweep_ephemeral()
 
@@ -75,9 +82,9 @@ class TestDryRun:
         assert result["backup"] is None
         # Nothing deleted
         n = store._conn.execute("SELECT COUNT(*) FROM kg_entities").fetchone()[0]
-        assert n == 2
+        assert n == 3
         n = store._conn.execute("SELECT COUNT(*) FROM kg_triples").fetchone()[0]
-        assert n == 2
+        assert n == 3
         # Regrowth record written, applied=false, no edge dump on dry runs
         lines = [
             json.loads(line)
@@ -90,26 +97,26 @@ class TestDryRun:
 
 
 class TestApply:
-    def test_deletes_candidates_and_their_edges_only(self, store, tmp_path):
+    def test_deletes_candidates_and_their_edges_only(self, store):
         _seed_graph(store)
-        result = store.kg_sweep_ephemeral(
-            apply=True, backup_dir=str(tmp_path / "bk")
-        )
+        result = store.kg_sweep_ephemeral(apply=True)
 
         assert result["applied"] is True
         assert result["n_candidates"] == 1
-        names = [
+        names = {
             r[0] for r in store._conn.execute("SELECT name FROM kg_entities")
-        ]
-        assert names == [DURABLE_NAME]
-        n = store._conn.execute("SELECT COUNT(*) FROM kg_triples").fetchone()[0]
-        assert n == 0
+        }
+        assert names == {DURABLE_NAME, DURABLE_NAME_2}
+        # The durable-durable edge survives — an over-broad edge delete
+        # (e.g. an unconditioned DELETE FROM kg_triples) must fail HERE.
+        edges = store._conn.execute(
+            "SELECT subject, object FROM kg_triples"
+        ).fetchall()
+        assert [(e[0], e[1]) for e in edges] == [(DURABLE_NAME, DURABLE_NAME_2)]
 
-    def test_backup_is_consistent_and_pre_delete(self, store, tmp_path):
+    def test_backup_is_consistent_and_pre_delete(self, store):
         _seed_graph(store)
-        result = store.kg_sweep_ephemeral(
-            apply=True, backup_dir=str(tmp_path / "bk")
-        )
+        result = store.kg_sweep_ephemeral(apply=True)
 
         assert result["backup"] is not None
         bconn = sqlite3.connect(result["backup"])
@@ -121,19 +128,20 @@ class TestApply:
         # The backup captures the graph BEFORE the delete — that is what
         # makes the sweep reversible.
         assert EPHEMERAL_NAME in names
-        assert edges == 2
+        assert edges == 3
 
-    def test_apply_log_records_deleted_edges(self, store, tmp_path):
+    def test_apply_log_records_deleted_edges(self, store):
         _seed_graph(store)
-        result = store.kg_sweep_ephemeral(
-            apply=True, backup_dir=str(tmp_path / "bk")
-        )
+        result = store.kg_sweep_ephemeral(apply=True)
         last = json.loads(
             open(result["log"], encoding="utf-8").readlines()[-1]
         )
         assert last["applied"] is True
         assert last["n_edges"] == 2
         assert {e["via"] for e in last["deleted_edges"]} == {EPHEMERAL_NAME}
+        # Script-parity: candidates are bare name strings, one consumer can
+        # read the whole regrowth series across both writers.
+        assert last["candidates"] == [EPHEMERAL_NAME]
 
     def test_empty_graph_apply_is_noop_without_backup(self, store):
         result = store.kg_sweep_ephemeral(apply=True)
@@ -142,12 +150,65 @@ class TestApply:
         assert result["backup"] is None
 
 
-class TestLogPath:
-    def test_custom_log_path_is_honored(self, store, tmp_path):
+class _FailingConn:
+    """Proxy that fails the entity delete for a specific name — simulates a
+    mid-loop OperationalError so the rollback contract can be pinned."""
+
+    def __init__(self, real: sqlite3.Connection, fail_name: str) -> None:
+        self._real = real
+        self._fail_name = fail_name
+
+    def execute(self, sql: str, params: tuple = ()) -> sqlite3.Cursor:
+        if "DELETE FROM kg_entities" in sql and self._fail_name in params:
+            raise sqlite3.OperationalError("disk I/O error (simulated)")
+        return self._real.execute(sql, params)
+
+    def __getattr__(self, name: str):
+        return getattr(self._real, name)
+
+
+class TestApplyRollback:
+    def test_mid_loop_failure_rolls_back_everything(self, store):
+        """A partial sweep left in an open transaction would be silently
+        committed by the next unrelated write. Apply must be all-or-nothing."""
+        _seed_graph(store)
+        _seed_entity(store, EPHEMERAL_STAMP)  # second candidate: fails mid-loop
+        real_conn = store._conn
+        store._conn = _FailingConn(real_conn, EPHEMERAL_STAMP)
+        try:
+            result = store.kg_sweep_ephemeral(apply=True)
+        finally:
+            store._conn = real_conn
+
+        assert result["applied"] is False
+        assert "apply_error" in result
+        assert not real_conn.in_transaction, "open transaction left behind"
+        # EVERYTHING survives — including the candidate whose delete succeeded
+        # before the failure (rolled back, not half-swept).
+        names = {r[0] for r in real_conn.execute("SELECT name FROM kg_entities")}
+        assert {EPHEMERAL_NAME, EPHEMERAL_STAMP} <= names
+        n = real_conn.execute("SELECT COUNT(*) FROM kg_triples").fetchone()[0]
+        assert n == 3
+        # The failed run is still visible in the regrowth log.
+        last = json.loads(open(result["log"], encoding="utf-8").readlines()[-1])
+        assert last["applied"] is False
+        assert "apply_error" in last
+
+
+class TestPathBoundary:
+    def test_log_path_outside_store_dir_is_refused(self, store, tmp_path):
+        with pytest.raises(ValueError, match="log_path"):
+            store.kg_sweep_ephemeral(log_path=str(tmp_path.parent / "x.jsonl"))
+
+    def test_backup_dir_outside_store_dir_is_refused(self, store, tmp_path):
+        with pytest.raises(ValueError, match="backup_dir"):
+            store.kg_sweep_ephemeral(backup_dir="/tmp/elsewhere")
+
+    def test_paths_under_store_dir_are_honored(self, store, tmp_path):
         _seed_entity(store, EPHEMERAL_STAMP)
         log = tmp_path / "custom" / "sweep.jsonl"
         result = store.kg_sweep_ephemeral(log_path=str(log))
         assert result["log"] == str(log)
         assert log.exists()
         rec = json.loads(log.read_text().splitlines()[-1])
-        assert rec["candidates"] == [{"name": EPHEMERAL_STAMP, "type": "unknown"}]
+        assert rec["candidates"] == [EPHEMERAL_STAMP]

--- a/tests/test_kg_sweep_store.py
+++ b/tests/test_kg_sweep_store.py
@@ -1,0 +1,153 @@
+"""Tests for the holder-side KG ephemeral sweep (#654).
+
+The sweep used to be an external script opening the live memory.db directly;
+storage-authority (#619/#1118/#1132) drives such direct opens to zero, so the
+sweep now runs INSIDE the store owner as ``ReflectionStore.kg_sweep_ephemeral``.
+These tests pin the contract the script provided: same detector as the
+write-guard, dry-run by default, backup-before-delete, and one JSONL regrowth
+record per run.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import time
+
+import pytest
+
+from pinky_memory.ephemeral_guard import is_ephemeral_entity
+from pinky_memory.store import ReflectionStore
+
+EPHEMERAL_NAME = "PR #124"
+EPHEMERAL_STAMP = "26.08.027"
+DURABLE_NAME = "Brad"
+
+
+@pytest.fixture
+def store(tmp_path):
+    return ReflectionStore(db_path=str(tmp_path / "test_memory.db"))
+
+
+def _seed_entity(store: ReflectionStore, name: str, etype: str = "unknown") -> None:
+    """Insert an entity directly — the write-guard (correctly) refuses
+    ephemeral names through kg_add, so seeding must bypass it."""
+    store._conn.execute(
+        "INSERT INTO kg_entities (id, name, type, created_at) VALUES (?, ?, ?, ?)",
+        (f"seed-{name}", name, etype, time.time()),
+    )
+    store._conn.commit()
+
+
+def _seed_edge(store: ReflectionStore, subject: str, obj: str) -> None:
+    store._conn.execute(
+        "INSERT INTO kg_triples (id, subject, predicate, object, extracted_at)"
+        " VALUES (?, ?, ?, ?, ?)",
+        (f"seed-{subject}-{obj}", subject, "mentions", obj, time.time()),
+    )
+    store._conn.commit()
+
+
+def _seed_graph(store: ReflectionStore) -> None:
+    _seed_entity(store, EPHEMERAL_NAME)
+    _seed_entity(store, DURABLE_NAME, "person")
+    _seed_edge(store, EPHEMERAL_NAME, DURABLE_NAME)
+    _seed_edge(store, DURABLE_NAME, EPHEMERAL_NAME)
+
+
+def test_seed_names_are_what_they_claim():
+    """Precondition: the seeds exercise both sides of the detector — if the
+    guard patterns change under these names, fail here, not mysteriously."""
+    assert is_ephemeral_entity(EPHEMERAL_NAME)
+    assert is_ephemeral_entity(EPHEMERAL_STAMP)
+    assert not is_ephemeral_entity(DURABLE_NAME)
+
+
+class TestDryRun:
+    def test_detects_but_does_not_delete(self, store, tmp_path):
+        _seed_graph(store)
+        result = store.kg_sweep_ephemeral()
+
+        assert result["n_candidates"] == 1
+        assert result["candidates"] == [EPHEMERAL_NAME]
+        assert result["n_edges"] == 2
+        assert result["applied"] is False
+        assert result["backup"] is None
+        # Nothing deleted
+        n = store._conn.execute("SELECT COUNT(*) FROM kg_entities").fetchone()[0]
+        assert n == 2
+        n = store._conn.execute("SELECT COUNT(*) FROM kg_triples").fetchone()[0]
+        assert n == 2
+        # Regrowth record written, applied=false, no edge dump on dry runs
+        lines = [
+            json.loads(line)
+            for line in open(result["log"], encoding="utf-8")
+        ]
+        assert lines[-1]["n_candidates"] == 1
+        assert lines[-1]["applied"] is False
+        assert lines[-1]["deleted_edges"] == []
+        assert lines[-1]["runner"] == "store"
+
+
+class TestApply:
+    def test_deletes_candidates_and_their_edges_only(self, store, tmp_path):
+        _seed_graph(store)
+        result = store.kg_sweep_ephemeral(
+            apply=True, backup_dir=str(tmp_path / "bk")
+        )
+
+        assert result["applied"] is True
+        assert result["n_candidates"] == 1
+        names = [
+            r[0] for r in store._conn.execute("SELECT name FROM kg_entities")
+        ]
+        assert names == [DURABLE_NAME]
+        n = store._conn.execute("SELECT COUNT(*) FROM kg_triples").fetchone()[0]
+        assert n == 0
+
+    def test_backup_is_consistent_and_pre_delete(self, store, tmp_path):
+        _seed_graph(store)
+        result = store.kg_sweep_ephemeral(
+            apply=True, backup_dir=str(tmp_path / "bk")
+        )
+
+        assert result["backup"] is not None
+        bconn = sqlite3.connect(result["backup"])
+        try:
+            names = {r[0] for r in bconn.execute("SELECT name FROM kg_entities")}
+            edges = bconn.execute("SELECT COUNT(*) FROM kg_triples").fetchone()[0]
+        finally:
+            bconn.close()
+        # The backup captures the graph BEFORE the delete — that is what
+        # makes the sweep reversible.
+        assert EPHEMERAL_NAME in names
+        assert edges == 2
+
+    def test_apply_log_records_deleted_edges(self, store, tmp_path):
+        _seed_graph(store)
+        result = store.kg_sweep_ephemeral(
+            apply=True, backup_dir=str(tmp_path / "bk")
+        )
+        last = json.loads(
+            open(result["log"], encoding="utf-8").readlines()[-1]
+        )
+        assert last["applied"] is True
+        assert last["n_edges"] == 2
+        assert {e["via"] for e in last["deleted_edges"]} == {EPHEMERAL_NAME}
+
+    def test_empty_graph_apply_is_noop_without_backup(self, store):
+        result = store.kg_sweep_ephemeral(apply=True)
+        assert result["n_candidates"] == 0
+        assert result["applied"] is False
+        assert result["backup"] is None
+
+
+class TestLogPath:
+    def test_custom_log_path_is_honored(self, store, tmp_path):
+        _seed_entity(store, EPHEMERAL_STAMP)
+        log = tmp_path / "custom" / "sweep.jsonl"
+        result = store.kg_sweep_ephemeral(log_path=str(log))
+        assert result["log"] == str(log)
+        assert log.exists()
+        rec = json.loads(log.read_text().splitlines()[-1])
+        assert rec["candidates"] == [{"name": EPHEMERAL_STAMP, "type": "unknown"}]


### PR DESCRIPTION
Closes the release-gating half of task #654 (sweep rework ahead of the storage-authority tightening).

## Problem
The recurring ephemeral-node sweep (#153 step-1 instrument) was an external script opening the live agent `memory.db` directly with raw sqlite3. Storage-authority (#619/#1118) drives direct opens of live stores to zero, and #1132 made the script refuse in-place opens while the holder runs — so the scheduled sweep would fail on every run after the next release deploys.

## Fix
The sweep now runs **inside the store owner**: `ReflectionStore.kg_sweep_ephemeral`, exposed as the `kg_sweep_ephemeral` MCP tool.
- Same detector as the write-guard (`ephemeral_guard` — one source of truth, no drift).
- Same JSONL regrowth-record shape (`n_candidates` per run = regrowth since last sweep — the instrument stays intact).
- Dry-run by default; `apply=True` backs up via the **SQLite backup API** (transaction-consistent, unlike a file copy) then deletes candidates + their edges in one transaction.
- The script remains for offline/holder-down use; while the holder runs it now correctly refuses (#1132).

Rollout note: the scheduled job switches from the script to the MCP tool at deploy time (schedule-prompt change, no code).

## Evidence
- 7 new tests: detection-without-deletion on dry runs, apply deletes candidates + edges only, backup provably captures the PRE-delete graph, empty-graph apply is a no-op, custom log path honored, and a precondition test pinning the seed names against the live guard patterns.
- Non-vacuity verified: inverting the backup/delete order (neuter experiment) turns exactly the pre-delete-backup test RED.
- Full suite green locally.

No UI change — no screenshot (store internals + MCP tool only).

🤖 Opened by barsik

🤖 Generated with [Claude Code](https://claude.com/claude-code)