### PR TITLE
Grace inflight transcript-proof recheck at the idle boundary (#1156)

### DIFF
--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -2103,6 +2103,10 @@ class TmuxSession(TransportReplacementMixin):
         # genuinely new head (deque advanced) auto-starts a fresh ceiling budget
         # without having to touch the out-of-loop head-start sites.
         self._inflight_pane_ext_anchor: tuple[object, float] | None = None
+        # (#1156) One watchdog-tick grace for transcript proof that lags the
+        # busy→idle boundary. Keyed by the deque head's identity so advancing
+        # to a genuinely new turn grants that turn its own bounded recheck.
+        self._inflight_idle_grace_head: object | None = None
         # #984 Defect 2 — continuous frozen-live-status observation.  One
         # bounded tuple per TmuxSession: (last_updated value, first-seen wall
         # clock, consecutive observations).  Any changed value starts a new
@@ -8216,6 +8220,13 @@ class TmuxSession(TransportReplacementMixin):
                 # (capture-pane + sample gap), during which a stop hook can pop or
                 # advance the head out from under us.
                 head_meta = self._inflight_metas[0]
+                if verdict != "idle":
+                    # Grace is per idle-entry, not per turn lifetime. If the
+                    # pane becomes active between samples, the next idle streak
+                    # must earn a fresh first-pass recheck. Two consecutive idle
+                    # samples still consume the latch and reconcile, so
+                    # busy/idle oscillation cannot create an unbounded deferral.
+                    self._inflight_idle_grace_head = None
                 restart_reason: str | None = None
                 if verdict == "growing":
                     # #118: head aged out BUT the transcript is still being
@@ -8249,6 +8260,35 @@ class TmuxSession(TransportReplacementMixin):
                     consumption_verdicts = self._phantom_consumption_verdicts(
                         candidates
                     )
+                    if (
+                        any(consumed is False for consumed in consumption_verdicts)
+                        and self._inflight_idle_grace_head is not head_meta
+                    ):
+                        # #1156: the REPL can consume pane input at the end of a
+                        # long turn just before its transcript row becomes
+                        # visible. Preserve every owner/bookkeeping field and
+                        # re-run the authoritative transcript probe next tick.
+                        # The aged head clock is intentionally NOT reset, making
+                        # this exactly one watchdog-cycle of grace.
+                        self._inflight_idle_grace_head = head_meta
+                        _log(
+                            f"tmux[{self.agent_name}]: inflight head aged "
+                            f"{age:.1f}s and REPL is idle but transcript proof "
+                            f"is absent — deferring reconciliation for one "
+                            f"watchdog tick (#1156; deque depth={depth})"
+                        )
+                        log_watchdog_decision(
+                            watchdog="inflight",
+                            agent=self.agent_name,
+                            decision="skip",
+                            reason="phantom_consumption_grace",
+                            state=self.state.value,
+                            progress_stale_s=age,
+                            inflight_turns=depth,
+                            inflight_active=False,
+                        )
+                        continue
+                    self._inflight_idle_grace_head = None
                     self._inflight_metas.clear()
                     self._head_started_at = None
                     self._inflight_pane_ext_anchor = None

--- a/tests/test_tmux_session.py
+++ b/tests/test_tmux_session.py
@@ -5863,6 +5863,74 @@ async def test_idle_phantom_verified_consumed_resolves_scheduler_true(
 
 
 @pytest.mark.asyncio
+async def test_idle_phantom_delayed_proof_rechecks_before_requeue(
+    monkeypatch, tmp_path,
+) -> None:
+    """#1156: proof landing one watchdog tick late suppresses duplicate replay."""
+    monkeypatch.setattr(tmux_session, "_TURN_DONE_TIMEOUT_SEC", 0.01)
+    monkeypatch.setattr(tmux_session, "_WATCHDOG_TICK_SEC", 0.01)
+    decisions = MagicMock()
+    monkeypatch.setattr(tmux_session, "log_watchdog_decision", decisions)
+
+    ss, _ = _make_session(state=SessionState.CONNECTED)
+    ss._config.live_status_fn = lambda: {
+        "status": "idle",
+        "last_updated": _time.time(),
+    }
+    ss._transcript_recently_grew = lambda *_args: False
+    transcript = tmp_path / "transcript.jsonl"
+    transcript.write_text('{"type":"system"}\n')
+    ss._tailer = MagicMock()
+    ss._tailer.transcript_path = transcript
+
+    completion = asyncio.Event()
+    delivery = asyncio.get_running_loop().create_future()
+    durable_accept = MagicMock(return_value=True)
+    prompt = "[agent | sender | internal | 2026-08-25T17:09:36-07:00]\nbody"
+    entry = _seed_inflight(
+        ss,
+        prompt=prompt,
+        completion_event=completion,
+        transport_accepted=False,
+    )
+    _bind_transcript_ticket(entry, transcript)
+    entry.turn.scheduler_delivery = delivery
+    entry.turn.scheduler_accept = durable_accept
+    backlog = _QueuedTurn(prompt="later backlog")
+    ss._message_queue.put_nowait(backlog)
+
+    original_probe = ss._phantom_consumption_verdicts
+    probe_results: list[list[bool | None]] = []
+
+    def probe_with_delayed_proof(candidates: list[_InflightMeta]) -> list[bool | None]:
+        verdicts = original_probe(candidates)
+        probe_results.append(verdicts)
+        if len(probe_results) == 1:
+            with transcript.open("a", encoding="utf-8") as handle:
+                handle.write(
+                    _json.dumps({"type": "user", "message": {"content": prompt}})
+                    + "\n"
+                )
+        return verdicts
+
+    monkeypatch.setattr(ss, "_phantom_consumption_verdicts", probe_with_delayed_proof)
+    ss._head_started_at = _time.time() - 1.0
+
+    await _run_idle_reconcile(ss)
+
+    assert probe_results == [[False], [True]]
+    assert completion.is_set()
+    assert delivery.result() is True
+    durable_accept.assert_called_once_with()
+    assert entry.turn.replay_count == 0
+    assert ss._message_queue.get_nowait() is backlog
+    assert ss._message_queue.empty()
+    reasons = [call.kwargs.get("reason") for call in decisions.call_args_list]
+    assert reasons.count("phantom_consumption_grace") == 1
+    assert "phantom_requeued_unconsumed" not in reasons
+
+
+@pytest.mark.asyncio
 async def test_idle_phantom_unconsumed_requeues_at_front(monkeypatch, tmp_path) -> None:
     """#1127: a header absent from the transcript is replayed, not completed."""
     monkeypatch.setattr(tmux_session, "_TURN_DONE_TIMEOUT_SEC", 0.01)
@@ -5890,6 +5958,8 @@ async def test_idle_phantom_unconsumed_requeues_at_front(monkeypatch, tmp_path) 
         transport_accepted=False,
     )
     _bind_transcript_ticket(original, transcript)
+    consumption_probe = MagicMock(wraps=ss._phantom_consumption_verdicts)
+    monkeypatch.setattr(ss, "_phantom_consumption_verdicts", consumption_probe)
     backlog = _QueuedTurn(prompt="later backlog")
     ss._message_queue.put_nowait(backlog)
     ss._head_started_at = _time.time() - 1.0
@@ -5897,13 +5967,13 @@ async def test_idle_phantom_unconsumed_requeues_at_front(monkeypatch, tmp_path) 
     await _run_idle_reconcile(ss)
 
     assert not completion.is_set()
+    assert consumption_probe.call_count == 2
     assert original.turn.replay_count == 1
     assert ss._message_queue.get_nowait() is original.turn
     assert ss._message_queue.get_nowait() is backlog
-    assert any(
-        call.kwargs.get("reason") == "phantom_requeued_unconsumed"
-        for call in decisions.call_args_list
-    )
+    reasons = [call.kwargs.get("reason") for call in decisions.call_args_list]
+    assert reasons.count("phantom_consumption_grace") == 1
+    assert reasons.count("phantom_requeued_unconsumed") == 1
 
 
 @pytest.mark.asyncio
@@ -5939,21 +6009,23 @@ async def test_idle_phantom_replay_cap_drops_loudly(
     )
     _bind_transcript_ticket(entry, transcript)
     turn = entry.turn
+    consumption_probe = MagicMock(wraps=ss._phantom_consumption_verdicts)
+    monkeypatch.setattr(ss, "_phantom_consumption_verdicts", consumption_probe)
     turn.submission_receipt = submission
     turn.replay_count = 1
     ss._head_started_at = _time.time() - 1.0
 
     await _run_idle_reconcile(ss)
 
+    assert consumption_probe.call_count == 2
     assert turn.replay_count == 2
     assert completion.is_set()
     assert submission.result() is False
     assert ss._message_queue.empty()
     assert header in capsys.readouterr().err
-    assert any(
-        call.kwargs.get("reason") == "phantom_replay_cap_dropped"
-        for call in decisions.call_args_list
-    )
+    reasons = [call.kwargs.get("reason") for call in decisions.call_args_list]
+    assert reasons.count("phantom_consumption_grace") == 1
+    assert reasons.count("phantom_replay_cap_dropped") == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Adds a one-watchdog-tick, per-head grace when transcript proof lags the REPL busy-to-idle boundary.
- Re-runs the authoritative transcript-consumption probe on the next tick without mutating the inflight deque, replay count, receipts, or queue during the grace pass.
- Emits the audited watchdog skip reason phantom_consumption_grace.
- Leaves the existing unconsumed replay, replay-cap drop, scheduler-terminal fencing, and pane-consumption bookkeeping branches untouched.

A delayed transcript row now proves the turn was consumed before any replay occurs. If proof remains absent, the existing recovery still requeues the genuinely unconsumed turn exactly once at the front on the next watchdog tick.

## Red to green chain

- 75b2c35 is the tests-only RED commit. The three focused cases failed on the prior production behavior because it reconciled after a single proof-negative sample.
- 7577da0 is the GREEN fix commit. The same cases pass with the bounded recheck.

## Validation

- Required focused cases: 3 passed.
- Wider phantom/inflight-watchdog slice: 19 passed.
- Full tests/test_tmux_session.py: 448 passed.
- Ruff: all checks passed.
- Murzik adversarial review: GO, zero must-fix.

Closes #1156.

🤖 Opened by Kuzya
