### PR TITLE
fix(delivery): durable inbound-message idempotency ledger (#667)

### DIFF
--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -1618,6 +1618,25 @@ class AgentRegistry:
                 FOREIGN KEY (agent_name) REFERENCES agents(name) ON DELETE CASCADE
             );
 
+            -- Durable inbound-delivery idempotency (#667). Records that a
+            -- given external message was already delivered to an agent's
+            -- session, keyed by the stable platform identity
+            -- (platform+chat+message_id). A message re-entering the pipeline
+            -- after a bounce (poller re-fetch on an uncommitted offset, broker
+            -- re-route, escalation re-feed) carries the same durable id but not
+            -- the in-memory transport-accepted fence, so it would be re-pasted
+            -- as a duplicate. The entry point consults this table and drops the
+            -- re-delivery. Rows are written only after positive delivery
+            -- evidence, so a present key always means a genuine prior delivery;
+            -- the table is bounded by a retention prune.
+            CREATE TABLE IF NOT EXISTS delivered_turn (
+                agent_name    TEXT NOT NULL,
+                idem_key      TEXT NOT NULL,
+                source        TEXT NOT NULL DEFAULT '',
+                delivered_at  REAL NOT NULL,
+                PRIMARY KEY (agent_name, idem_key)
+            );
+
             CREATE TABLE IF NOT EXISTS approval_requests (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 agent_name TEXT NOT NULL,
@@ -1727,6 +1746,8 @@ class AgentRegistry:
                 ON recurring_schedule_stale_drops(agent_name, schedule_id);
             CREATE INDEX IF NOT EXISTS idx_pending_messages_agent_chat
                 ON pending_messages(agent_name, chat_id, delivered);
+            CREATE INDEX IF NOT EXISTS idx_delivered_turn_at
+                ON delivered_turn(delivered_at);
             CREATE INDEX IF NOT EXISTS idx_approval_requests_retry
                 ON approval_requests(gate_state, notification_state, next_retry_at);
             CREATE INDEX IF NOT EXISTS idx_group_chats_agent
@@ -7076,6 +7097,95 @@ except Exception as exc:
         )
         self._db.commit()
         return cursor.rowcount > 0
+
+    # ── Inbound-delivery idempotency (#667) ───────────────────────────
+    #
+    # A durable record that a given external message was already delivered to
+    # an agent's session, so a re-entry after a bounce is suppressed at the
+    # single inbound entry point. Key construction lives here so the mark and
+    # the check can never drift apart. \x1f (unit separator) can't occur in a
+    # platform/chat/message id, so the joined key is unambiguous.
+
+    @staticmethod
+    def _delivery_idem_key(platform: str, chat_id: str, message_id: str) -> str:
+        return f"{platform}\x1f{chat_id}\x1f{message_id}"
+
+    def mark_turn_delivered(
+        self,
+        agent_name: str,
+        platform: str,
+        chat_id: str,
+        message_id: str,
+        *,
+        source: str = "",
+    ) -> bool:
+        """Record an external message as delivered to ``agent_name``.
+
+        Returns ``True`` if this call inserted a new row, ``False`` if the key
+        was already present (idempotent) or the message has no stable id.
+        Call only after positive delivery evidence — a present key must always
+        mean a genuine prior delivery, never merely an attempt.
+        """
+        if not agent_name or not message_id:
+            return False
+        key = self._delivery_idem_key(platform, chat_id, message_id)
+        # The mark runs on the transcript-tailer thread while the check runs on
+        # the send path; serialize both through the same lock every other
+        # writer on this shared connection uses, so an interleaved commit can't
+        # flush a half-formed statement from another thread.
+        with self._rmw_lock:
+            cursor = self._db.execute(
+                "INSERT INTO delivered_turn (agent_name, idem_key, source, delivered_at) "
+                "VALUES (?, ?, ?, ?) "
+                "ON CONFLICT(agent_name, idem_key) DO NOTHING",
+                (agent_name, key, source, time.time()),
+            )
+            self._db.commit()
+            return cursor.rowcount > 0
+
+    def is_turn_delivered(
+        self,
+        agent_name: str,
+        platform: str,
+        chat_id: str,
+        message_id: str,
+    ) -> bool:
+        """True if this external message was already delivered in any prior life.
+
+        Messages without a stable platform id (internal, wake, scheduler, or
+        approval-drain turns) are never in the ledger and always return False.
+        """
+        if not agent_name or not message_id:
+            return False
+        key = self._delivery_idem_key(platform, chat_id, message_id)
+        with self._rmw_lock:
+            row = self._db.execute(
+                "SELECT 1 FROM delivered_turn WHERE agent_name=? AND idem_key=? LIMIT 1",
+                (agent_name, key),
+            ).fetchone()
+        return row is not None
+
+    def prune_delivered_turns(
+        self,
+        *,
+        retention_sec: float = 14 * 24 * 60 * 60,
+        now: float | None = None,
+    ) -> int:
+        """Delete delivered-turn rows older than the retention window.
+
+        A delivered key only needs to outlive the windows in which a stale
+        turn could still re-enter (restart drain, watchdog, boot-drain,
+        poller offset lag) — minutes — so a multi-day floor is generous while
+        bounding table growth. Returns the number of rows removed.
+        """
+        cutoff = (time.time() if now is None else now) - retention_sec
+        with self._rmw_lock:
+            cursor = self._db.execute(
+                "DELETE FROM delivered_turn WHERE delivered_at < ?",
+                (cutoff,),
+            )
+            self._db.commit()
+            return cursor.rowcount
 
     def delete_pending_messages(self, agent_name: str, chat_id: str = "") -> int:
         """Delete pending messages. If chat_id given, only for that chat."""

--- a/src/pinky_daemon/scheduler.py
+++ b/src/pinky_daemon/scheduler.py
@@ -701,6 +701,21 @@ class AgentScheduler:
                     self._outbox_reaper_payload_trim_after_sec
                 ),
             )
+            # #667: bound the durable inbound-idempotency table on the same
+            # daily pass. Guarded independently so retention housekeeping can
+            # never fail the wake-reaper maintenance it rides along with.
+            try:
+                pruned = self._registry.prune_delivered_turns(now=now)
+                if pruned:
+                    _log(
+                        f"scheduler: pruned {pruned} expired delivery-ledger "
+                        "row(s)"
+                    )
+            except Exception as exc:
+                _log(
+                    "scheduler: delivery-ledger prune failed: "
+                    f"{type(exc).__name__}: {exc}"
+                )
         except Exception as exc:
             self._last_outbox_reaper_failed_at = now
             _log(

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -4755,6 +4755,34 @@ class TmuxSession(TransportReplacementMixin):
             )
             return False
 
+        # #667: durable inbound idempotency. A message already delivered to
+        # this agent in a prior life re-enters here carrying the same durable
+        # platform message_id but not the in-memory transport-accepted fence
+        # (which a restart wipes) — the realistic source is a platform poller
+        # re-fetching the same update after a bounce on an uncommitted offset.
+        # It would be re-pasted as a duplicate the user sees (and wasted work
+        # re-running the turn). Suppress it before any side effect
+        # (conversation log, stats, paste). Only external turns with a stable
+        # platform message_id are guarded; internal, wake, scheduler, and
+        # approval-drain turns carry no message_id and pass through — their
+        # re-delivery stays at-least-once, as the broker already documents.
+        # Return True — the message genuinely WAS delivered, so the caller
+        # commits its offset instead of retrying — never False, which the
+        # approval-drain path treats as a hard handoff failure.
+        if (
+            message_id
+            and not scheduler_serialized
+            and self._registry is not None
+            and self._registry.is_turn_delivered(
+                self.agent_name, platform, chat_id, message_id
+            )
+        ):
+            _log(
+                f"tmux[{self.agent_name}]: DROPPING already-delivered inbound "
+                f"message (idempotent #667; chat={chat_id}, msg={message_id})"
+            )
+            return True
+
         self.last_active = time.time()
         self._stats["messages_sent"] += 1
 
@@ -9060,6 +9088,34 @@ class TmuxSession(TransportReplacementMixin):
                     "positive evidence; suppressing unsafe replay"
                 )
         turn.transport_accepted = True
+        # #667: mirror the just-confirmed acceptance into the durable delivery
+        # ledger so a later re-entry of the same external message (across a
+        # restart that wipes this in-memory fence) is suppressed at the inbound
+        # entry point. Written strictly AFTER positive delivery evidence, so a
+        # recorded key always means a genuine prior delivery — the guard can
+        # only ever drop a true duplicate, never an undelivered message.
+        # Internal/wake/scheduler turns carry no message_id and are skipped.
+        if (
+            turn.message_id
+            and not turn.scheduler_serialized
+            and self._registry is not None
+        ):
+            try:
+                self._registry.mark_turn_delivered(
+                    self.agent_name,
+                    turn.platform,
+                    turn.chat_id,
+                    turn.message_id,
+                    source=turn.platform,
+                )
+            except Exception as exc:
+                # Durability is a safety net over the in-memory fence, never a
+                # correctness precondition for this turn — log loudly and let
+                # acceptance proceed rather than fail an accepted delivery.
+                _log(
+                    f"tmux[{self.agent_name}]: delivery-ledger mark failed "
+                    f"({type(exc).__name__}: {exc})"
+                )
         for receipt in (turn.scheduler_delivery, turn.submission_receipt):
             if receipt is not None and not receipt.done():
                 receipt.set_result(True)

--- a/tests/test_667_delivery_idempotency.py
+++ b/tests/test_667_delivery_idempotency.py
@@ -1,0 +1,219 @@
+"""#667 — durable inbound-delivery idempotency.
+
+A message delivered to an agent's session exactly once must never be
+re-delivered after a bounce. The in-memory ``transport_accepted`` fence
+guarantees that within one process life, but a re-entry through the single
+inbound entry point (``send``/``_queue_external_turn``) — a poller re-fetch on
+an uncommitted offset, a broker re-route, an escalation re-feed — carries the
+same durable platform id but not the in-memory fence, so without a durable
+ledger it is re-pasted as a duplicate. These tests pin the durable guard.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from pinky_daemon.agent_registry import AgentRegistry
+from pinky_daemon.streaming_session import StreamingSessionConfig
+from pinky_daemon.tmux_session import TmuxSession, _QueuedTurn, _TmuxControl
+from pinky_daemon.transport_state import SessionState
+
+
+def _session(registry: AgentRegistry) -> TmuxSession:
+    control = MagicMock(spec=_TmuxControl)
+    control.session_name = "pinky-review"
+    control.kill_session = AsyncMock()
+    cfg = StreamingSessionConfig(agent_name="review", working_dir="/tmp/667-review")
+    session = TmuxSession(cfg, tmux_control=control, registry=registry)
+    session._state_machine._state = SessionState.CONNECTED
+    return session
+
+
+def _queue_depth(session: TmuxSession) -> int:
+    return len(session._message_queue._queue)  # type: ignore[attr-defined]
+
+
+# ── Registry primitive ────────────────────────────────────────────────
+
+
+def test_registry_mark_and_check_roundtrip(tmp_path):
+    reg = AgentRegistry(db_path=str(tmp_path / "agents.db"))
+    assert reg.is_turn_delivered("review", "telegram", "123", "42") is False
+    assert reg.mark_turn_delivered("review", "telegram", "123", "42") is True
+    assert reg.is_turn_delivered("review", "telegram", "123", "42") is True
+    # Idempotent second mark is a no-op.
+    assert reg.mark_turn_delivered("review", "telegram", "123", "42") is False
+
+
+def test_registry_empty_message_id_is_never_recorded(tmp_path):
+    reg = AgentRegistry(db_path=str(tmp_path / "agents.db"))
+    assert reg.mark_turn_delivered("review", "telegram", "123", "") is False
+    assert reg.is_turn_delivered("review", "telegram", "123", "") is False
+
+
+def test_registry_scopes_by_agent_and_identity(tmp_path):
+    reg = AgentRegistry(db_path=str(tmp_path / "agents.db"))
+    reg.mark_turn_delivered("review", "telegram", "123", "42")
+    # Different agent, different chat, different message id are all distinct.
+    assert reg.is_turn_delivered("other", "telegram", "123", "42") is False
+    assert reg.is_turn_delivered("review", "telegram", "999", "42") is False
+    assert reg.is_turn_delivered("review", "telegram", "123", "43") is False
+
+
+def test_registry_prune_respects_retention(tmp_path):
+    reg = AgentRegistry(db_path=str(tmp_path / "agents.db"))
+    reg.mark_turn_delivered("review", "telegram", "123", "42")
+    # Nothing old enough yet.
+    assert reg.prune_delivered_turns(retention_sec=3600) == 0
+    assert reg.is_turn_delivered("review", "telegram", "123", "42") is True
+    # A future 'now' pushes the row past retention.
+    import time as _t
+
+    removed = reg.prune_delivered_turns(retention_sec=0, now=_t.time() + 1)
+    assert removed == 1
+    assert reg.is_turn_delivered("review", "telegram", "123", "42") is False
+
+
+# ── Session entry-point behavior ──────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_duplicate_external_message_dropped_after_delivery(tmp_path):
+    """The core guard: a re-delivered external message is not re-enqueued."""
+    reg = AgentRegistry(db_path=str(tmp_path / "agents.db"))
+    session = _session(reg)
+    msg = dict(platform="telegram", chat_id="123", message_id="42")
+
+    # First delivery enqueues one turn.
+    assert await session._queue_external_turn("hello", **msg) is True
+    assert _queue_depth(session) == 1
+    turn = session._message_queue._queue[-1]  # type: ignore[attr-defined]
+
+    # Positive delivery evidence lands: the turn is durably recorded.
+    session._mark_transport_accepted(turn)
+    assert reg.is_turn_delivered("review", "telegram", "123", "42") is True
+
+    # A bounce re-feeds the SAME message (same durable id). It must not
+    # re-enqueue, and must report idempotent success (it WAS delivered) so the
+    # caller commits its offset instead of retrying.
+    depth_before = _queue_depth(session)
+    stats_before = session._stats["messages_sent"]
+    result = await session._queue_external_turn("hello", **msg)
+    assert result is True
+    assert _queue_depth(session) == depth_before
+    # Suppression happens before any side effect: the stats counter must not
+    # advance for a dropped duplicate.
+    assert session._stats["messages_sent"] == stats_before
+
+
+def test_scheduler_turn_with_message_id_is_not_recorded(tmp_path):
+    """A scheduler-serialized turn is never written to the ledger, even if it
+    somehow carries a message_id — the mark site guards on scheduler_serialized."""
+    reg = AgentRegistry(db_path=str(tmp_path / "agents.db"))
+    session = _session(reg)
+    turn = _QueuedTurn(
+        prompt="wake",
+        platform="telegram",
+        chat_id="123",
+        message_id="900",
+        scheduler_serialized=True,
+    )
+    session._mark_transport_accepted(turn)
+    assert turn.transport_accepted is True
+    assert reg.is_turn_delivered("review", "telegram", "123", "900") is False
+
+
+def test_mark_failure_does_not_block_acceptance(tmp_path):
+    """A ledger write error must never fail an otherwise-accepted delivery."""
+
+    class _BoomRegistry:
+        def mark_turn_delivered(self, *a, **k):
+            raise RuntimeError("ledger down")
+
+    reg = AgentRegistry(db_path=str(tmp_path / "agents.db"))
+    session = _session(reg)
+    session._registry = _BoomRegistry()  # type: ignore[assignment]
+    turn = _QueuedTurn(
+        prompt="hi", platform="telegram", chat_id="123", message_id="42"
+    )
+    assert session._mark_transport_accepted(turn) is True
+    assert turn.transport_accepted is True
+
+
+@pytest.mark.asyncio
+async def test_distinct_message_is_still_delivered(tmp_path):
+    """A different message id must never be suppressed by a prior delivery."""
+    reg = AgentRegistry(db_path=str(tmp_path / "agents.db"))
+    session = _session(reg)
+    reg.mark_turn_delivered("review", "telegram", "123", "42")
+
+    assert (
+        await session._queue_external_turn(
+            "second", platform="telegram", chat_id="123", message_id="43"
+        )
+        is True
+    )
+    assert _queue_depth(session) == 1
+
+
+@pytest.mark.asyncio
+async def test_same_text_distinct_message_ids_both_delivered(tmp_path):
+    """Two genuine sends of identical text must both land.
+
+    Dedup keys on the platform message id, never on content — a user who
+    sends "yes" twice in succession produces two distinct platform message
+    ids, so both are delivered. Only the SAME message id arriving twice (a
+    real redelivery after a bounce) is suppressed.
+    """
+    reg = AgentRegistry(db_path=str(tmp_path / "agents.db"))
+    session = _session(reg)
+
+    assert (
+        await session._queue_external_turn(
+            "yes", platform="telegram", chat_id="123", message_id="100"
+        )
+        is True
+    )
+    first = session._message_queue._queue[-1]  # type: ignore[attr-defined]
+    session._mark_transport_accepted(first)
+
+    # Same text, next message — a different platform message id.
+    assert (
+        await session._queue_external_turn(
+            "yes", platform="telegram", chat_id="123", message_id="101"
+        )
+        is True
+    )
+    assert _queue_depth(session) == 2
+
+
+@pytest.mark.asyncio
+async def test_empty_message_id_is_never_suppressed(tmp_path):
+    """Internal/wake/scheduler/approval-drain turns have no id and always pass."""
+    reg = AgentRegistry(db_path=str(tmp_path / "agents.db"))
+    session = _session(reg)
+
+    # Two internal-style sends with empty message_id both enqueue.
+    assert await session._queue_external_turn("wake-a", platform="", chat_id="") is True
+    assert await session._queue_external_turn("wake-b", platform="", chat_id="") is True
+    assert _queue_depth(session) == 2
+
+
+@pytest.mark.asyncio
+async def test_no_registry_falls_back_to_legacy_behavior(tmp_path):
+    """With no registry wired, the entry point must not raise — just enqueue."""
+    cfg = StreamingSessionConfig(agent_name="review", working_dir="/tmp/667-review")
+    control = MagicMock(spec=_TmuxControl)
+    control.kill_session = AsyncMock()
+    session = TmuxSession(cfg, tmux_control=control)  # registry=None
+    session._state_machine._state = SessionState.CONNECTED
+
+    assert (
+        await session._queue_external_turn(
+            "hello", platform="telegram", chat_id="123", message_id="42"
+        )
+        is True
+    )
+    assert _queue_depth(session) == 1


### PR DESCRIPTION
## Summary

Closes #667. A message delivered to an agent's session exactly once could be re-delivered after a session bounce, producing a duplicate inbound message (and duplicated reprocessing). The re-arrival re-enters through the single inbound entry point carrying the same durable platform message id but **not** the in-memory `transport_accepted` fence, which a restart wipes — the realistic source is a platform poller re-fetching the same update on an uncommitted offset after a bounce.

## Fix

A durable per-agent idempotency ledger (`delivered_turn` in `agents.db`, owned by `AgentRegistry`):

- **Write** at `_mark_transport_accepted` (the single delivery-confirm funnel) — record the message keyed on `platform + chat_id + message_id`, the moment delivery is positively confirmed.
- **Check** at `_queue_external_turn` (the single inbound entry point, right after the CONNECTED guard) — if the message was already delivered in a prior life, suppress it and return idempotent success, so the caller commits its offset instead of retrying.
- **Prune** — a daily retention pass (14d) rides the existing outbox-reaper maintenance, bounding table growth; guarded so it can never fail that pass.

### Safety

Marking happens strictly **after** positive delivery evidence, so a recorded key always means a genuine prior delivery — the guard can only ever suppress a true duplicate, never drop an undelivered message. The key is the durable platform message id, **not content**: two distinct messages with identical text carry different message ids and are both delivered; only the *same* message id arriving twice is suppressed. Ledger writes/reads take the registry read-modify-write lock since the mark runs on the transcript-tailer thread over the shared connection.

### Scope

Guarded turns are external messages with a stable platform message id. Internal, wake, scheduler, and approval-drain turns carry no message id and pass through unchanged — their re-delivery stays at-least-once, exactly as the broker already documents. The distinct case where the delivery evidence itself is lost so acceptance is never confirmed is the transcript-reliability line addressed by recent related work, and is intentionally out of scope here (tightening it there risks the opposite failure — dropping real messages).

## Tests

`tests/test_667_delivery_idempotency.py` — registry primitives (mark/check/scope/prune), entry-point suppression of a re-delivered message, no over-suppression of distinct ids, identical-text/distinct-id both delivered, side-effect suppression on a dropped duplicate, scheduler-serialized skip at the mark site, mark-failure tolerance, empty-id passthrough, and no-registry fallback. Full `tmux_session`, `broker`, `agent_registry`, and `scheduler` suites pass locally with no regressions.

## Screenshot

No UI surface — this is a daemon delivery-path change. Behavior is covered by the tests above.

🤖 Opened by barsik
