### PR TITLE
Guard tmux transcript binds by session lineage (#1148)

### DIFF
--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -1311,9 +1311,10 @@ forwards transcript_path to the daemon.
 """
 import hashlib, hmac, base64, time, urllib.request, json, os, sys
 
-# #1148: only daemon-launched tmux panes receive this exact marker. A headless
-# utility Claude session can inherit the workspace's settings.json, but not the
-# pane-only marker, so it exits before signing or POSTing a transcript bind.
+# #1148: daemon-spawned headless sessions can load the workspace settings, but
+# the daemon environment never carries this marker, so they exit before POSTing.
+# Processes descended from the pane inherit it; the session-lineage guard is
+# the backstop for transcript binds from those descendants.
 if os.environ.get("PINKY_TMUX_TRANSCRIPT_BIND", "").strip() != "1":
     sys.exit(0)
 

--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -1311,6 +1311,12 @@ forwards transcript_path to the daemon.
 """
 import hashlib, hmac, base64, time, urllib.request, json, os, sys
 
+# #1148: only daemon-launched tmux panes receive this exact marker. A headless
+# utility Claude session can inherit the workspace's settings.json, but not the
+# pane-only marker, so it exits before signing or POSTing a transcript bind.
+if os.environ.get("PINKY_TMUX_TRANSCRIPT_BIND", "").strip() != "1":
+    sys.exit(0)
+
 secret = os.environ.get("PINKY_AGENT_KEY", "").strip() or os.environ.get("PINKY_SESSION_SECRET", "").strip()
 if not secret:
     sys.exit(0)

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -7558,13 +7558,15 @@ npm run build</pre>
         update = getattr(session, "set_transcript_path", None)
         if callable(update):
             try:
-                update(normalised)
+                accepted = update(normalised, session_id=req.session_id)
             except Exception as e:
                 _log(
                     f"api: transport_transcript_path set_transcript_path "
                     f"raised for {name}: {e}"
                 )
                 raise HTTPException(500, str(e))
+            if accepted is False:
+                raise HTTPException(409, "transcript bind rejected")
         return {"ok": True, "agent": name, "transcript_path": str(normalised)}
 
     @app.post("/agents/{name}/transport/tool-use")

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -5093,10 +5093,12 @@ class TmuxSession(TransportReplacementMixin):
         hook reports the actual path Claude Code is writing to.
 
         #1148 session-lineage perimeter: external callers must provide a
-        non-empty ``session_id``. A new id is accepted only during the
-        daemon-opened per-spawn first-bind window; after that, only repeat
-        reports from the bound lineage may update the path. Returns ``False``
-        on rejection so the HTTP boundary can return a loud conflict.
+        non-empty ``session_id``. A new id is accepted during the
+        daemon-opened per-spawn first-bind window or when trusted recovery
+        consumed that window without establishing lineage. Once lineage is
+        established, only its repeat reports may update the path outside a
+        new window. Returns ``False`` on rejection so the HTTP boundary can
+        return a loud conflict.
 
         Trusted filesystem discovery never calls this method. It uses the
         separate ``_set_transcript_path_internal`` call site below, so no HTTP
@@ -5173,7 +5175,11 @@ class TmuxSession(TransportReplacementMixin):
         rejection_reason = ""
         if not requested_session_id:
             rejection_reason = "missing_session_id"
-        elif not bind_window_open and requested_session_id != bound_session_id:
+        elif (
+            bound_session_id
+            and not bind_window_open
+            and requested_session_id != bound_session_id
+        ):
             rejection_reason = "foreign_session_id"
 
         if rejection_reason:

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -510,9 +510,9 @@ _PLACEHOLDER_TRANSCRIPT_PATH = Path("/dev/null/no-transcript-yet")
 # SessionStart hook latency (sub-second to ~200ms).
 _FIRST_BIND_RECOVERY_DELAY_SEC = 5.0
 
-# #1148 — only a daemon-launched tmux pane receives this marker. The generated
-# SessionStart hook requires the exact value before it can report a transcript
-# bind, keeping sibling/headless Claude processes in the same cwd silent.
+# #1148 — this per-session marker gates daemon-spawned headless sessions because
+# the daemon environment never carries it. Pane-descendant processes inherit
+# the marker; the session-lineage guard is the backstop for their binds.
 _TMUX_TRANSCRIPT_BIND_MARKER_ENV = "PINKY_TMUX_TRANSCRIPT_BIND"
 _TMUX_TRANSCRIPT_BIND_MARKER_VALUE = "1"
 

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -510,6 +510,16 @@ _PLACEHOLDER_TRANSCRIPT_PATH = Path("/dev/null/no-transcript-yet")
 # SessionStart hook latency (sub-second to ~200ms).
 _FIRST_BIND_RECOVERY_DELAY_SEC = 5.0
 
+# #1148 — only a daemon-launched tmux pane receives this marker. The generated
+# SessionStart hook requires the exact value before it can report a transcript
+# bind, keeping sibling/headless Claude processes in the same cwd silent.
+_TMUX_TRANSCRIPT_BIND_MARKER_ENV = "PINKY_TMUX_TRANSCRIPT_BIND"
+_TMUX_TRANSCRIPT_BIND_MARKER_VALUE = "1"
+
+# Stable incident signature for api.log greps. Keep the prefix unchanged even
+# if the structured fields below evolve.
+_TRANSCRIPT_BIND_REJECTED_LOG_PREFIX = "TRANSCRIPT_BIND_REJECTED"
+
 
 class _ContextLockDeferral(Exception):  # noqa: N818
     """Transient: context-lock file present at paste time.
@@ -1986,6 +1996,7 @@ class TmuxSession(TransportReplacementMixin):
             "errors": 0,
             "reconnects": 0,
             "auto_restarts": 0,
+            "transcript_bind_rejections": 0,
         }
         self.usage = SessionUsage()
 
@@ -2153,6 +2164,12 @@ class TmuxSession(TransportReplacementMixin):
         # ``stop_hook_summary``. Continue launches preserve the
         # seek-to-EOF default (#496 round-1 Case 3 reply-spam defense).
         self._tailer_first_bind_pending: bool = False
+
+        # #1148 — lineage reported by the pane's SessionStart hook. A new
+        # non-empty id may replace this only while the daemon's per-spawn
+        # first-bind window above is open. Retain it across relaunches; a
+        # legitimate daemon relaunch re-arms the window in ``_start_tailer``.
+        self._bound_transcript_session_id: str = ""
 
         # Issue #565 — handle to the delayed first-bind recovery task
         # scheduled from ``_start_tailer``. Cancelled in ``_stop_tailer``
@@ -4237,6 +4254,7 @@ class TmuxSession(TransportReplacementMixin):
             env["CLAUDE_CODE_OAUTH_TOKEN"] = oauth_token
         if self.agent_name:
             env["PINKY_AGENT_NAME"] = self.agent_name
+        env[_TMUX_TRANSCRIPT_BIND_MARKER_ENV] = _TMUX_TRANSCRIPT_BIND_MARKER_VALUE
         env["CLAUDE_CODE_MAX_CONCURRENT_SUBAGENTS"] = str(
             DEFAULT_MAX_CONCURRENT_SUBAGENTS
         )
@@ -5065,9 +5083,24 @@ class TmuxSession(TransportReplacementMixin):
         if self._tailer is not None:
             self._tailer.wake()
 
-    def set_transcript_path(self, path: Path | str) -> None:
+    def set_transcript_path(
+        self,
+        path: Path | str,
+        *,
+        session_id: str,
+    ) -> bool:
         """Update the watched transcript path — called when SessionStart
         hook reports the actual path Claude Code is writing to.
+
+        #1148 session-lineage perimeter: external callers must provide a
+        non-empty ``session_id``. A new id is accepted only during the
+        daemon-opened per-spawn first-bind window; after that, only repeat
+        reports from the bound lineage may update the path. Returns ``False``
+        on rejection so the HTTP boundary can return a loud conflict.
+
+        Trusted filesystem discovery never calls this method. It uses the
+        separate ``_set_transcript_path_internal`` call site below, so no HTTP
+        payload shape can turn a missing session id into an internal bypass.
 
         Cleaner than guessing the path via mtime glob: the SessionStart
         hook fires before the first model call, so the tailer is
@@ -5133,6 +5166,37 @@ class TmuxSession(TransportReplacementMixin):
         delivery (not enqueue) so the wake turn stays at queue head
         and external sends queue behind — FIFO preserved (Murzik #571
         review).
+        """
+        requested_session_id = (session_id or "").strip()
+        bind_window_open = self._tailer_first_bind_pending
+        bound_session_id = self._bound_transcript_session_id
+        rejection_reason = ""
+        if not requested_session_id:
+            rejection_reason = "missing_session_id"
+        elif not bind_window_open and requested_session_id != bound_session_id:
+            rejection_reason = "foreign_session_id"
+
+        if rejection_reason:
+            self._stats["transcript_bind_rejections"] += 1
+            _log(
+                f"{_TRANSCRIPT_BIND_REJECTED_LOG_PREFIX} "
+                f"agent={self.agent_name} reason={rejection_reason} "
+                f"requested_session_id={requested_session_id[:12] or '<missing>'} "
+                f"bound_session_id={bound_session_id[:12] or '<none>'} "
+                f"bind_window_open={str(bind_window_open).lower()}"
+            )
+            return False
+
+        self._bound_transcript_session_id = requested_session_id
+        self._set_transcript_path_internal(path)
+        return True
+
+    def _set_transcript_path_internal(self, path: Path | str) -> None:
+        """Trusted call-site-only transcript rebind for daemon discovery.
+
+        This is intentionally a separate method rather than a flag on the
+        public hook path. Only in-process first-bind recovery calls it; the API
+        endpoint exposes ``set_transcript_path`` and cannot select this path.
         """
         if self._tailer is None:
             return
@@ -6621,10 +6685,11 @@ class TmuxSession(TransportReplacementMixin):
 
         Recovery decision needs ``_tailer_first_bind_pending`` and
         ``_last_launch_used_continue``, which the tailer doesn't know
-        about — keep it here at ``TmuxSession``. Route the rebind
-        through ``set_transcript_path`` so the existing first-bind
-        seek-to-start path (PR #564) handles the seek + flag-consume,
-        and so the #496 continue-launch reply-spam defense remains
+        about — keep it here at ``TmuxSession``. Route the rebind through
+        the call-site-only ``_set_transcript_path_internal`` method so the
+        existing first-bind seek-to-start path (PR #564) handles the seek +
+        flag-consume without making a missing external session id a trust
+        discriminator. The #496 continue-launch reply-spam defense remains
         intact for the predicate-evaluates-False branch.
 
         No-op when:
@@ -6669,7 +6734,7 @@ class TmuxSession(TransportReplacementMixin):
         )
         # Routes through the standard first-bind path → seeks to byte 0
         # and consumes the ``_tailer_first_bind_pending`` flag (PR #564).
-        self.set_transcript_path(discovered)
+        self._set_transcript_path_internal(discovered)
 
     async def _stop_tailer(self) -> None:
         """Stop the tailer if running. Idempotent.

--- a/tests/test_agent_registry.py
+++ b/tests/test_agent_registry.py
@@ -5,9 +5,13 @@ from __future__ import annotations
 import json
 import os
 import sqlite3
+import sys
 import tempfile
 import threading
 import time
+import urllib.request
+from io import StringIO
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -389,6 +393,46 @@ class TestSigningKeys:
             # The old inline f-string shape (f"http://localhost:8888{path}")
             # must be gone — that URL can never be overridden at runtime.
             assert 'f"http://localhost:8888' not in src
+
+    def test_tmux_session_start_hook_skips_post_without_pane_marker(
+        self,
+        monkeypatch,
+    ):
+        """#1148: a headless Claude session in the cwd never reports a bind."""
+        from pinky_daemon import agent_registry as ar
+
+        source = ar._tmux_session_start_hook_source("dymok")
+        post = MagicMock()
+        monkeypatch.setattr(urllib.request, "urlopen", post)
+        monkeypatch.setenv("PINKY_AGENT_KEY", "test-agent-key")
+        monkeypatch.delenv("PINKY_TMUX_TRANSCRIPT_BIND", raising=False)
+        monkeypatch.setattr(
+            sys,
+            "stdin",
+            StringIO(json.dumps({
+                "transcript_path": "/tmp/headless.jsonl",
+                "session_id": "headless-session-id",
+            })),
+        )
+
+        with pytest.raises(SystemExit) as exit_info:
+            exec(compile(source, "hook_tmux_session_start.py", "exec"), {})
+
+        assert exit_info.value.code == 0
+        post.assert_not_called()
+
+    def test_stale_session_start_hook_is_rewritten_with_pane_marker(self, tmp_path):
+        """Workspace hook sync upgrades existing agents to the #1148 gate."""
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+        hook_path = claude_dir / "hook_tmux_session_start.py"
+        hook_path.write_text("#!/usr/bin/env python3\n# stale pre-1148 hook\n")
+
+        AgentRegistry._setup_hooks(tmp_path, "dymok")
+
+        source = hook_path.read_text()
+        assert "stale pre-1148" not in source
+        assert 'os.environ.get("PINKY_TMUX_TRANSCRIPT_BIND", "")' in source
 
     def test_stale_status_hooks_rewritten_in_place(self, tmp_path):
         """#638 review fix: hook_working.py / hook_idle.py were historically

--- a/tests/test_agent_status.py
+++ b/tests/test_agent_status.py
@@ -15,6 +15,7 @@ import os
 import tempfile
 import time
 from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import pytest
 from fastapi.testclient import TestClient
@@ -560,6 +561,67 @@ class TestTransportEndpoints:
         # session: None (the path validation already succeeded, which is
         # what this test pins).
         assert body.get("session") is None
+
+    def test_transcript_path_rejection_is_loud_and_forwards_session_id(self):
+        """#1148: a live transport rejection is an HTTP conflict, not 200."""
+        from pathlib import Path
+
+        client = self._client_with_agent()
+        app = client.app
+        session = FakeStreamingSession("dymok")
+        session.set_transcript_path = MagicMock(return_value=False)
+        app.state.broker.register_streaming("dymok", session, label="main")
+        candidate = (
+            Path.home() / ".claude" / "projects" / "test-agent"
+            / "foreign-session.jsonl"
+        )
+
+        resp = client.post(
+            "/agents/dymok/transport/transcript-path",
+            json={
+                "transcript_path": str(candidate),
+                "session_id": "foreign-session-id",
+            },
+        )
+
+        assert resp.status_code == 409
+        assert "rejected" in resp.json()["detail"].lower()
+        session.set_transcript_path.assert_called_once_with(
+            candidate.resolve(strict=False),
+            session_id="foreign-session-id",
+        )
+
+    def test_transcript_path_payload_cannot_select_internal_rebind(self):
+        """The trusted #565 call site is not an HTTP-selectable code path."""
+        from pathlib import Path
+
+        client = self._client_with_agent()
+        app = client.app
+        session = FakeStreamingSession("dymok")
+        session.set_transcript_path = MagicMock(return_value=False)
+        session._set_transcript_path_internal = MagicMock(return_value=True)
+        app.state.broker.register_streaming("dymok", session, label="main")
+        candidate = (
+            Path.home() / ".claude" / "projects" / "test-agent"
+            / "untrusted-session.jsonl"
+        )
+
+        resp = client.post(
+            "/agents/dymok/transport/transcript-path",
+            json={
+                "transcript_path": str(candidate),
+                "trusted": True,
+                "internal": True,
+                "daemon_initiated": True,
+            },
+        )
+
+        assert resp.status_code == 409
+        session.set_transcript_path.assert_called_once_with(
+            candidate.resolve(strict=False),
+            session_id="",
+        )
+        session._set_transcript_path_internal.assert_not_called()
 
 
 # ──────────────────────────────────────────────────────────────────────────

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -250,6 +250,17 @@ async def test_cold_start_caps_concurrent_subagents_in_spawn_env() -> None:
 
 
 @pytest.mark.asyncio
+async def test_cold_start_marks_pane_for_transcript_bind_hook() -> None:
+    """Only daemon-launched tmux panes may report SessionStart binds."""
+    ss, tmux = _make_session()
+
+    await ss.connect()
+
+    env = tmux.new_session.await_args.kwargs["env"]
+    assert env["PINKY_TMUX_TRANSCRIPT_BIND"] == "1"
+
+
+@pytest.mark.asyncio
 async def test_cold_start_failure_drives_to_dead_via_boot_failed() -> None:
     """If ``tmux new-session`` fails, cold-start lands BOOTING → DEAD via
     BOOT_FAILED (not silent disconnect)."""
@@ -2643,10 +2654,123 @@ async def test_set_transcript_path_forwards_to_tailer(tmp_path) -> None:
     await ss.connect()
     new_path = tmp_path / "new-session.jsonl"
     new_path.touch()
-    ss.set_transcript_path(new_path)
+    ss.set_transcript_path(new_path, session_id="test-session-id")
     assert ss._tailer.transcript_path == new_path
     # Offset reset on rotation (per tailer contract).
     assert ss._tailer.offset == 0
+    await ss.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_transcript_bind_rejects_foreign_mid_session(
+    tmp_path,
+    capsys,
+) -> None:
+    """#1148: a sibling headless session cannot replace the REPL tailer."""
+    ss, _ = _make_session()
+    await ss.connect()
+    original = tmp_path / "repl-session.jsonl"
+    foreign = tmp_path / "librarian-session.jsonl"
+    original.touch()
+    foreign.touch()
+
+    assert ss.set_transcript_path(
+        original,
+        session_id="repl-session-id",
+    ) is True
+    assert ss._tailer.transcript_path == original
+    assert ss._session_ready_event.is_set()
+
+    assert ss.set_transcript_path(
+        foreign,
+        session_id="librarian-session-id",
+    ) is False
+
+    assert ss._tailer.transcript_path == original
+    assert ss._bound_transcript_session_id == "repl-session-id"
+    assert ss._session_ready_event.is_set()
+    assert ss.stats["transcript_bind_rejections"] == 1
+    assert "TRANSCRIPT_BIND_REJECTED" in capsys.readouterr().err
+    await ss.disconnect()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("session_id", ["", "   "], ids=["empty", "blank"])
+async def test_transcript_bind_rejects_absent_session_id_without_consuming_window(
+    tmp_path,
+    session_id,
+) -> None:
+    """Fail closed on absence, while preserving the real pane's bind chance."""
+    ss, _ = _make_session()
+    await ss.connect()
+    original_path = ss._tailer.transcript_path
+    candidate = tmp_path / "missing-lineage.jsonl"
+    candidate.touch()
+
+    assert ss._tailer_first_bind_pending is True
+    assert ss.set_transcript_path(candidate, session_id=session_id) is False
+    assert ss._tailer.transcript_path == original_path
+    assert ss._tailer_first_bind_pending is True
+    assert not ss._session_ready_event.is_set()
+    assert ss.stats["transcript_bind_rejections"] == 1
+
+    assert ss.set_transcript_path(
+        candidate,
+        session_id="real-pane-session-id",
+    ) is True
+    assert ss._tailer.transcript_path == candidate
+    assert ss._bound_transcript_session_id == "real-pane-session-id"
+    await ss.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_transcript_bind_accepts_fresh_and_same_lineage_repeat(tmp_path) -> None:
+    """A fresh pane establishes lineage; later same-lineage posts stay valid."""
+    ss, _ = _make_session()
+    await ss.connect()
+    first = tmp_path / "fresh.jsonl"
+    repeated = tmp_path / "fresh-rotated.jsonl"
+    first.touch()
+    repeated.touch()
+
+    assert ss.set_transcript_path(first, session_id="fresh-session-id") is True
+    assert ss._tailer_first_bind_pending is False
+    assert ss.set_transcript_path(
+        repeated,
+        session_id="fresh-session-id",
+    ) is True
+    assert ss._tailer.transcript_path == repeated
+    assert ss.stats["transcript_bind_rejections"] == 0
+    await ss.disconnect()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "last_launch_used_continue",
+    [True, False],
+    ids=["daemon-resume", "context-restart"],
+)
+async def test_transcript_bind_window_accepts_new_lineage_on_daemon_relaunch(
+    tmp_path,
+    last_launch_used_continue,
+) -> None:
+    """Every daemon-initiated pane relaunch may establish its new session id."""
+    ss, _ = _make_session()
+    await ss.connect()
+    old_path = tmp_path / "old.jsonl"
+    new_path = tmp_path / "new.jsonl"
+    old_path.touch()
+    new_path.touch()
+    assert ss.set_transcript_path(old_path, session_id="old-session-id") is True
+
+    await ss._stop_tailer()
+    ss._last_launch_used_continue = last_launch_used_continue
+    await ss._start_tailer()
+
+    assert ss._tailer_first_bind_pending is True
+    assert ss.set_transcript_path(new_path, session_id="new-session-id") is True
+    assert ss._bound_transcript_session_id == "new-session-id"
+    assert ss._tailer.transcript_path == new_path
     await ss.disconnect()
 
 
@@ -2655,7 +2779,10 @@ async def test_set_transcript_path_safe_before_connect(tmp_path) -> None:
     """set_transcript_path before tailer exists is a silent no-op."""
     ss, _ = _make_session()
     # Don't connect — tailer is None.
-    ss.set_transcript_path(tmp_path / "x.jsonl")  # must not raise
+    ss.set_transcript_path(
+        tmp_path / "x.jsonl",
+        session_id="test-session-id",
+    )  # must not raise
     assert ss._tailer is None
 
 
@@ -2674,7 +2801,7 @@ async def test_end_to_end_tailer_to_response_callback(tmp_path) -> None:
     # Replace the tailer's path with our synthetic transcript.
     transcript = tmp_path / "synthetic.jsonl"
     transcript.write_text("")
-    ss.set_transcript_path(transcript)
+    ss.set_transcript_path(transcript, session_id="test-session-id")
 
     # Simulate _deliver_turn capturing routing meta.
     ss._inflight_meta = {
@@ -2818,7 +2945,7 @@ async def test_set_transcript_path_from_placeholder_seeks_to_start(
     assert transcript.stat().st_size > 0, "pre-condition: JSONL has content"
 
     # SessionStart hook fires AFTER the content was written.
-    ss.set_transcript_path(transcript)
+    ss.set_transcript_path(transcript, session_id="test-session-id")
     assert ss._tailer.transcript_path == transcript
     assert ss._tailer.offset == 0, (
         "placeholder→real transition must seek to byte 0 — otherwise "
@@ -2903,7 +3030,7 @@ async def test_set_transcript_path_fresh_launch_old_real_to_new_real_seeks_to_st
     new_real.write_text("\n".join(_json.dumps(e) for e in entries) + "\n")
 
     # SessionStart hook lands.
-    ss.set_transcript_path(new_real)
+    ss.set_transcript_path(new_real, session_id="test-session-id")
     assert ss._tailer.transcript_path == new_real
     assert ss._tailer.offset == 0, (
         "fresh-launch old-real→new-real transition must seek to byte 0 — "
@@ -2970,7 +3097,7 @@ async def test_set_transcript_path_continue_launch_old_real_to_new_real_preserve
     other.write_text("\n".join(_json.dumps(e) for e in historical_entries) + "\n")
     historical_size = other.stat().st_size
 
-    ss.set_transcript_path(other)
+    ss.set_transcript_path(other, session_id="test-session-id")
     assert ss._tailer.transcript_path == other
     assert ss._tailer.offset == historical_size, (
         "continue-launch path swap must seek to EOF — #496 reply-spam "
@@ -3377,7 +3504,7 @@ async def test_start_tailer_rearms_first_bind_state_on_retained_instance_respawn
     # instance so the next spawn can resume from its last path.
     fake_path = tmp_path / "retained-instance.jsonl"
     fake_path.write_text("")
-    ss.set_transcript_path(fake_path)
+    ss.set_transcript_path(fake_path, session_id="test-session-id")
     assert ss._tailer_first_bind_pending is False, (
         "explicit bind must consume the flag — sanity check before "
         "exercising the respawn re-arm"
@@ -3444,7 +3571,7 @@ async def test_first_bind_recovery_after_retained_instance_respawn_rebinds_and_s
     # the tailer (retaining the instance).
     first_real = tmp_path / "first.jsonl"
     first_real.write_text("")
-    ss.set_transcript_path(first_real)
+    ss.set_transcript_path(first_real, session_id="test-session-id")
     assert ss._tailer_first_bind_pending is False
     await ss._stop_tailer()
 
@@ -3526,7 +3653,7 @@ async def test_set_transcript_path_real_to_real_preserves_seek_to_eof(tmp_path) 
     # seeks to start, but file is empty so offset stays 0).
     first_real = tmp_path / "first.jsonl"
     first_real.write_text("")
-    ss.set_transcript_path(first_real)
+    ss.set_transcript_path(first_real, session_id="test-session-id")
     assert ss._tailer.transcript_path == first_real
 
     # Second real path — has prior turns already (simulating compact-resume
@@ -3568,7 +3695,7 @@ async def test_set_transcript_path_real_to_real_preserves_seek_to_eof(tmp_path) 
     second_real.write_text("\n".join(_json.dumps(e) for e in historical_entries) + "\n")
     historical_size = second_real.stat().st_size
 
-    ss.set_transcript_path(second_real)
+    ss.set_transcript_path(second_real, session_id="test-session-id")
     assert ss._tailer.transcript_path == second_real
     assert ss._tailer.offset == historical_size, (
         "real→real swap must seek to EOF (#496 reply-spam defense) — "
@@ -4640,7 +4767,7 @@ async def test_multi_prompt_routing_no_cross_user_leak(tmp_path) -> None:
     # Repoint tailer at our synthetic transcript.
     transcript = tmp_path / "session.jsonl"
     transcript.write_text("")
-    ss.set_transcript_path(transcript)
+    ss.set_transcript_path(transcript, session_id="test-session-id")
     # Use tight cadences so the test runs fast.
     ss._tailer._fallback_poll_sec = 0.02
     ss._tailer._active_poll_sec = 0.01
@@ -6271,7 +6398,7 @@ async def test_force_restart_resumes_tailer(tmp_path) -> None:
     # actually deliver a response?
     transcript = tmp_path / "post_restart.jsonl"
     transcript.write_text("")
-    ss.set_transcript_path(transcript)
+    ss.set_transcript_path(transcript, session_id="test-session-id")
 
     ss._inflight_meta = {
         "platform": "telegram",
@@ -6345,7 +6472,7 @@ async def test_stop_tailer_drains_buffer_for_same_path_resume(tmp_path) -> None:
     # Replace the tailer's path with a controlled synthetic transcript.
     transcript = tmp_path / "session_x.jsonl"
     transcript.write_text("")
-    ss.set_transcript_path(transcript)
+    ss.set_transcript_path(transcript, session_id="test-session-id")
 
     # Feed a partial turn — assistant entry without stop_hook_summary.
     # This simulates the in-flight state when a session is killed mid-turn.
@@ -8231,6 +8358,7 @@ class TestWakePromptReadinessGate:
         ss._session_ready_event = asyncio.Event()  # closed
         ss._tailer = MagicMock()
         ss._tailer.set_transcript_path = MagicMock()
+        ss._tailer_first_bind_pending = True
 
         wake_turn = _QueuedTurn(
             prompt="WAKE_BODY",
@@ -8247,7 +8375,10 @@ class TestWakePromptReadinessGate:
         tmux.paste_text.assert_not_called()
 
         # Simulate SessionStart hook arriving.
-        ss.set_transcript_path("/tmp/fake-transcript.jsonl")
+        ss.set_transcript_path(
+            "/tmp/fake-transcript.jsonl",
+            session_id="test-session-id",
+        )
         assert ss._session_ready_event.is_set()
 
         await asyncio.wait_for(deliver_task, timeout=2.0)
@@ -8374,9 +8505,13 @@ class TestWakePromptReadinessGate:
         ss._session_ready_event = asyncio.Event()  # closed
         ss._tailer = MagicMock()
         ss._tailer.set_transcript_path = MagicMock()
+        ss._tailer_first_bind_pending = True
 
         assert not ss._session_ready_event.is_set()
-        ss.set_transcript_path("/tmp/fake-transcript.jsonl")
+        ss.set_transcript_path(
+            "/tmp/fake-transcript.jsonl",
+            session_id="test-session-id",
+        )
         assert ss._session_ready_event.is_set(), (
             "set_transcript_path must open the readiness gate"
         )
@@ -8391,12 +8526,19 @@ class TestWakePromptReadinessGate:
         ss, _ = _make_session()
         ss._tailer = MagicMock()
         ss._tailer.set_transcript_path = MagicMock()
+        ss._tailer_first_bind_pending = True
 
-        ss.set_transcript_path("/tmp/fake-transcript.jsonl")
+        ss.set_transcript_path(
+            "/tmp/fake-transcript.jsonl",
+            session_id="test-session-id",
+        )
         first_event = ss._session_ready_event
         assert first_event.is_set()
 
-        ss.set_transcript_path("/tmp/fake-transcript.jsonl")
+        ss.set_transcript_path(
+            "/tmp/fake-transcript.jsonl",
+            session_id="test-session-id",
+        )
         assert ss._session_ready_event is first_event, (
             "repeat set_transcript_path must not reassign the event"
         )
@@ -8540,6 +8682,7 @@ class TestWakePromptGateMetrics:
         ss._session_ready_event = asyncio.Event()  # closed
         ss._tailer = MagicMock()
         ss._tailer.set_transcript_path = MagicMock()
+        ss._tailer_first_bind_pending = True
 
         wake_turn = _QueuedTurn(
             prompt="WAKE_BODY",
@@ -8550,7 +8693,10 @@ class TestWakePromptGateMetrics:
         deliver_task = asyncio.create_task(ss._deliver_turn(wake_turn))
         # Let the deliver task park in the gate await.
         await asyncio.sleep(0.15)
-        ss.set_transcript_path("/tmp/fake-transcript.jsonl")
+        ss.set_transcript_path(
+            "/tmp/fake-transcript.jsonl",
+            session_id="test-session-id",
+        )
         await asyncio.wait_for(deliver_task, timeout=2.0)
 
         analytics.log_activity.assert_called_once()

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -3220,6 +3220,76 @@ async def test_first_bind_recovery_fresh_with_prior_history_rebinds_and_seeks_to
 
 
 @pytest.mark.asyncio
+async def test_late_hook_establishes_lineage_after_internal_recovery(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    """#1148: an authoritative late hook can correct recovery's mtime guess."""
+    ss, _ = _make_session()
+    await ss.connect()
+    recovered_guess = tmp_path / "newest-sibling.jsonl"
+    authoritative = tmp_path / "real-pane.jsonl"
+    recovered_guess.touch()
+    authoritative.touch()
+    ss._last_launch_used_continue = False
+    monkeypatch.setattr(
+        ss,
+        "_discover_transcript_path",
+        lambda: recovered_guess,
+    )
+
+    ss._attempt_first_bind_recovery()
+
+    assert ss._tailer.transcript_path == recovered_guess
+    assert ss._tailer_first_bind_pending is False
+    assert ss._bound_transcript_session_id == ""
+    assert ss.set_transcript_path(
+        authoritative,
+        session_id="real-pane-session-id",
+    ) is True
+    assert ss._bound_transcript_session_id == "real-pane-session-id"
+    assert ss._tailer.transcript_path == authoritative
+    await ss.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_late_hook_lineage_rejects_foreign_followup(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    """Once the late hook establishes lineage, ordinary mismatch rules resume."""
+    ss, _ = _make_session()
+    await ss.connect()
+    recovered_guess = tmp_path / "newest-sibling.jsonl"
+    authoritative = tmp_path / "real-pane.jsonl"
+    foreign = tmp_path / "later-foreign.jsonl"
+    recovered_guess.touch()
+    authoritative.touch()
+    foreign.touch()
+    ss._last_launch_used_continue = False
+    monkeypatch.setattr(
+        ss,
+        "_discover_transcript_path",
+        lambda: recovered_guess,
+    )
+
+    ss._attempt_first_bind_recovery()
+    assert ss.set_transcript_path(
+        authoritative,
+        session_id="real-pane-session-id",
+    ) is True
+
+    assert ss.set_transcript_path(
+        foreign,
+        session_id="foreign-session-id",
+    ) is False
+    assert ss._bound_transcript_session_id == "real-pane-session-id"
+    assert ss._tailer.transcript_path == authoritative
+    assert ss.stats["transcript_bind_rejections"] == 1
+    await ss.disconnect()
+
+
+@pytest.mark.asyncio
 async def test_first_bind_recovery_continue_launch_noops_and_preserves_eof(
     tmp_path, monkeypatch,
 ) -> None:


### PR DESCRIPTION
## Summary

Fixes #1148.

A daemon-spawned headless utility session in the same working directory loaded the workspace `SessionStart` hook and stole the transcript bind. The tailer then watched the wrong transcript, leading to phantom wake redelivery.

This change adds two independent guard layers:

- The generated hook requires an environment marker injected into the managed tmux session. The daemon environment never carries that marker, so daemon-spawned headless sessions exit without posting a bind.
- `set_transcript_path` enforces session lineage through daemon-opened first-bind windows, rather than relying on bare session-ID equality. Legitimate daemon relaunches re-arm the window.

Rejected foreign, absent, or blank session IDs return HTTP 409, increment the `transcript_bind_rejections` counter, and emit the stable `TRANSCRIPT_BIND_REJECTED` log prefix.

The unbound-lineage exception allows a late authoritative hook to correct an internal recovery mtime guess and establish lineage. Once established, later foreign IDs are rejected.

## Residuals

Two documented residuals remain: unbound acceptance before the first bind, marker-covered for daemon-spawned sessions; and a foreign marker-bearing bind inside an open window.

Adversarial review found three perimeter gaps tracked as follow-ups:

1. The first-bind window can stay open indefinitely on lost-hook plus no-op recovery branches.
2. The environment marker is inherited by pane-descendant processes; a per-spawn nonce is a candidate hardening.
3. Operator-driven session rotation in an attached pane (`/clear`, `/resume`) is now rejected with no self-heal until the next daemon-driven respawn. This is loud through the rejection counter and log, and recoverable by restart.

Follow-up issue numbers will be added in a comment.

## Screenshots

N/A — daemon-internal transport hardening with no UI surface.

## Test evidence

- Final head: 446 tmux-module tests plus 190 registry/status tests passed (636 total).
- Red-first coverage: foreign, absent, and blank IDs; hook marker gate; spawn-environment pin; and late lineage establishment after recovery.
- Full suite: 5534 passed, 1 skipped; the known environment-only Camoufox live-scrape failure reproduced identically on the base revision.

🤖 Opened by Kuzya