### PR TITLE
Centralize SQLite store lifecycle authority and ordered shutdown

### DIFF
--- a/src/pinky_daemon/activity_store.py
+++ b/src/pinky_daemon/activity_store.py
@@ -13,7 +13,12 @@ import threading
 import time
 from pathlib import Path
 
-from pinky_daemon.store_catalog import StoreCatalog
+from pinky_daemon.store_catalog import (
+    StoreCatalog,
+    apply_store_connection_policy,
+    open_store_connection,
+    store_connection_policy,
+)
 
 
 class ActivityStore:
@@ -36,11 +41,19 @@ class ActivityStore:
         """Return the calling thread's connection, creating it on first use."""
         connection = getattr(self._thread_local, "connection", None)
         if connection is None:
-            connection = sqlite3.connect(self._db_path)
+            connection = open_store_connection(
+                self._catalog,
+                "activity",
+                self._db_path,
+                owner=type(self).__name__,
+            )
             journal_mode = str(
                 connection.execute("PRAGMA journal_mode=WAL").fetchone()[0]
             ).lower()
-            connection.execute("PRAGMA busy_timeout=30000")
+            apply_store_connection_policy(
+                connection,
+                store_connection_policy(self._catalog, "activity"),
+            )
             if self._catalog is not None:
                 self._catalog.register(
                     "activity",

--- a/src/pinky_daemon/agent_comms.py
+++ b/src/pinky_daemon/agent_comms.py
@@ -23,7 +23,12 @@ import time
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from pinky_daemon.store_catalog import StoreCatalog
+from pinky_daemon.store_catalog import (
+    StoreCatalog,
+    apply_store_connection_policy,
+    open_store_connection,
+    store_connection_policy,
+)
 
 
 @dataclass
@@ -89,12 +94,20 @@ class AgentComms:
         """Return the calling thread's connection, creating it on first use."""
         connection = getattr(self._thread_local, "connection", None)
         if connection is None:
-            connection = sqlite3.connect(self._db_path)
+            connection = open_store_connection(
+                self._catalog,
+                "agent_comms",
+                self._db_path,
+                owner="AgentComms",
+            )
             connection.row_factory = sqlite3.Row
             journal_mode = str(
                 connection.execute("PRAGMA journal_mode=WAL").fetchone()[0]
             ).lower()
-            connection.execute("PRAGMA busy_timeout=30000")
+            apply_store_connection_policy(
+                connection,
+                store_connection_policy(self._catalog, "agent_comms"),
+            )
             if self._catalog is not None:
                 self._catalog.register(
                     "agent_comms",

--- a/src/pinky_daemon/agent_registry.py
+++ b/src/pinky_daemon/agent_registry.py
@@ -43,7 +43,14 @@ from pinky_daemon.agent_signing_key_store import (
 )
 from pinky_daemon.cron_utils import _field_matches
 from pinky_daemon.effort import is_ultracode
-from pinky_daemon.store_catalog import StoreCatalog
+from pinky_daemon.store_catalog import (
+    StoreCatalog,
+    StoreConnectionPolicy,
+    apply_store_connection_policy,
+    default_store_connection_policy,
+    open_store_connection,
+    store_connection_policy,
+)
 
 # Agent names appear in filesystem paths (data/agents/{name}/, hook scripts
 # under .claude/, settings.json, .mcp.json) and database queries. Restrict
@@ -1367,7 +1374,11 @@ class AgentDbConfigError(RuntimeError):
 
 
 def _configure_agents_db_connection(
-    conn: sqlite3.Connection, *, retries: int = 6, busy_ms: int = 5000
+    conn: sqlite3.Connection,
+    *,
+    retries: int | None = None,
+    busy_ms: int | None = None,
+    policy: StoreConnectionPolicy | None = None,
 ) -> str:
     """Put the agents-DB connection into rollback (TRUNCATE) journal mode.
 
@@ -1386,9 +1397,19 @@ def _configure_agents_db_connection(
     bounded retries, raises :class:`AgentDbConfigError` rather than silently
     running on WAL. Returns the effective journal mode (``"truncate"``).
     """
-    conn.execute(f"PRAGMA busy_timeout={int(busy_ms)}")
+    declared_policy = policy or default_store_connection_policy("agents")
+    effective_busy_ms = declared_policy.busy_timeout_ms if busy_ms is None else busy_ms
+    effective_retries = declared_policy.rollback_retries if retries is None else retries
+    apply_store_connection_policy(
+        conn,
+        StoreConnectionPolicy(
+            busy_timeout_ms=effective_busy_ms,
+            rollback_retries=declared_policy.rollback_retries,
+            rollback_retry_delay_seconds=declared_policy.rollback_retry_delay_seconds,
+        ),
+    )
     last: str | None = None
-    for attempt in range(retries):
+    for attempt in range(effective_retries):
         # If still on WAL, drain it first so no hot WAL content is stranded
         # before the wal-index is dropped. Busy here is non-fatal — the mode
         # switch below retries.
@@ -1405,10 +1426,10 @@ def _configure_agents_db_connection(
                 return last
         except sqlite3.OperationalError as exc:
             last = f"error:{exc}"
-        time.sleep(0.2 * (attempt + 1))
+        time.sleep(declared_policy.rollback_retry_delay_seconds * (attempt + 1))
     raise AgentDbConfigError(
         f"conversations_agents.db refused to leave WAL: journal_mode={last!r} "
-        f"after {retries} attempts — refusing to run on the WAL -shm SIGBUS "
+        f"after {effective_retries} attempts — refusing to run on the WAL -shm SIGBUS "
         f"surface (#797/#220)."
     )
 
@@ -1428,12 +1449,19 @@ class AgentRegistry:
         # stdio MCP subprocesses an explicit DB location for request-time
         # signing-key lookup (#641) rather than relying on their cwd.
         self._db_path = str(Path(db_path).resolve())
+        self._catalog = catalog
         self._buzz_device_key_path = str(
             Path(buzz_device_key_path).resolve()
             if buzz_device_key_path
             else Path(self._db_path).parent / "identity" / ".device_key"
         )
-        self._db = sqlite3.connect(db_path, check_same_thread=False)
+        self._db = open_store_connection(
+            catalog,
+            "agents",
+            db_path,
+            owner=FLEET_SIGNING_KEY_OWNER,
+            check_same_thread=False,
+        )
         # #797/#220: the agents DB runs in ROLLBACK (TRUNCATE) journal mode, NOT
         # WAL. The WAL wal-index (-shm) is always mmap'd; under the long-lived
         # registry connection + per-request RO signing-key resolver churn, that
@@ -1441,7 +1469,10 @@ class AgentRegistry:
         # (si_addr confirmed inside conversations_agents.db-shm). Rollback mode
         # has no -shm, so the daemon never maps it. Runs before _init_tables and
         # before any MCP/session resume spawns stdio children. Agents DB only.
-        journal_mode = _configure_agents_db_connection(self._db)
+        journal_mode = _configure_agents_db_connection(
+            self._db,
+            policy=store_connection_policy(catalog, "agents"),
+        )
         self._db.execute("PRAGMA foreign_keys=ON")
         if catalog is not None:
             catalog.register(
@@ -7396,10 +7427,13 @@ except Exception as exc:
         a durable held row always has the request discovered by the restart
         retry loop; before commit, neither side survives.
         """
-        transaction_db = sqlite3.connect(
-            self._db_path, timeout=5.0, check_same_thread=False,
+        transaction_db = open_store_connection(
+            self._catalog,
+            "agents",
+            self._db_path,
+            owner=FLEET_SIGNING_KEY_OWNER,
+            check_same_thread=False,
         )
-        transaction_db.execute("PRAGMA busy_timeout=5000")
         transaction_db.execute("PRAGMA foreign_keys=ON")
         try:
             transaction_db.execute("BEGIN IMMEDIATE")

--- a/src/pinky_daemon/agent_signing_key_store.py
+++ b/src/pinky_daemon/agent_signing_key_store.py
@@ -13,7 +13,12 @@ import time
 from pathlib import Path
 from typing import Protocol, runtime_checkable
 
-from pinky_daemon.store_catalog import BoundSQLiteFile, StoreCatalog, StoreObservation
+from pinky_daemon.store_catalog import (
+    BoundSQLiteFile,
+    StoreCatalog,
+    StoreObservation,
+    open_store_connection,
+)
 
 AGENT_SIGNING_KEY_LOGICAL_NAME = "agent_signing_keys"
 FLEET_SIGNING_KEY_OWNER = "AgentRegistry+AgentSigningKeyStore"
@@ -192,7 +197,13 @@ class AgentSigningKeyStore:
                     staging_root_path / attempt_name,
                     attempt_descriptor,
                 )
-                connection = sqlite3.connect(database, uri=uri)
+                connection = open_store_connection(
+                    catalog,
+                    AGENT_SIGNING_KEY_LOGICAL_NAME,
+                    database,
+                    owner=cls.__name__,
+                    uri=uri,
+                )
                 try:
                     row = connection.execute("PRAGMA journal_mode=DELETE").fetchone()
                     journal_mode = str(row[0]).lower() if row else ""

--- a/src/pinky_daemon/analytics_store.py
+++ b/src/pinky_daemon/analytics_store.py
@@ -6,7 +6,7 @@ import sqlite3
 from contextlib import contextmanager
 from datetime import UTC, datetime, timedelta
 
-from pinky_daemon.store_catalog import StoreCatalog
+from pinky_daemon.store_catalog import StoreCatalog, open_store_connection
 
 # Providers to include in analytics dashboards.
 # Only Anthropic/Claude usage — excludes Codex CLI (OpenAI) and other non-Anthropic providers.
@@ -75,7 +75,12 @@ class AnalyticsStore:
 
     @contextmanager
     def _connect(self):
-        conn = sqlite3.connect(self.db_path)
+        conn = open_store_connection(
+            self._catalog,
+            "analytics",
+            self.db_path,
+            owner=type(self).__name__,
+        )
         conn.row_factory = sqlite3.Row
         try:
             yield conn

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -210,6 +210,7 @@ from pinky_daemon.store_manifest import (
     derive_fleet_store_manifest,
     derive_standalone_tenant_store_manifest_for_agent,
 )
+from pinky_daemon.store_shutdown import StoreShutdownError
 from pinky_daemon.store_snapshot import (
     SnapshotResult,
     StoreSnapshotError,
@@ -1731,8 +1732,9 @@ def create_api(
 
     db_path = os.path.realpath(db_path)
     _data_dir = Path(db_path).parent
-    store_catalog = DaemonStoreCatalog(expected_root=_data_dir)
     store_manifest = _derive_api_store_manifest(db_path)
+    store_catalog = DaemonStoreCatalog(expected_root=_data_dir)
+    store_catalog.configure_manifest(store_manifest)
     storage_observability = StorageObservability(store_manifest)
     try:
         store_catalog.preflight_integrity(
@@ -1845,6 +1847,7 @@ def create_api(
             tenant_catalog = StoreCatalog(
                 expected_root=tenant_root,
                 silence_allowlist={},
+                manifest=tenant_manifest,
             )
             observations = tenant_catalog.preflight_integrity(tenant_manifest.values())
             for target in tenant_manifest.values():
@@ -12880,10 +12883,19 @@ npm run build</pre>
         if shared_mcp_manager and shared_mcp_manager.is_running:
             await shared_mcp_manager.stop()
             _log("shutdown: shared MCP server stopped")
-        message_context_store.close()
         for tenant_catalog in tenant_store_catalogs.values():
             tenant_catalog.close()
-        store_catalog.close()
+        try:
+            report = store_catalog.shutdown(deadline_seconds=10.0)
+        except StoreShutdownError as exc:
+            app.state.store_shutdown_report = exc.report
+            _log(f"ERROR shutdown: {exc}")
+            raise
+        app.state.store_shutdown_report = report
+        _log(
+            "shutdown: store finalization complete "
+            f"attempted={len(report.attempted)} finalized={len(report.finalized)}"
+        )
 
     # ── Admin: Session Watchdog ─────────────────────────
 

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -12876,6 +12876,9 @@ npm run build</pre>
         if app.state.buzz_poller_tasks:
             await asyncio.gather(*app.state.buzz_poller_tasks, return_exceptions=True)
         app.state.buzz_poller_tasks.clear()
+        from pinky_daemon.pollers import quiesce_delivery_tasks
+
+        await quiesce_delivery_tasks()
         await autonomy.stop()
         await scheduler.stop()
         await watchdog.stop()

--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -2716,6 +2716,7 @@ def create_api(
         message_context_store=message_context_store,
     )
     _broker_pollers: list = []  # Track active broker pollers
+    from pinky_daemon.pollers import quiesce_delivery_tasks, start_poller
 
     app.state.manager = manager
     app.state.broker = broker
@@ -8665,7 +8666,7 @@ npm run build</pre>
                     adapter, name, broker, registry=agents,
                 )
                 _broker_pollers.append(poller)
-                asyncio.create_task(poller.start())
+                start_poller(poller)
                 _log(f"api: started telegram poller for {name}")
             except Exception as e:
                 _log(f"api: failed to start telegram poller for {name}: {e}")
@@ -8699,7 +8700,7 @@ npm run build</pre>
                     watched_channels=watched,
                 )
                 _broker_pollers.append(poller)
-                asyncio.create_task(poller.start())
+                start_poller(poller)
                 _log(
                     f"api: started discord poller for {name} "
                     f"(poll_interval={poll_interval}s, "
@@ -12612,7 +12613,7 @@ npm run build</pre>
                         adapter, agent.name, broker, registry=agents,
                     )
                     _broker_pollers.append(poller)
-                    asyncio.create_task(poller.start())
+                    start_poller(poller)
                     _log(f"startup: broker poller started for {agent.name}")
 
             # Discord poller — REST polling (Gateway/WebSocket is a future v0.2)
@@ -12642,7 +12643,7 @@ npm run build</pre>
                             watched_channels=watched,
                         )
                         _broker_pollers.append(d_poller)
-                        asyncio.create_task(d_poller.start())
+                        start_poller(d_poller)
                         _log(
                             f"startup: discord poller started for {agent.name} "
                             f"(interval={poll_interval}s, "
@@ -12686,7 +12687,7 @@ npm run build</pre>
                                 app_token=app_token,
                             )
                             _broker_pollers.append(s_poller)
-                            asyncio.create_task(s_poller.start())
+                            start_poller(s_poller)
                             _log(f"startup: slack socket-mode poller started for {agent.name}")
                     except Exception as e:
                         _log(f"startup: slack poller failed for {agent.name}: {e}")
@@ -12712,7 +12713,7 @@ npm run build</pre>
                         im_adapter, agent.name, broker,
                     )
                     _broker_pollers.append(im_poller)
-                    asyncio.create_task(im_poller.start())
+                    start_poller(im_poller)
                     _log(f"startup: iMessage poller started for {agent.name}")
                 except Exception as e:
                     _log(f"startup: iMessage poller failed for {agent.name}: {e}")
@@ -12876,8 +12877,6 @@ npm run build</pre>
         if app.state.buzz_poller_tasks:
             await asyncio.gather(*app.state.buzz_poller_tasks, return_exceptions=True)
         app.state.buzz_poller_tasks.clear()
-        from pinky_daemon.pollers import quiesce_delivery_tasks
-
         await quiesce_delivery_tasks()
         await autonomy.stop()
         await scheduler.stop()

--- a/src/pinky_daemon/app_store.py
+++ b/src/pinky_daemon/app_store.py
@@ -12,13 +12,12 @@ from __future__ import annotations
 
 import re
 import secrets
-import sqlite3
 import sys
 import time
 from dataclasses import dataclass
 from pathlib import Path
 
-from pinky_daemon.store_catalog import StoreCatalog
+from pinky_daemon.store_catalog import StoreCatalog, open_store_connection
 
 
 def _log(msg: str) -> None:
@@ -84,7 +83,13 @@ class AppStore:
     ) -> None:
         Path(db_path).parent.mkdir(parents=True, exist_ok=True)
         self._db_path = db_path
-        self._db = sqlite3.connect(db_path, check_same_thread=False)
+        self._db = open_store_connection(
+            catalog,
+            "apps",
+            db_path,
+            owner=type(self).__name__,
+            check_same_thread=False,
+        )
         journal_mode = str(
             self._db.execute("PRAGMA journal_mode=WAL").fetchone()[0]
         ).lower()

--- a/src/pinky_daemon/audit_store.py
+++ b/src/pinky_daemon/audit_store.py
@@ -8,7 +8,12 @@ import time
 from dataclasses import dataclass
 from pathlib import Path
 
-from pinky_daemon.store_catalog import StoreCatalog
+from pinky_daemon.store_catalog import (
+    StoreCatalog,
+    apply_store_connection_policy,
+    open_store_connection,
+    store_connection_policy,
+)
 
 
 @dataclass
@@ -61,9 +66,17 @@ class AuditStore:
         """Return the calling thread's connection, creating it on first use."""
         connection = getattr(self._thread_local, "connection", None)
         if connection is None:
-            connection = sqlite3.connect(self._db_path)
+            connection = open_store_connection(
+                self._catalog,
+                "audit",
+                self._db_path,
+                owner=type(self).__name__,
+            )
             journal_mode = str(connection.execute("PRAGMA journal_mode=WAL").fetchone()[0]).lower()
-            connection.execute("PRAGMA busy_timeout=30000")
+            apply_store_connection_policy(
+                connection,
+                store_connection_policy(self._catalog, "audit"),
+            )
             if self._catalog is not None:
                 self._catalog.register(
                     "audit",

--- a/src/pinky_daemon/conversation_store.py
+++ b/src/pinky_daemon/conversation_store.py
@@ -19,7 +19,11 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 from pinky_daemon.db_journal import configure_rollback_journal
-from pinky_daemon.store_catalog import StoreCatalog
+from pinky_daemon.store_catalog import (
+    StoreCatalog,
+    open_store_connection,
+    store_connection_policy,
+)
 
 
 def _fts5_phrase(query: str) -> str:
@@ -101,13 +105,21 @@ class ConversationStore:
         """Return the calling thread's connection, creating it on first use."""
         connection = getattr(self._thread_local, "connection", None)
         if connection is None:
-            connection = sqlite3.connect(self._db_path)
+            connection = open_store_connection(
+                self._catalog,
+                "conversations",
+                self._db_path,
+                owner=type(self).__name__,
+            )
             connection.row_factory = sqlite3.Row
             # #889: rollback (TRUNCATE) journal mode, NOT WAL — so an external
             # sqlite client opening this live DB and closing cannot unlink the
             # -wal/-shm out from under the daemon's connection. Sets busy_timeout
             # internally. See pinky_daemon.db_journal.
-            journal_mode = configure_rollback_journal(connection, busy_ms=30000)
+            journal_mode = configure_rollback_journal(
+                connection,
+                policy=store_connection_policy(self._catalog, "conversations"),
+            )
             if self._catalog is not None:
                 self._catalog.register(
                     "conversations",

--- a/src/pinky_daemon/db_journal.py
+++ b/src/pinky_daemon/db_journal.py
@@ -28,6 +28,12 @@ from __future__ import annotations
 import sqlite3
 import time
 
+from pinky_daemon.store_catalog import (
+    StoreConnectionPolicy,
+    apply_store_connection_policy,
+    default_store_connection_policy,
+)
+
 
 class RollbackJournalError(RuntimeError):
     """Raised when a store DB cannot be confirmed in rollback (TRUNCATE) journal
@@ -37,9 +43,10 @@ class RollbackJournalError(RuntimeError):
 def configure_rollback_journal(
     conn: sqlite3.Connection,
     *,
-    busy_ms: int = 30000,
-    retries: int = 6,
+    busy_ms: int | None = None,
+    retries: int | None = None,
     strict: bool = True,
+    policy: StoreConnectionPolicy | None = None,
 ) -> str:
     """Put ``conn`` into rollback (TRUNCATE) journal mode. Returns the effective
     journal mode (``"truncate"`` on success).
@@ -51,9 +58,19 @@ def configure_rollback_journal(
     serialization. With ``strict=True`` (default) raises :class:`RollbackJournalError`
     if the mode cannot be confirmed, rather than silently continuing on WAL.
     """
-    conn.execute(f"PRAGMA busy_timeout={int(busy_ms)}")
+    declared_policy = policy or default_store_connection_policy("conversations")
+    effective_busy_ms = declared_policy.busy_timeout_ms if busy_ms is None else busy_ms
+    effective_retries = declared_policy.rollback_retries if retries is None else retries
+    apply_store_connection_policy(
+        conn,
+        StoreConnectionPolicy(
+            busy_timeout_ms=effective_busy_ms,
+            rollback_retries=declared_policy.rollback_retries,
+            rollback_retry_delay_seconds=declared_policy.rollback_retry_delay_seconds,
+        ),
+    )
     last: str | None = None
-    for attempt in range(retries):
+    for attempt in range(effective_retries):
         try:
             cur = conn.execute("PRAGMA journal_mode").fetchone()
             if cur and str(cur[0]).lower() == "wal":
@@ -67,10 +84,10 @@ def configure_rollback_journal(
                 return last
         except sqlite3.OperationalError as exc:
             last = f"error:{exc}"
-        time.sleep(0.2 * (attempt + 1))
+        time.sleep(declared_policy.rollback_retry_delay_seconds * (attempt + 1))
     if strict:
         raise RollbackJournalError(
-            f"DB refused to leave WAL: journal_mode={last!r} after {retries} "
+            f"DB refused to leave WAL: journal_mode={last!r} after {effective_retries} "
             f"attempts — refusing to run on the #889 deleted-WAL substrate."
         )
     return last or "unknown"

--- a/src/pinky_daemon/dream_runner.py
+++ b/src/pinky_daemon/dream_runner.py
@@ -39,7 +39,12 @@ from pinky_daemon.auth import (
 )
 from pinky_daemon.dream_prompt import DREAM_SYSTEM_PROMPT
 from pinky_daemon.sdk_runner import SDKRunner, SDKRunnerConfig
-from pinky_daemon.store_catalog import StoreCatalog
+from pinky_daemon.store_catalog import (
+    StoreCatalog,
+    apply_store_connection_policy,
+    open_store_connection,
+    store_connection_policy,
+)
 from pinky_daemon.tmux_dream_runner import TmuxDreamConfig, TmuxDreamRunner
 from pinky_memory.store import ReflectionStore
 
@@ -170,11 +175,19 @@ class DreamRunner:
         """Return the calling thread's connection, creating it on first use."""
         connection = getattr(self._thread_local, "connection", None)
         if connection is None:
-            connection = sqlite3.connect(self._db_path)
+            connection = open_store_connection(
+                self._catalog,
+                "dream_state",
+                self._db_path,
+                owner=type(self).__name__,
+            )
             journal_mode = str(
                 connection.execute("PRAGMA journal_mode=WAL").fetchone()[0]
             ).lower()
-            connection.execute("PRAGMA busy_timeout=30000")
+            apply_store_connection_policy(
+                connection,
+                store_connection_policy(self._catalog, "dream_state"),
+            )
             if self._catalog is not None:
                 self._catalog.register(
                     "dream_state",

--- a/src/pinky_daemon/kb_store.py
+++ b/src/pinky_daemon/kb_store.py
@@ -34,7 +34,7 @@ from pathlib import Path
 
 import yaml
 
-from pinky_daemon.store_catalog import StoreCatalog
+from pinky_daemon.store_catalog import StoreCatalog, open_store_connection
 
 
 def _log(msg: str) -> None:
@@ -184,7 +184,12 @@ class KBStore:
         self._init_db()
 
     def _conn(self) -> sqlite3.Connection:
-        conn = sqlite3.connect(str(self.db_path))
+        conn = open_store_connection(
+            self._catalog,
+            "kb",
+            str(self.db_path),
+            owner=type(self).__name__,
+        )
         journal_mode = str(
             conn.execute("PRAGMA journal_mode=WAL").fetchone()[0]
         ).lower()

--- a/src/pinky_daemon/librarian_runner.py
+++ b/src/pinky_daemon/librarian_runner.py
@@ -22,7 +22,7 @@ from pathlib import Path
 from pinky_daemon.kb_store import _FRONTMATTER_RE, KBStore, _content_hash
 from pinky_daemon.librarian_prompt import LIBRARIAN_SYSTEM_PROMPT
 from pinky_daemon.sdk_runner import SDKRunner, SDKRunnerConfig
-from pinky_daemon.store_catalog import StoreCatalog
+from pinky_daemon.store_catalog import StoreCatalog, open_store_connection
 
 
 def _log(msg: str) -> None:
@@ -69,7 +69,12 @@ class LibrarianRunner:
         self._init_db()
 
     def _conn(self) -> sqlite3.Connection:
-        conn = sqlite3.connect(str(self._db_path))
+        conn = open_store_connection(
+            self._catalog,
+            "librarian_state",
+            str(self._db_path),
+            owner="LibrarianRunner",
+        )
         journal_mode = str(conn.execute("PRAGMA journal_mode=WAL").fetchone()[0]).lower()
         conn.row_factory = sqlite3.Row
         if self._catalog is not None:
@@ -78,7 +83,8 @@ class LibrarianRunner:
                 self._db_path,
                 journal_mode=journal_mode,
                 owner="LibrarianRunner",
-                criticality="derived",
+                criticality="telemetry",
+                recovery="rebuild",
             )
         return conn
 

--- a/src/pinky_daemon/mesh_store.py
+++ b/src/pinky_daemon/mesh_store.py
@@ -22,14 +22,13 @@ PinkyBot issue: #419.
 from __future__ import annotations
 
 import json
-import sqlite3
 import threading
 import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Literal
 
-from pinky_daemon.store_catalog import StoreCatalog
+from pinky_daemon.store_catalog import StoreCatalog, open_store_connection
 
 # -- Records -------------------------------------------------------------------
 
@@ -108,7 +107,13 @@ class MeshStore:
         catalog: StoreCatalog | None = None,
     ) -> None:
         Path(db_path).parent.mkdir(parents=True, exist_ok=True)
-        self._db = sqlite3.connect(db_path, check_same_thread=False)
+        self._db = open_store_connection(
+            catalog,
+            "mesh",
+            db_path,
+            owner=type(self).__name__,
+            check_same_thread=False,
+        )
         journal_mode = str(
             self._db.execute("PRAGMA journal_mode=WAL").fetchone()[0]
         ).lower()

--- a/src/pinky_daemon/message_context_store.py
+++ b/src/pinky_daemon/message_context_store.py
@@ -9,7 +9,12 @@ import time
 from pathlib import Path
 from typing import Any
 
-from pinky_daemon.store_catalog import StoreCatalog
+from pinky_daemon.store_catalog import (
+    StoreCatalog,
+    apply_store_connection_policy,
+    open_store_connection,
+    store_connection_policy,
+)
 
 DEFAULT_RETENTION_DAYS = 30
 DEFAULT_MAX_PER_AGENT = 1000
@@ -31,12 +36,21 @@ class MessageContextStore:
         self.max_per_agent = max(1, max_per_agent)
         self._lock = threading.RLock()
         Path(db_path).parent.mkdir(parents=True, exist_ok=True)
-        self._db = sqlite3.connect(db_path, check_same_thread=False)
+        self._db = open_store_connection(
+            catalog,
+            "message_context",
+            db_path,
+            owner=type(self).__name__,
+            check_same_thread=False,
+        )
         self._db.row_factory = sqlite3.Row
         journal_mode = str(
             self._db.execute("PRAGMA journal_mode=WAL").fetchone()[0]
         ).lower()
-        self._db.execute("PRAGMA busy_timeout=5000")
+        apply_store_connection_policy(
+            self._db,
+            store_connection_policy(catalog, "message_context"),
+        )
         if catalog is not None:
             catalog.register(
                 "message_context",

--- a/src/pinky_daemon/outreach_config.py
+++ b/src/pinky_daemon/outreach_config.py
@@ -11,14 +11,17 @@ Storage: SQLite with one table:
 from __future__ import annotations
 
 import json
-import sqlite3
 import sys
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
 
 from pinky_daemon.db_journal import configure_rollback_journal
-from pinky_daemon.store_catalog import StoreCatalog
+from pinky_daemon.store_catalog import (
+    StoreCatalog,
+    open_store_connection,
+    store_connection_policy,
+)
 
 
 def _log(msg: str) -> None:
@@ -60,11 +63,20 @@ class OutreachConfigStore:
         catalog: StoreCatalog | None = None,
     ) -> None:
         Path(db_path).parent.mkdir(parents=True, exist_ok=True)
-        self._db = sqlite3.connect(db_path, check_same_thread=False)
+        self._db = open_store_connection(
+            catalog,
+            "outreach_config",
+            db_path,
+            owner=type(self).__name__,
+            check_same_thread=False,
+        )
         # #889: rollback (TRUNCATE) journal mode, NOT WAL — an external sqlite
         # client's open/close can't unlink -wal/-shm out from under the daemon.
         # See pinky_daemon.db_journal.
-        journal_mode = configure_rollback_journal(self._db)
+        journal_mode = configure_rollback_journal(
+            self._db,
+            policy=store_connection_policy(catalog, "outreach_config"),
+        )
         if catalog is not None:
             catalog.register(
                 "outreach_config",

--- a/src/pinky_daemon/plugin_manager.py
+++ b/src/pinky_daemon/plugin_manager.py
@@ -38,7 +38,7 @@ from typing import Any, Callable
 
 import yaml
 
-from pinky_daemon.store_catalog import StoreCatalog
+from pinky_daemon.store_catalog import StoreCatalog, open_store_connection
 
 
 def _log(msg: str) -> None:
@@ -142,7 +142,13 @@ class PluginContext:
                 data_dir = self._working_dir / "data"
                 data_dir.mkdir(parents=True, exist_ok=True)
                 self._db_path = str(data_dir / "plugins.db")
-            self._db = sqlite3.connect(self._db_path, check_same_thread=False)
+            self._db = open_store_connection(
+                self._catalog,
+                "plugins",
+                self._db_path,
+                owner="PluginManager",
+                check_same_thread=False,
+            )
             journal_mode = str(
                 self._db.execute("PRAGMA journal_mode=WAL").fetchone()[0]
             ).lower()
@@ -310,7 +316,13 @@ class PluginManager:
     def _init_state_db(self) -> None:
         """Initialize the plugin state tracking table."""
         Path(self._state_db_path).parent.mkdir(parents=True, exist_ok=True)
-        db = sqlite3.connect(self._state_db_path, check_same_thread=False)
+        db = open_store_connection(
+            self._catalog,
+            "plugins",
+            self._state_db_path,
+            owner="PluginManager",
+            check_same_thread=False,
+        )
         journal_mode = str(db.execute("PRAGMA journal_mode=WAL").fetchone()[0]).lower()
         if self._catalog is not None:
             self._catalog.register(
@@ -556,7 +568,13 @@ class PluginManager:
 
     def _save_state(self, name: str, state: str) -> None:
         try:
-            db = sqlite3.connect(self._state_db_path, check_same_thread=False)
+            db = open_store_connection(
+                self._catalog,
+                "plugins",
+                self._state_db_path,
+                owner="PluginManager",
+                check_same_thread=False,
+            )
             now = time.time()
             db.execute(
                 """INSERT INTO plugin_state (name, state, enabled, updated_at)
@@ -573,7 +591,13 @@ class PluginManager:
     def get_previously_enabled(self) -> list[str]:
         """Get names of plugins that were enabled in previous run."""
         try:
-            db = sqlite3.connect(self._state_db_path, check_same_thread=False)
+            db = open_store_connection(
+                self._catalog,
+                "plugins",
+                self._state_db_path,
+                owner="PluginManager",
+                check_same_thread=False,
+            )
             rows = db.execute("SELECT name FROM plugin_state WHERE enabled=1").fetchall()
             db.close()
             return [r[0] for r in rows]

--- a/src/pinky_daemon/pollers.py
+++ b/src/pinky_daemon/pollers.py
@@ -78,6 +78,14 @@ def _deliver_in_background(coro, log_prefix: str) -> "asyncio.Task":
     task.add_done_callback(_on_done)
     return task
 
+
+async def quiesce_delivery_tasks() -> None:
+    """Wait until every admitted inbound delivery has stopped writing."""
+    while _DELIVERY_TASKS:
+        tasks = tuple(_DELIVERY_TASKS)
+        await asyncio.gather(*tasks, return_exceptions=True)
+        _DELIVERY_TASKS.difference_update(tasks)
+
 if TYPE_CHECKING:
     from pinky_outreach.slack import SlackAdapter
     from pinky_outreach.types import Chat
@@ -167,7 +175,7 @@ class _TelegramPollWatchdog:
         if fut.exception() is not None:  # consumed: no "never retrieved" noise
             return
         late = fut.result()
-        if not late:
+        if not late or not self._accepting_deliveries:
             return
         _log(
             f"{self._watchdog_label}: abandoned poll completed late with "
@@ -234,12 +242,14 @@ class TelegramPoller(_TelegramPollWatchdog):
         self._allowed_chats = set(allowed_chat_ids) if allowed_chat_ids else None
         self._event_callback = event_callback  # async fn(platform, chat_id, sender, content)
         self._running = False
+        self._accepting_deliveries = True
         self._poll_count = 0
         self._init_watchdog("telegram-poller", watchdog_grace)
 
     async def start(self) -> None:
         """Start the polling loop."""
         self._running = True
+        self._accepting_deliveries = True
         _log("telegram-poller: starting")
 
         # Verify bot connection — on the poller's executor, under a deadline,
@@ -277,12 +287,16 @@ class TelegramPoller(_TelegramPollWatchdog):
 
         self._poll_count += 1
 
+        if not self._accepting_deliveries:
+            return
         await self._process_messages(messages)
 
     async def _process_messages(self, messages) -> None:
         """Route polled updates to the handler — also the watchdog's
         late-delivery path for polls that complete after abandonment."""
         for msg in messages:
+            if not self._accepting_deliveries:
+                return
             # Filter by allowed chats
             if self._allowed_chats and msg.chat_id not in self._allowed_chats:
                 _log(f"telegram-poller: ignoring message from chat {msg.chat_id}")
@@ -325,6 +339,7 @@ class TelegramPoller(_TelegramPollWatchdog):
     def stop(self) -> None:
         """Stop the polling loop."""
         self._running = False
+        self._accepting_deliveries = False
         self._shutdown_watchdog()
         _log("telegram-poller: stopping")
 
@@ -369,6 +384,7 @@ class BrokerTelegramPoller(_TelegramPollWatchdog):
         self._poll_interval = poll_interval
         self._event_callback = event_callback
         self._running = False
+        self._accepting_deliveries = True
         self._poll_count = 0
         self._bot_username = ""
         self._init_watchdog(f"broker-poller[{agent_name}]", watchdog_grace)
@@ -376,6 +392,7 @@ class BrokerTelegramPoller(_TelegramPollWatchdog):
     async def start(self) -> None:
         """Start the polling loop."""
         self._running = True
+        self._accepting_deliveries = True
         _log(f"broker-poller[{self._agent_name}]: starting")
 
         # On the poller's executor, under a deadline — a wedged network can't
@@ -414,12 +431,16 @@ class BrokerTelegramPoller(_TelegramPollWatchdog):
 
         self._poll_count += 1
 
+        if not self._accepting_deliveries:
+            return
         await self._process_messages(messages)
 
     async def _process_messages(self, messages) -> None:
         """Route polled updates through the broker — also the watchdog's
         late-delivery path for polls that complete after abandonment."""
         for msg in messages:
+            if not self._accepting_deliveries:
+                return
             chat_type = msg.metadata.get("chat_type", "")
             is_group = chat_type in ("group", "supergroup")
 
@@ -477,6 +498,7 @@ class BrokerTelegramPoller(_TelegramPollWatchdog):
     def stop(self) -> None:
         """Stop the polling loop."""
         self._running = False
+        self._accepting_deliveries = False
         self._shutdown_watchdog()
         _log(f"broker-poller[{self._agent_name}]: stopping")
 
@@ -518,11 +540,13 @@ class BrokeriMessagePoller:
         self._poll_interval = poll_interval
         self._event_callback = event_callback
         self._running = False
+        self._accepting_deliveries = True
         self._poll_count = 0
 
     async def start(self) -> None:
         """Start the polling loop."""
         self._running = True
+        self._accepting_deliveries = True
         _log(f"imessage-poller[{self._agent_name}]: starting")
 
         if not self._adapter.can_receive:
@@ -561,7 +585,11 @@ class BrokeriMessagePoller:
 
         self._poll_count += 1
 
+        if not self._accepting_deliveries:
+            return
         for msg in messages:
+            if not self._accepting_deliveries:
+                return
             is_group = msg.metadata.get("is_group", False)
 
             broker_msg = self._BrokerMessage(
@@ -600,6 +628,7 @@ class BrokeriMessagePoller:
 
     def stop(self) -> None:
         self._running = False
+        self._accepting_deliveries = False
         _log(f"imessage-poller[{self._agent_name}]: stopping")
 
     @property
@@ -660,6 +689,7 @@ class BrokerDiscordPoller:
         self._configured_channels = list(watched_channels or [])
         self._event_callback = event_callback
         self._running = False
+        self._accepting_deliveries = True
         self._poll_count = 0
         self._bot_user_id = ""
         self._bot_username = ""
@@ -691,6 +721,7 @@ class BrokerDiscordPoller:
     async def start(self) -> None:
         """Start the polling loop."""
         self._running = True
+        self._accepting_deliveries = True
         _log(f"discord-poller[{self._agent_name}]: starting")
 
         # Verify bot connection
@@ -892,6 +923,8 @@ class BrokerDiscordPoller:
                 )
                 continue
 
+            if not self._accepting_deliveries:
+                return
             if not messages:
                 continue
 
@@ -904,10 +937,14 @@ class BrokerDiscordPoller:
             # renames are rare). Resolve once per channel per sweep instead
             # of fanning out N get_channel calls in the per-message loop.
             chat_info = await self._resolve_channel_info(channel_id)
+            if not self._accepting_deliveries:
+                return
             chat_title = chat_info.title if chat_info and chat_info.title else ""
             is_group = bool(chat_info and chat_info.chat_type != "dm")
 
             for msg in messages:
+                if not self._accepting_deliveries:
+                    return
                 # Track high-water mark even for skipped messages so we don't
                 # re-fetch them next tick.
                 self._last_id[channel_id] = msg.message_id
@@ -968,6 +1005,7 @@ class BrokerDiscordPoller:
     def stop(self) -> None:
         """Stop the polling loop."""
         self._running = False
+        self._accepting_deliveries = False
         _log(f"discord-poller[{self._agent_name}]: stopping")
 
 
@@ -1074,6 +1112,7 @@ class BrokerSlackPoller:
         self._app_token = app_token
         self._event_callback = event_callback
         self._running = False
+        self._accepting_deliveries = True
         self._bot_user_id = ""
         self._bot_id = ""  # our own bot_id (from auth.test) — filters our bot_message echoes
         self._client = None  # slack_sdk SocketModeClient, created in start()
@@ -1187,6 +1226,7 @@ class BrokerSlackPoller:
         client.socket_mode_request_listeners.append(_on_request)
 
         self._running = True
+        self._accepting_deliveries = True
         try:
             await client.connect()
             _log(f"slack-poller[{self._agent_name}]: socket mode connected, listening")
@@ -1475,6 +1515,8 @@ class BrokerSlackPoller:
         )
 
     async def _handle_event(self, payload: dict) -> None:
+        if not self._accepting_deliveries:
+            return
         event = (payload or {}).get("event") or {}
         if event.get("type") != "message":
             return
@@ -1522,6 +1564,9 @@ class BrokerSlackPoller:
                 sender_name = resolved
         chat_title = await self._resolve_channel_title(channel)
         text = await self._resolve_text_refs(text)
+
+        if not self._accepting_deliveries:
+            return
 
         attachments = [
             {
@@ -1587,6 +1632,7 @@ class BrokerSlackPoller:
         logged rather than silently dropped.
         """
         self._running = False
+        self._accepting_deliveries = False
         _log(f"slack-poller[{self._agent_name}]: stopping")
         client = self._client
         if client is not None:

--- a/src/pinky_daemon/pollers.py
+++ b/src/pinky_daemon/pollers.py
@@ -60,6 +60,7 @@ _PRIME_FRESH_WINDOW_SECONDS = 30.0
 # weak references, so a bare fire-and-forget create_task can be garbage
 # collected mid-flight and its exception silently dropped.
 _DELIVERY_TASKS: set["asyncio.Task"] = set()
+_POLLER_TASKS: set["asyncio.Task"] = set()
 
 
 def _deliver_in_background(coro, log_prefix: str) -> "asyncio.Task":
@@ -79,11 +80,29 @@ def _deliver_in_background(coro, log_prefix: str) -> "asyncio.Task":
     return task
 
 
+def start_poller(poller) -> "asyncio.Task":
+    """Start and retain one poller loop until its admitted batch has drained."""
+    task = asyncio.create_task(poller.start())
+    _POLLER_TASKS.add(task)
+
+    def _on_done(done: "asyncio.Task") -> None:
+        _POLLER_TASKS.discard(done)
+        if done.cancelled():
+            return
+        exc = done.exception()
+        if exc is not None:
+            _log(f"{type(poller).__name__}: poller task failed: {exc!r}")
+
+    task.add_done_callback(_on_done)
+    return task
+
+
 async def quiesce_delivery_tasks() -> None:
-    """Wait until every admitted inbound delivery has stopped writing."""
-    while _DELIVERY_TASKS:
-        tasks = tuple(_DELIVERY_TASKS)
+    """Wait until poller loops and every admitted delivery stop writing."""
+    while _POLLER_TASKS or _DELIVERY_TASKS:
+        tasks = tuple(_POLLER_TASKS | _DELIVERY_TASKS)
         await asyncio.gather(*tasks, return_exceptions=True)
+        _POLLER_TASKS.difference_update(tasks)
         _DELIVERY_TASKS.difference_update(tasks)
 
 if TYPE_CHECKING:
@@ -175,7 +194,13 @@ class _TelegramPollWatchdog:
         if fut.exception() is not None:  # consumed: no "never retrieved" noise
             return
         late = fut.result()
-        if not late or not self._accepting_deliveries:
+        if not late:
+            return
+        if not self._accepting_deliveries:
+            _log(
+                f"{self._watchdog_label}: abandoned poll completed after stop; "
+                f"platform=telegram dropping {len(late)} update(s)"
+            )
             return
         _log(
             f"{self._watchdog_label}: abandoned poll completed late with "
@@ -295,8 +320,6 @@ class TelegramPoller(_TelegramPollWatchdog):
         """Route polled updates to the handler — also the watchdog's
         late-delivery path for polls that complete after abandonment."""
         for msg in messages:
-            if not self._accepting_deliveries:
-                return
             # Filter by allowed chats
             if self._allowed_chats and msg.chat_id not in self._allowed_chats:
                 _log(f"telegram-poller: ignoring message from chat {msg.chat_id}")
@@ -439,8 +462,6 @@ class BrokerTelegramPoller(_TelegramPollWatchdog):
         """Route polled updates through the broker — also the watchdog's
         late-delivery path for polls that complete after abandonment."""
         for msg in messages:
-            if not self._accepting_deliveries:
-                return
             chat_type = msg.metadata.get("chat_type", "")
             is_group = chat_type in ("group", "supergroup")
 
@@ -588,8 +609,6 @@ class BrokeriMessagePoller:
         if not self._accepting_deliveries:
             return
         for msg in messages:
-            if not self._accepting_deliveries:
-                return
             is_group = msg.metadata.get("is_group", False)
 
             broker_msg = self._BrokerMessage(
@@ -1564,9 +1583,6 @@ class BrokerSlackPoller:
                 sender_name = resolved
         chat_title = await self._resolve_channel_title(channel)
         text = await self._resolve_text_refs(text)
-
-        if not self._accepting_deliveries:
-            return
 
         attachments = [
             {

--- a/src/pinky_daemon/pollers.py
+++ b/src/pinky_daemon/pollers.py
@@ -97,6 +97,19 @@ def start_poller(poller) -> "asyncio.Task":
     return task
 
 
+async def _sleep_until_stopped(stop_event: asyncio.Event, delay: float) -> None:
+    """Sleep between polls, returning immediately when stop closes ingress."""
+    if stop_event.is_set():
+        return
+    if delay <= 0:
+        await asyncio.sleep(0)
+        return
+    try:
+        await asyncio.wait_for(stop_event.wait(), timeout=delay)
+    except TimeoutError:
+        pass
+
+
 async def quiesce_delivery_tasks() -> None:
     """Wait until poller loops and every admitted delivery stop writing."""
     while _POLLER_TASKS or _DELIVERY_TASKS:
@@ -154,6 +167,7 @@ class _TelegramPollWatchdog:
         )
         self._watchdog_fires = 0
         self._last_poll_ok = 0.0
+        self._active_poll = None
 
     async def _watched_poll(self, poll_fn):
         """Run ``poll_fn`` on the dedicated executor under a hard deadline.
@@ -170,18 +184,23 @@ class _TelegramPollWatchdog:
         """
         loop = asyncio.get_running_loop()
         fut = loop.run_in_executor(self._poll_executor, poll_fn)
+        self._active_poll = fut
         deadline = self._poll_timeout + self._watchdog_grace
         try:
-            result = await asyncio.wait_for(asyncio.shield(fut), timeout=deadline)
-        except TimeoutError:
-            if fut.done() and not fut.cancelled() and fut.exception() is None:
-                # Completed on the deadline edge (loop scheduled the timeout
-                # callback first) — a healthy poll, not a stuck one.
-                self._last_poll_ok = time.monotonic()
-                return fut.result()
-            fut.add_done_callback(self._on_abandoned_poll_done)
-            self._recycle_after_stuck_poll(deadline)
-            return []
+            try:
+                result = await asyncio.wait_for(asyncio.shield(fut), timeout=deadline)
+            except TimeoutError:
+                if fut.done() and not fut.cancelled() and fut.exception() is None:
+                    # Completed on the deadline edge (loop scheduled the timeout
+                    # callback first) — a healthy poll, not a stuck one.
+                    self._last_poll_ok = time.monotonic()
+                    return fut.result()
+                fut.add_done_callback(self._on_abandoned_poll_done)
+                self._recycle_after_stuck_poll(deadline)
+                return []
+        finally:
+            if self._active_poll is fut:
+                self._active_poll = None
         self._last_poll_ok = time.monotonic()
         return result
 
@@ -230,6 +249,12 @@ class _TelegramPollWatchdog:
         old.shutdown(wait=False)
 
     def _shutdown_watchdog(self) -> None:
+        active = self._active_poll
+        if active is not None and not active.done():
+            try:
+                self._adapter.recycle()
+            except Exception as e:
+                _log(f"{self._watchdog_label}: stop-time adapter recycle failed: {e}")
         self._poll_executor.shutdown(wait=False)
 
     @property
@@ -268,6 +293,7 @@ class TelegramPoller(_TelegramPollWatchdog):
         self._event_callback = event_callback  # async fn(platform, chat_id, sender, content)
         self._running = False
         self._accepting_deliveries = True
+        self._stop_event = asyncio.Event()
         self._poll_count = 0
         self._init_watchdog("telegram-poller", watchdog_grace)
 
@@ -275,6 +301,7 @@ class TelegramPoller(_TelegramPollWatchdog):
         """Start the polling loop."""
         self._running = True
         self._accepting_deliveries = True
+        self._stop_event.clear()
         _log("telegram-poller: starting")
 
         # Verify bot connection — on the poller's executor, under a deadline,
@@ -295,12 +322,12 @@ class TelegramPoller(_TelegramPollWatchdog):
                 await self._poll_once()
             except TelegramError as e:
                 _log(f"telegram-poller: error: {e}")
-                await asyncio.sleep(5)  # Back off on error
+                await _sleep_until_stopped(self._stop_event, 5)
             except Exception as e:
                 _log(f"telegram-poller: unexpected error: {e}")
-                await asyncio.sleep(5)
+                await _sleep_until_stopped(self._stop_event, 5)
 
-            await asyncio.sleep(self._poll_interval)
+            await _sleep_until_stopped(self._stop_event, self._poll_interval)
 
     async def _poll_once(self) -> None:
         """Single poll iteration."""
@@ -363,6 +390,7 @@ class TelegramPoller(_TelegramPollWatchdog):
         """Stop the polling loop."""
         self._running = False
         self._accepting_deliveries = False
+        self._stop_event.set()
         self._shutdown_watchdog()
         _log("telegram-poller: stopping")
 
@@ -408,6 +436,7 @@ class BrokerTelegramPoller(_TelegramPollWatchdog):
         self._event_callback = event_callback
         self._running = False
         self._accepting_deliveries = True
+        self._stop_event = asyncio.Event()
         self._poll_count = 0
         self._bot_username = ""
         self._init_watchdog(f"broker-poller[{agent_name}]", watchdog_grace)
@@ -416,6 +445,7 @@ class BrokerTelegramPoller(_TelegramPollWatchdog):
         """Start the polling loop."""
         self._running = True
         self._accepting_deliveries = True
+        self._stop_event.clear()
         _log(f"broker-poller[{self._agent_name}]: starting")
 
         # On the poller's executor, under a deadline — a wedged network can't
@@ -437,12 +467,12 @@ class BrokerTelegramPoller(_TelegramPollWatchdog):
                 await self._poll_once()
             except TelegramError as e:
                 _log(f"broker-poller[{self._agent_name}]: error: {e}")
-                await asyncio.sleep(5)
+                await _sleep_until_stopped(self._stop_event, 5)
             except Exception as e:
                 _log(f"broker-poller[{self._agent_name}]: unexpected error: {e}")
-                await asyncio.sleep(5)
+                await _sleep_until_stopped(self._stop_event, 5)
 
-            await asyncio.sleep(self._poll_interval)
+            await _sleep_until_stopped(self._stop_event, self._poll_interval)
 
     async def _poll_once(self) -> None:
         """Single poll iteration — routes messages through broker."""
@@ -520,6 +550,7 @@ class BrokerTelegramPoller(_TelegramPollWatchdog):
         """Stop the polling loop."""
         self._running = False
         self._accepting_deliveries = False
+        self._stop_event.set()
         self._shutdown_watchdog()
         _log(f"broker-poller[{self._agent_name}]: stopping")
 
@@ -562,12 +593,14 @@ class BrokeriMessagePoller:
         self._event_callback = event_callback
         self._running = False
         self._accepting_deliveries = True
+        self._stop_event = asyncio.Event()
         self._poll_count = 0
 
     async def start(self) -> None:
         """Start the polling loop."""
         self._running = True
         self._accepting_deliveries = True
+        self._stop_event.clear()
         _log(f"imessage-poller[{self._agent_name}]: starting")
 
         if not self._adapter.can_receive:
@@ -578,7 +611,7 @@ class BrokeriMessagePoller:
             _log(f"imessage-poller[{self._agent_name}]: send-only mode (no inbound)")
             # Don't return — keep running so outbound still works
             while self._running:
-                await asyncio.sleep(self._poll_interval)
+                await _sleep_until_stopped(self._stop_event, self._poll_interval)
             return
 
         _log(f"imessage-poller[{self._agent_name}]: chat.db connected, polling")
@@ -588,9 +621,9 @@ class BrokeriMessagePoller:
                 await self._poll_once()
             except Exception as e:
                 _log(f"imessage-poller[{self._agent_name}]: error: {e}")
-                await asyncio.sleep(5)
+                await _sleep_until_stopped(self._stop_event, 5)
 
-            await asyncio.sleep(self._poll_interval)
+            await _sleep_until_stopped(self._stop_event, self._poll_interval)
 
     async def _poll_once(self) -> None:
         """Single poll iteration."""
@@ -648,6 +681,7 @@ class BrokeriMessagePoller:
     def stop(self) -> None:
         self._running = False
         self._accepting_deliveries = False
+        self._stop_event.set()
         _log(f"imessage-poller[{self._agent_name}]: stopping")
 
     @property
@@ -709,6 +743,7 @@ class BrokerDiscordPoller:
         self._event_callback = event_callback
         self._running = False
         self._accepting_deliveries = True
+        self._stop_event = asyncio.Event()
         self._poll_count = 0
         self._bot_user_id = ""
         self._bot_username = ""
@@ -741,6 +776,7 @@ class BrokerDiscordPoller:
         """Start the polling loop."""
         self._running = True
         self._accepting_deliveries = True
+        self._stop_event.clear()
         _log(f"discord-poller[{self._agent_name}]: starting")
 
         # Verify bot connection
@@ -776,15 +812,18 @@ class BrokerDiscordPoller:
                     f"discord-poller[{self._agent_name}]: rate limited, "
                     f"sleeping {e.retry_after:.2f}s"
                 )
-                await asyncio.sleep(min(e.retry_after, 30.0))
+                await _sleep_until_stopped(
+                    self._stop_event,
+                    min(e.retry_after, 30.0),
+                )
             except DiscordError as e:
                 _log(f"discord-poller[{self._agent_name}]: error: {e}")
-                await asyncio.sleep(5)
+                await _sleep_until_stopped(self._stop_event, 5)
             except Exception as e:
                 _log(f"discord-poller[{self._agent_name}]: unexpected error: {e}")
-                await asyncio.sleep(5)
+                await _sleep_until_stopped(self._stop_event, 5)
 
-            await asyncio.sleep(self._poll_interval)
+            await _sleep_until_stopped(self._stop_event, self._poll_interval)
 
     async def _refresh_channels(self, *, verbose: bool) -> None:
         """Refresh the watched-channel set and prime last_id for newcomers.
@@ -1025,6 +1064,7 @@ class BrokerDiscordPoller:
         """Stop the polling loop."""
         self._running = False
         self._accepting_deliveries = False
+        self._stop_event.set()
         _log(f"discord-poller[{self._agent_name}]: stopping")
 
 

--- a/src/pinky_daemon/pollers.py
+++ b/src/pinky_daemon/pollers.py
@@ -292,6 +292,7 @@ class TelegramPoller(_TelegramPollWatchdog):
         self._allowed_chats = set(allowed_chat_ids) if allowed_chat_ids else None
         self._event_callback = event_callback  # async fn(platform, chat_id, sender, content)
         self._running = False
+        self._stop_requested = False
         self._accepting_deliveries = True
         self._stop_event = asyncio.Event()
         self._poll_count = 0
@@ -299,6 +300,9 @@ class TelegramPoller(_TelegramPollWatchdog):
 
     async def start(self) -> None:
         """Start the polling loop."""
+        if self._stop_requested:
+            _log("telegram-poller: start suppressed after stop")
+            return
         self._running = True
         self._accepting_deliveries = True
         self._stop_event.clear()
@@ -388,6 +392,7 @@ class TelegramPoller(_TelegramPollWatchdog):
 
     def stop(self) -> None:
         """Stop the polling loop."""
+        self._stop_requested = True
         self._running = False
         self._accepting_deliveries = False
         self._stop_event.set()
@@ -435,6 +440,7 @@ class BrokerTelegramPoller(_TelegramPollWatchdog):
         self._poll_interval = poll_interval
         self._event_callback = event_callback
         self._running = False
+        self._stop_requested = False
         self._accepting_deliveries = True
         self._stop_event = asyncio.Event()
         self._poll_count = 0
@@ -443,6 +449,9 @@ class BrokerTelegramPoller(_TelegramPollWatchdog):
 
     async def start(self) -> None:
         """Start the polling loop."""
+        if self._stop_requested:
+            _log(f"broker-poller[{self._agent_name}]: start suppressed after stop")
+            return
         self._running = True
         self._accepting_deliveries = True
         self._stop_event.clear()
@@ -548,6 +557,7 @@ class BrokerTelegramPoller(_TelegramPollWatchdog):
 
     def stop(self) -> None:
         """Stop the polling loop."""
+        self._stop_requested = True
         self._running = False
         self._accepting_deliveries = False
         self._stop_event.set()
@@ -592,12 +602,16 @@ class BrokeriMessagePoller:
         self._poll_interval = poll_interval
         self._event_callback = event_callback
         self._running = False
+        self._stop_requested = False
         self._accepting_deliveries = True
         self._stop_event = asyncio.Event()
         self._poll_count = 0
 
     async def start(self) -> None:
         """Start the polling loop."""
+        if self._stop_requested:
+            _log(f"imessage-poller[{self._agent_name}]: start suppressed after stop")
+            return
         self._running = True
         self._accepting_deliveries = True
         self._stop_event.clear()
@@ -679,6 +693,7 @@ class BrokeriMessagePoller:
                     _log(f"imessage-poller[{self._agent_name}]: event callback error: {e}")
 
     def stop(self) -> None:
+        self._stop_requested = True
         self._running = False
         self._accepting_deliveries = False
         self._stop_event.set()
@@ -742,6 +757,7 @@ class BrokerDiscordPoller:
         self._configured_channels = list(watched_channels or [])
         self._event_callback = event_callback
         self._running = False
+        self._stop_requested = False
         self._accepting_deliveries = True
         self._stop_event = asyncio.Event()
         self._poll_count = 0
@@ -774,6 +790,9 @@ class BrokerDiscordPoller:
 
     async def start(self) -> None:
         """Start the polling loop."""
+        if self._stop_requested:
+            _log(f"discord-poller[{self._agent_name}]: start suppressed after stop")
+            return
         self._running = True
         self._accepting_deliveries = True
         self._stop_event.clear()
@@ -1062,6 +1081,7 @@ class BrokerDiscordPoller:
 
     def stop(self) -> None:
         """Stop the polling loop."""
+        self._stop_requested = True
         self._running = False
         self._accepting_deliveries = False
         self._stop_event.set()
@@ -1171,6 +1191,7 @@ class BrokerSlackPoller:
         self._app_token = app_token
         self._event_callback = event_callback
         self._running = False
+        self._stop_requested = False
         self._accepting_deliveries = True
         self._bot_user_id = ""
         self._bot_id = ""  # our own bot_id (from auth.test) — filters our bot_message echoes
@@ -1199,6 +1220,9 @@ class BrokerSlackPoller:
         background tasks, then returns — the connection stays alive as long as
         this poller (and thus ``self._client``) is referenced by the daemon.
         """
+        if self._stop_requested:
+            _log(f"slack-poller[{self._agent_name}]: start suppressed after stop")
+            return
         if self._running:
             _log(f"slack-poller[{self._agent_name}]: already running, ignoring start()")
             return
@@ -1223,6 +1247,9 @@ class BrokerSlackPoller:
         except Exception as e:
             _log(f"slack-poller[{self._agent_name}]: auth.test failed: {e}")
             return
+        if self._stop_requested:
+            _log(f"slack-poller[{self._agent_name}]: startup stopped before connect")
+            return
         self._bot_user_id = info.get("user_id", "") or ""
         if not self._bot_user_id:
             # Fail closed: without our own user id the self-filter is disarmed
@@ -1245,6 +1272,18 @@ class BrokerSlackPoller:
         )
         self._client = client
 
+        async def _run_admitted_request(req_type: str, payload: dict) -> None:
+            try:
+                if req_type == "interactive":
+                    await self._handle_interactive(payload, _admitted=True)
+                else:
+                    await self._handle_event(payload, _admitted=True)
+            except Exception as e:
+                _log(
+                    f"slack-poller[{self._agent_name}]: handle_{req_type} "
+                    f"error: {e!r}"
+                )
+
         async def _on_request(smc, req) -> None:
             # ACK FIRST — every Socket Mode request envelope (events_api,
             # slash_commands, interactive, …) carries an envelope_id and must be
@@ -1258,15 +1297,25 @@ class BrokerSlackPoller:
                     )
                 except Exception as e:
                     _log(f"slack-poller[{self._agent_name}]: ack failed: {e}")
-            # Interactive envelopes (block_actions button clicks) carry the
-            # purchase Approve/Reject buttons (#249). Handle them here; every
-            # other non-events_api envelope is dropped (already acked) so Slack
-            # doesn't keep retrying.
-            if req.type == "interactive":
-                try:
-                    await self._handle_interactive(req.payload or {})
-                except Exception as e:
-                    _log(f"slack-poller[{self._agent_name}]: handle_interactive error: {e!r}")
+            # After the prompt ACK, atomically fence or transfer the whole
+            # request into the delivery-task set. slack_sdk does not retain its
+            # own listener tasks, so this tracked child is the publication
+            # barrier for both message and interactive paths.
+            if req.type in ("interactive", "events_api"):
+                if not self._accepting_deliveries:
+                    _log(
+                        f"slack-poller[{self._agent_name}]: dropping {req.type} "
+                        "envelope after stop"
+                    )
+                    return
+                admitted = _deliver_in_background(
+                    _run_admitted_request(req.type, req.payload or {}),
+                    f"slack-poller[{self._agent_name}] {req.type} listener",
+                )
+                # Preserve the listener's existing completion contract for
+                # callers while shielding the retained child from SDK task
+                # cancellation during close(). The ACK already completed.
+                await asyncio.shield(admitted)
                 return
             # Only message events are wired up for #224; other (already-acked)
             # envelope types are dropped so Slack doesn't keep retrying them.
@@ -1277,10 +1326,6 @@ class BrokerSlackPoller:
                         f"envelope ({req.type})"
                     )
                 return
-            try:
-                await self._handle_event(req.payload or {})
-            except Exception as e:
-                _log(f"slack-poller[{self._agent_name}]: handle_event error: {e!r}")
 
         client.socket_mode_request_listeners.append(_on_request)
 
@@ -1288,12 +1333,18 @@ class BrokerSlackPoller:
         self._accepting_deliveries = True
         try:
             await client.connect()
-            _log(f"slack-poller[{self._agent_name}]: socket mode connected, listening")
+            if not self._stop_requested:
+                _log(f"slack-poller[{self._agent_name}]: socket mode connected, listening")
         except Exception as e:
             _log(f"slack-poller[{self._agent_name}]: connect failed: {e}")
             self._running = False
 
-    async def _handle_interactive(self, payload: dict) -> None:
+    async def _handle_interactive(
+        self,
+        payload: dict,
+        *,
+        _admitted: bool = False,
+    ) -> None:
         """Handle a Slack interactive (block_actions) envelope — purchase buttons (#249).
 
         SECURITY (financial boundary): the approver identity is taken from
@@ -1303,6 +1354,9 @@ class BrokerSlackPoller:
         here and never reach the agent. The agent is told to act ONLY after this
         gate passes, so the LLM is not the security boundary.
         """
+        if not _admitted and not self._accepting_deliveries:
+            _log(f"slack-poller[{self._agent_name}]: dropping interactive after stop")
+            return
         if (payload or {}).get("type") != "block_actions":
             return
         actions = payload.get("actions") or []
@@ -1573,8 +1627,14 @@ class BrokerSlackPoller:
             channel_namer=self._resolve_channel_title,
         )
 
-    async def _handle_event(self, payload: dict) -> None:
-        if not self._accepting_deliveries:
+    async def _handle_event(
+        self,
+        payload: dict,
+        *,
+        _admitted: bool = False,
+    ) -> None:
+        if not _admitted and not self._accepting_deliveries:
+            _log(f"slack-poller[{self._agent_name}]: dropping events_api after stop")
             return
         event = (payload or {}).get("event") or {}
         if event.get("type") != "message":
@@ -1623,6 +1683,13 @@ class BrokerSlackPoller:
                 sender_name = resolved
         chat_title = await self._resolve_channel_title(channel)
         text = await self._resolve_text_refs(text)
+
+        if not _admitted and not self._accepting_deliveries:
+            _log(
+                f"slack-poller[{self._agent_name}]: dropping message after stop "
+                "before broker publication"
+            )
+            return
 
         attachments = [
             {
@@ -1687,6 +1754,7 @@ class BrokerSlackPoller:
         task is strongly referenced (not GC'd mid-flight) and any close error is
         logged rather than silently dropped.
         """
+        self._stop_requested = True
         self._running = False
         self._accepting_deliveries = False
         _log(f"slack-poller[{self._agent_name}]: stopping")

--- a/src/pinky_daemon/presentation_store.py
+++ b/src/pinky_daemon/presentation_store.py
@@ -23,7 +23,12 @@ import time
 from dataclasses import dataclass
 from pathlib import Path
 
-from pinky_daemon.store_catalog import StoreCatalog
+from pinky_daemon.store_catalog import (
+    StoreCatalog,
+    apply_store_connection_policy,
+    open_store_connection,
+    store_connection_policy,
+)
 
 
 def _log(msg: str) -> None:
@@ -144,11 +149,19 @@ class PresentationStore:
         """Return the calling thread's connection, creating it on first use."""
         connection = getattr(self._thread_local, "connection", None)
         if connection is None:
-            connection = sqlite3.connect(self._db_path)
+            connection = open_store_connection(
+                self._catalog,
+                "presentations",
+                self._db_path,
+                owner=type(self).__name__,
+            )
             journal_mode = str(
                 connection.execute("PRAGMA journal_mode=WAL").fetchone()[0]
             ).lower()
-            connection.execute("PRAGMA busy_timeout=30000")
+            apply_store_connection_policy(
+                connection,
+                store_connection_policy(self._catalog, "presentations"),
+            )
             connection.execute("PRAGMA foreign_keys=ON")
             if self._catalog is not None:
                 self._catalog.register(

--- a/src/pinky_daemon/research_store.py
+++ b/src/pinky_daemon/research_store.py
@@ -23,7 +23,12 @@ import time
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from pinky_daemon.store_catalog import StoreCatalog
+from pinky_daemon.store_catalog import (
+    StoreCatalog,
+    apply_store_connection_policy,
+    open_store_connection,
+    store_connection_policy,
+)
 
 
 def _log(msg: str) -> None:
@@ -154,11 +159,19 @@ class ResearchStore:
         """Return the calling thread's connection, creating it on first use."""
         connection = getattr(self._thread_local, "connection", None)
         if connection is None:
-            connection = sqlite3.connect(self._db_path)
+            connection = open_store_connection(
+                self._catalog,
+                "research",
+                self._db_path,
+                owner=type(self).__name__,
+            )
             journal_mode = str(
                 connection.execute("PRAGMA journal_mode=WAL").fetchone()[0]
             ).lower()
-            connection.execute("PRAGMA busy_timeout=30000")
+            apply_store_connection_policy(
+                connection,
+                store_connection_policy(self._catalog, "research"),
+            )
             connection.execute("PRAGMA foreign_keys=ON")
             if self._catalog is not None:
                 self._catalog.register(

--- a/src/pinky_daemon/session_store.py
+++ b/src/pinky_daemon/session_store.py
@@ -20,7 +20,12 @@ import time
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from pinky_daemon.store_catalog import StoreCatalog
+from pinky_daemon.store_catalog import (
+    StoreCatalog,
+    apply_store_connection_policy,
+    open_store_connection,
+    store_connection_policy,
+)
 
 SESSION_DB_OWNER = "SessionStore+SessionEventStore"
 
@@ -80,11 +85,19 @@ class SessionStore:
         """Return the calling thread's connection, creating it on first use."""
         connection = getattr(self._thread_local, "connection", None)
         if connection is None:
-            connection = sqlite3.connect(self._db_path)
+            connection = open_store_connection(
+                self._catalog,
+                "sessions",
+                self._db_path,
+                owner=SESSION_DB_OWNER,
+            )
             journal_mode = str(
                 connection.execute("PRAGMA journal_mode=WAL").fetchone()[0]
             ).lower()
-            connection.execute("PRAGMA busy_timeout=30000")
+            apply_store_connection_policy(
+                connection,
+                store_connection_policy(self._catalog, "sessions"),
+            )
             if self._catalog is not None:
                 self._catalog.register(
                     "sessions",
@@ -338,11 +351,19 @@ class SessionEventStore:
         """Return the calling thread's connection, creating it on first use."""
         connection = getattr(self._thread_local, "connection", None)
         if connection is None:
-            connection = sqlite3.connect(self._db_path)
+            connection = open_store_connection(
+                self._catalog,
+                "session_events",
+                self._db_path,
+                owner=SESSION_DB_OWNER,
+            )
             journal_mode = str(
                 connection.execute("PRAGMA journal_mode=WAL").fetchone()[0]
             ).lower()
-            connection.execute("PRAGMA busy_timeout=30000")
+            apply_store_connection_policy(
+                connection,
+                store_connection_policy(self._catalog, "session_events"),
+            )
             if self._catalog is not None:
                 self._catalog.register(
                     "session_events",

--- a/src/pinky_daemon/skill_store.py
+++ b/src/pinky_daemon/skill_store.py
@@ -29,7 +29,12 @@ from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
 
-from pinky_daemon.store_catalog import StoreCatalog
+from pinky_daemon.store_catalog import (
+    StoreCatalog,
+    apply_store_connection_policy,
+    open_store_connection,
+    store_connection_policy,
+)
 
 
 def _log(msg: str) -> None:
@@ -160,11 +165,19 @@ class SkillStore:
         """Return the calling thread's connection, creating it on first use."""
         connection = getattr(self._thread_local, "connection", None)
         if connection is None:
-            connection = sqlite3.connect(self._db_path)
+            connection = open_store_connection(
+                self._catalog,
+                "skills",
+                self._db_path,
+                owner=type(self).__name__,
+            )
             journal_mode = str(
                 connection.execute("PRAGMA journal_mode=WAL").fetchone()[0]
             ).lower()
-            connection.execute("PRAGMA busy_timeout=30000")
+            apply_store_connection_policy(
+                connection,
+                store_connection_policy(self._catalog, "skills"),
+            )
             connection.execute("PRAGMA foreign_keys=ON")
             if self._catalog is not None:
                 self._catalog.register(

--- a/src/pinky_daemon/store_catalog.py
+++ b/src/pinky_daemon/store_catalog.py
@@ -290,7 +290,15 @@ class StoreIntegrityTarget:
     criticality: str = "authoritative"
     recovery: str = "snapshot"
     journal_mode: str | None = None
-    connection_policy: StoreConnectionPolicy = field(default_factory=StoreConnectionPolicy)
+    connection_policy: StoreConnectionPolicy | None = None
+
+    def __post_init__(self) -> None:
+        if self.connection_policy is None:
+            object.__setattr__(
+                self,
+                "connection_policy",
+                default_store_connection_policy(self.logical_name),
+            )
 
 
 class StoreCatalogError(RuntimeError):
@@ -371,6 +379,11 @@ class _StoreConnectionAuthority:
                     f"store connection opened after shutdown began: {logical_name!r}"
                 )
             connection = sqlite3.connect(database, **kwargs)
+            try:
+                apply_store_connection_policy(connection, policy)
+            except BaseException:
+                connection.close()
+                raise
             handle_id = self._next_handle_id
             self._next_handle_id += 1
             target = self._catalog.manifest_target(logical_name)
@@ -440,8 +453,22 @@ class _StoreConnectionAuthority:
             except BaseException as exc:
                 errors.append(exc)
         if errors:
+            already_closed = (
+                connection._store_authority is None
+                and connection._store_handle_id is None
+                and all(_is_closed_database_error(exc) for exc in errors)
+            )
+            if already_closed:
+                return
             details = "; ".join(f"{type(exc).__name__}: {exc}" for exc in errors)
             raise RuntimeError(details)
+
+
+def _is_closed_database_error(exc: BaseException) -> bool:
+    return (
+        isinstance(exc, sqlite3.ProgrammingError)
+        and str(exc) == "Cannot operate on a closed database."
+    )
 
 
 @dataclass(slots=True)
@@ -1748,4 +1775,10 @@ def open_store_connection(
     kwargs["timeout"] = (
         _SQLITE_DEFAULT_TIMEOUT_SECONDS if requested_timeout is None else float(requested_timeout)
     )
-    return sqlite3.connect(database, **kwargs)
+    connection = sqlite3.connect(database, **kwargs)
+    try:
+        apply_store_connection_policy(connection, policy)
+    except BaseException:
+        connection.close()
+        raise
+    return connection

--- a/src/pinky_daemon/store_catalog.py
+++ b/src/pinky_daemon/store_catalog.py
@@ -12,11 +12,43 @@ import stat
 import sys
 import threading
 from collections.abc import Callable, Iterable, Mapping
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Any
 from urllib.parse import parse_qsl
 
+from pinky_daemon.store_shutdown import StoreShutdownCoordinator, StoreShutdownReport
+
 logger = logging.getLogger("pinky.store_catalog")
+
+_THIRTY_SECOND_BUSY_STORES = frozenset(
+    {
+        "sessions",
+        "session_events",
+        "conversations",
+        "audit",
+        "agent_comms",
+        "activity",
+        "dream_state",
+        "skills",
+        "outreach_config",
+        "tasks",
+        "research",
+        "presentations",
+        "triggers",
+        "voice",
+        "user_profiles",
+    }
+)
+_CRITICALITY_RANK = {
+    "telemetry": 0,
+    "derived": 0,
+    "memory": 1,
+    "authority": 2,
+    "authoritative": 2,
+    "delivery": 3,
+}
+_SQLITE_DEFAULT_TIMEOUT_SECONDS = 5.0
 
 
 DEFAULT_FILESYSTEM_SILENCE_ALLOWLIST: dict[str, str] = {
@@ -220,6 +252,21 @@ def sqlite_header_journal_mode(path: str | os.PathLike[str]) -> str | None:
 
 
 @dataclass(frozen=True, slots=True)
+class StoreConnectionPolicy:
+    """One logical store's centrally declared SQLite open/retry policy."""
+
+    busy_timeout_ms: int = 5_000
+    rollback_retries: int = 6
+    rollback_retry_delay_seconds: float = 0.2
+
+
+def default_store_connection_policy(logical_name: str) -> StoreConnectionPolicy:
+    """Return the behavior-preserving policy for a logical daemon store."""
+    busy_timeout_ms = 30_000 if logical_name in _THIRTY_SECOND_BUSY_STORES else 5_000
+    return StoreConnectionPolicy(busy_timeout_ms=busy_timeout_ms)
+
+
+@dataclass(frozen=True, slots=True)
 class StoreRecord:
     """One logical store's observed physical SQLite identity."""
 
@@ -230,6 +277,8 @@ class StoreRecord:
     criticality: str
     dev_ino: tuple[int, int] | None
     is_memory: bool
+    recovery: str = "snapshot"
+    connection_policy: StoreConnectionPolicy = field(default_factory=StoreConnectionPolicy)
 
 
 @dataclass(frozen=True, slots=True)
@@ -241,10 +290,158 @@ class StoreIntegrityTarget:
     criticality: str = "authoritative"
     recovery: str = "snapshot"
     journal_mode: str | None = None
+    connection_policy: StoreConnectionPolicy = field(default_factory=StoreConnectionPolicy)
 
 
 class StoreCatalogError(RuntimeError):
     """Raised when the daemon's store layout is unsafe or incoherent."""
+
+
+class _ManagedSQLiteConnection(sqlite3.Connection):
+    """Connection subclass that removes itself from the live-handle ledger."""
+
+    _store_authority: _StoreConnectionAuthority | None = None
+    _store_handle_id: int | None = None
+
+    def close(self) -> None:
+        super().close()
+        authority = self._store_authority
+        handle_id = self._store_handle_id
+        if authority is not None and handle_id is not None:
+            authority._forget(handle_id)
+            self._store_authority = None
+            self._store_handle_id = None
+
+
+@dataclass(slots=True)
+class _ManagedConnection:
+    handle_id: int
+    logical_name: str
+    path: str
+    owner: str
+    connection: _ManagedSQLiteConnection
+    sequence: int
+    journal_mode: str | None
+
+
+class _StoreConnectionAuthority:
+    """Open and retain every live catalog-owned SQLite connection."""
+
+    def __init__(self, catalog: StoreCatalog) -> None:
+        self._catalog = catalog
+        self._lock = threading.RLock()
+        self._handles: dict[int, _ManagedConnection] = {}
+        self._next_handle_id = 1
+        self._accepting = True
+
+    def open(
+        self,
+        logical_name: str,
+        database: Any,
+        *,
+        owner: str,
+        **kwargs: Any,
+    ) -> sqlite3.Connection:
+        policy = self._catalog.connection_policy(logical_name)
+        requested_timeout = kwargs.pop("timeout", None)
+        timeout_seconds = policy.busy_timeout_ms / 1_000
+        if requested_timeout is not None and float(requested_timeout) != timeout_seconds:
+            raise StoreCatalogError(
+                "connection timeout override diverges from catalog policy: "
+                f"logical_store={logical_name!r} requested={requested_timeout!r} "
+                f"declared={timeout_seconds!r}"
+            )
+        if "factory" in kwargs:
+            raise StoreCatalogError("catalog-owned store connections cannot override the factory")
+
+        # Catalog-owned handles must be finalizable by the single shutdown
+        # coordinator after request worker threads have quiesced. Stores retain
+        # their existing thread-local access discipline; only the sqlite runtime
+        # affinity check is relaxed for central close.
+        kwargs["check_same_thread"] = False
+        kwargs["timeout"] = (
+            _SQLITE_DEFAULT_TIMEOUT_SECONDS
+            if requested_timeout is None
+            else float(requested_timeout)
+        )
+        kwargs["factory"] = _ManagedSQLiteConnection
+        with self._lock:
+            if not self._accepting:
+                raise StoreCatalogError(
+                    f"store connection opened after shutdown began: {logical_name!r}"
+                )
+            connection = sqlite3.connect(database, **kwargs)
+            handle_id = self._next_handle_id
+            self._next_handle_id += 1
+            target = self._catalog.manifest_target(logical_name)
+            path = os.path.realpath(os.fspath(target.path if target is not None else database))
+            handle = _ManagedConnection(
+                handle_id=handle_id,
+                logical_name=logical_name,
+                path=path,
+                owner=owner,
+                connection=connection,
+                sequence=handle_id,
+                journal_mode=None if target is None else target.journal_mode,
+            )
+            connection._store_authority = self
+            connection._store_handle_id = handle_id
+            self._handles[handle_id] = handle
+            return connection
+
+    def update_registration(self, record: StoreRecord) -> None:
+        with self._lock:
+            for handle in self._handles.values():
+                if (
+                    handle.logical_name == record.logical_name
+                    and handle.path == record.resolved_path
+                    and handle.owner == record.owner
+                ):
+                    handle.journal_mode = record.journal_mode
+
+    def _forget(self, handle_id: int) -> None:
+        with self._lock:
+            self._handles.pop(handle_id, None)
+
+    def shutdown(self, *, deadline_seconds: float) -> StoreShutdownReport:
+        with self._lock:
+            self._accepting = False
+            handles = sorted(self._handles.values(), key=lambda handle: handle.sequence)
+        coordinator = StoreShutdownCoordinator(deadline_seconds=deadline_seconds)
+        for handle in handles:
+            coordinator.register(
+                handle.logical_name,
+                self._catalog.effective_criticality(handle.logical_name),
+                lambda handle=handle: self._finalize(handle),
+            )
+        return coordinator.shutdown()
+
+    @staticmethod
+    def _finalize(handle: _ManagedConnection) -> None:
+        connection = handle.connection
+        errors: list[BaseException] = []
+        try:
+            connection.commit()
+            journal_mode = handle.journal_mode
+            if journal_mode is None:
+                row = connection.execute("PRAGMA journal_mode").fetchone()
+                journal_mode = str(row[0]).lower() if row else None
+            if journal_mode == "wal":
+                checkpoint = connection.execute("PRAGMA wal_checkpoint(TRUNCATE)").fetchone()
+                if checkpoint and int(checkpoint[0]):
+                    raise sqlite3.OperationalError(
+                        "WAL checkpoint remained busy during store finalization"
+                    )
+        except BaseException as exc:
+            errors.append(exc)
+        finally:
+            try:
+                connection.close()
+            except BaseException as exc:
+                errors.append(exc)
+        if errors:
+            details = "; ".join(f"{type(exc).__name__}: {exc}" for exc in errors)
+            raise RuntimeError(details)
 
 
 @dataclass(slots=True)
@@ -304,6 +501,7 @@ class StoreCatalog:
         expected_root: str | os.PathLike[str] | None = None,
         *,
         silence_allowlist: Mapping[str, str] | None = None,
+        manifest: Mapping[str, StoreIntegrityTarget] | None = None,
     ) -> None:
         root = os.getcwd() if expected_root is None else os.fspath(expected_root)
         self._expected_root = os.path.realpath(root)
@@ -311,14 +509,85 @@ class StoreCatalog:
             DEFAULT_FILESYSTEM_SILENCE_ALLOWLIST if silence_allowlist is None else silence_allowlist
         )
         self._silence_allowlist = dict(configured_allowlist)
+        self._manifest = dict(manifest or {})
         self._entries: list[_CatalogEntry] = []
         self._observations: list[StoreObservation] = []
         self._lock = threading.RLock()
+        self._connection_authority = _StoreConnectionAuthority(self)
 
     @property
     def expected_root(self) -> str:
         """Return the canonical filesystem root this catalog governs."""
         return self._expected_root
+
+    def manifest_target(self, logical_name: str) -> StoreIntegrityTarget | None:
+        """Return the declared target for one logical store, if configured."""
+        return self._manifest.get(logical_name)
+
+    def configure_manifest(
+        self,
+        manifest: Mapping[str, StoreIntegrityTarget],
+    ) -> None:
+        """Attach the boot manifest before any constructor registers a store."""
+        with self._lock:
+            if self._entries:
+                raise StoreCatalogError("store manifest cannot change after registration")
+            self._manifest = dict(manifest)
+
+    def connection_policy(self, logical_name: str) -> StoreConnectionPolicy:
+        """Return the catalog-declared connection policy for one store."""
+        target = self.manifest_target(logical_name)
+        if target is not None:
+            return target.connection_policy
+        return default_store_connection_policy(logical_name)
+
+    def effective_criticality(self, logical_name: str) -> str:
+        """Return physical-cohort criticality using the strongest declaration."""
+        target = self.manifest_target(logical_name)
+        if target is not None:
+            target_path = os.path.realpath(os.fspath(target.path))
+            cohort = [
+                candidate.criticality
+                for candidate in self._manifest.values()
+                if os.path.realpath(os.fspath(candidate.path)) == target_path
+            ]
+            return max(cohort, key=lambda criticality: _CRITICALITY_RANK[criticality])
+        with self._lock:
+            records = [
+                entry.record for entry in self._entries if entry.record.logical_name == logical_name
+            ]
+        if not records:
+            return "authority"
+        record = records[-1]
+        cohort = []
+        with self._lock:
+            for entry in self._entries:
+                if entry.record.resolved_path == record.resolved_path:
+                    cohort.append(entry.record.criticality)
+        return max(cohort, key=lambda criticality: _CRITICALITY_RANK[criticality])
+
+    def open_connection(
+        self,
+        logical_name: str,
+        database: Any,
+        *,
+        owner: str,
+        **kwargs: Any,
+    ) -> sqlite3.Connection:
+        """Open and track one connection under the catalog's declared policy."""
+        return self._connection_authority.open(
+            logical_name,
+            database,
+            owner=owner,
+            **kwargs,
+        )
+
+    def shutdown(self, *, deadline_seconds: float) -> StoreShutdownReport:
+        """Finalize every tracked connection, then release preflight descriptors."""
+        try:
+            return self._connection_authority.shutdown(deadline_seconds=deadline_seconds)
+        finally:
+            self.close()
 
     def register(
         self,
@@ -327,7 +596,9 @@ class StoreCatalog:
         *,
         journal_mode: str,
         owner: str,
-        criticality: str = "authoritative",
+        criticality: str | None = None,
+        recovery: str | None = None,
+        connection_policy: StoreConnectionPolicy | None = None,
     ) -> None:
         """Record one store connection, canonicalized to physical path identity.
 
@@ -338,14 +609,26 @@ class StoreCatalog:
         raw_path = os.fspath(path)
         is_memory = self._is_memory_path(raw_path)
         resolved_path = os.path.realpath(raw_path)
+        target = self.manifest_target(logical_name)
+        declared_criticality = (
+            target.criticality if target is not None else criticality or "authoritative"
+        )
+        declared_recovery = target.recovery if target is not None else recovery or "snapshot"
+        declared_policy = (
+            target.connection_policy
+            if target is not None
+            else connection_policy or default_store_connection_policy(logical_name)
+        )
         record = StoreRecord(
             logical_name=logical_name,
             resolved_path=resolved_path,
             journal_mode=journal_mode.lower(),
             owner=owner,
-            criticality=criticality,
+            criticality=declared_criticality,
             dev_ino=None if is_memory else self._stat_identity(resolved_path),
             is_memory=is_memory,
+            recovery=declared_recovery,
+            connection_policy=declared_policy,
         )
         used_relative_path = not os.path.isabs(raw_path)
 
@@ -358,10 +641,13 @@ class StoreCatalog:
                     and current.resolved_path == record.resolved_path
                     and current.journal_mode == record.journal_mode
                     and current.criticality == record.criticality
+                    and current.recovery == record.recovery
+                    and current.connection_policy == record.connection_policy
                     and current.is_memory == record.is_memory
                 ):
                     entry.record = record
                     entry.used_relative_path = entry.used_relative_path or used_relative_path
+                    self._connection_authority.update_registration(record)
                     return
             self._entries.append(
                 _CatalogEntry(
@@ -369,6 +655,7 @@ class StoreCatalog:
                     used_relative_path=used_relative_path,
                 )
             )
+            self._connection_authority.update_registration(record)
 
     def register_observed(
         self,
@@ -408,6 +695,8 @@ class StoreCatalog:
                 criticality=target.criticality,
                 dev_ino=observation.dev_ino,
                 is_memory=False,
+                recovery=target.recovery,
+                connection_policy=target.connection_policy,
             )
             if any(
                 entry.record.logical_name == record.logical_name
@@ -427,6 +716,7 @@ class StoreCatalog:
                     observation=(observation if observation.dev_ino is not None else None),
                 )
             )
+            self._connection_authority.update_registration(record)
 
     def reserve(
         self,
@@ -435,7 +725,9 @@ class StoreCatalog:
         *,
         journal_mode: str,
         owner: str,
-        criticality: str = "authoritative",
+        criticality: str | None = None,
+        recovery: str | None = None,
+        connection_policy: StoreConnectionPolicy | None = None,
     ) -> StoreReservation:
         """Publish an absent store in the catalog before its exclusive create.
 
@@ -449,14 +741,23 @@ class StoreCatalog:
         if is_memory:
             raise StoreCatalogError("cannot reserve an in-memory store")
         absolute_path = os.path.abspath(raw_path)
+        target = self.manifest_target(logical_name)
         record = StoreRecord(
             logical_name=logical_name,
             resolved_path=absolute_path,
             journal_mode=journal_mode.lower(),
             owner=owner,
-            criticality=criticality,
+            criticality=(
+                target.criticality if target is not None else criticality or "authoritative"
+            ),
             dev_ino=self._stat_identity(absolute_path),
             is_memory=False,
+            recovery=target.recovery if target is not None else recovery or "snapshot",
+            connection_policy=(
+                target.connection_policy
+                if target is not None
+                else connection_policy or default_store_connection_policy(logical_name)
+            ),
         )
         entry = _CatalogEntry(
             record=record,
@@ -494,6 +795,8 @@ class StoreCatalog:
                 criticality=record.criticality,
                 dev_ino=dev_ino,
                 is_memory=False,
+                recovery=record.recovery,
+                connection_policy=record.connection_policy,
             )
             return entry.record
 
@@ -532,6 +835,8 @@ class StoreCatalog:
                 criticality=record.criticality,
                 dev_ino=observation.dev_ino,
                 is_memory=False,
+                recovery=record.recovery,
+                connection_policy=record.connection_policy,
             )
             self._observations.append(observation)
             return entry.record
@@ -565,6 +870,7 @@ class StoreCatalog:
             entries = list(self._entries)
 
         violations: list[str] = []
+        warnings: list[str] = []
         records = [entry.record for entry in entries]
 
         for entry in entries:
@@ -583,6 +889,8 @@ class StoreCatalog:
 
         records_by_logical_name: dict[str, list[StoreRecord]] = {}
         for record in records:
+            if record.criticality not in _CRITICALITY_RANK:
+                violations.append("unknown criticality on " + self._format_record(record))
             records_by_logical_name.setdefault(record.logical_name, []).append(record)
         for logical_name, matching_records in records_by_logical_name.items():
             if len({record.resolved_path for record in matching_records}) > 1:
@@ -612,12 +920,29 @@ class StoreCatalog:
                         "without a shared owner identity: " + pair
                     )
 
+        registered_logical_names = set(records_by_logical_name)
+        for logical_name in self._manifest:
+            if logical_name in registered_logical_names:
+                continue
+            effective_criticality = self.effective_criticality(logical_name)
+            absence = (
+                f"logical_store={logical_name!r} "
+                f"effective_criticality={effective_criticality!r} "
+                "post-construction catalog absence"
+            )
+            if effective_criticality == "telemetry":
+                warnings.append(f"degraded telemetry store: {absence}")
+            else:
+                violations.append(absence)
+
         if violations:
             raise StoreCatalogError(
                 "Store catalog validation failed:\n- " + "\n- ".join(violations)
             )
 
-        return self.reconcile_filesystem()
+        for warning in warnings:
+            logger.warning("STORE CATALOG WARNING: %s", warning)
+        return [*warnings, *self.reconcile_filesystem()]
 
     def preflight_integrity(
         self,
@@ -999,6 +1324,8 @@ class StoreCatalog:
                     criticality=record.criticality,
                     dev_ino=dev_ino,
                     is_memory=record.is_memory,
+                    recovery=record.recovery,
+                    connection_policy=record.connection_policy,
                 )
 
     def _enumerate_database_files(
@@ -1233,6 +1560,7 @@ class StoreCatalog:
         return (
             f"{record.logical_name!r} owner={record.owner!r} "
             f"path={record.resolved_path!r} journal_mode={record.journal_mode!r} "
+            f"criticality={record.criticality!r} recovery={record.recovery!r} "
             f"dev_ino={record.dev_ino!r} is_memory={record.is_memory!r}"
         )
 
@@ -1247,7 +1575,9 @@ class DaemonStoreCatalog(StoreCatalog):
         *,
         journal_mode: str,
         owner: str,
-        criticality: str = "authoritative",
+        criticality: str | None = None,
+        recovery: str | None = None,
+        connection_policy: StoreConnectionPolicy | None = None,
     ) -> None:
         """Allow a fleet authority constructor to fulfill a preflight absence."""
         raw_path = os.fspath(path)
@@ -1266,6 +1596,8 @@ class DaemonStoreCatalog(StoreCatalog):
             journal_mode=journal_mode,
             owner=owner,
             criticality=criticality,
+            recovery=recovery,
+            connection_policy=connection_policy,
         )
         if fulfilled_absences:
             with self._lock:
@@ -1372,3 +1704,48 @@ class DaemonStoreCatalog(StoreCatalog):
                 continue
             identities[descriptor] = (descriptor_stat.st_dev, descriptor_stat.st_ino)
         return identities
+
+
+def store_connection_policy(
+    catalog: StoreCatalog | None,
+    logical_name: str,
+) -> StoreConnectionPolicy:
+    """Resolve one store's policy with or without a boot catalog."""
+    if catalog is not None:
+        return catalog.connection_policy(logical_name)
+    return default_store_connection_policy(logical_name)
+
+
+def apply_store_connection_policy(
+    connection: sqlite3.Connection,
+    policy: StoreConnectionPolicy,
+) -> None:
+    """Apply a declared post-open policy without changing journal mode."""
+    connection.execute(f"PRAGMA busy_timeout={int(policy.busy_timeout_ms)}")
+
+
+def open_store_connection(
+    catalog: StoreCatalog | None,
+    logical_name: str,
+    database: Any,
+    *,
+    owner: str,
+    **kwargs: Any,
+) -> sqlite3.Connection:
+    """Route every owner-side SQLite open through the central policy seam."""
+    if catalog is not None:
+        return catalog.open_connection(logical_name, database, owner=owner, **kwargs)
+
+    policy = default_store_connection_policy(logical_name)
+    timeout_seconds = policy.busy_timeout_ms / 1_000
+    requested_timeout = kwargs.pop("timeout", None)
+    if requested_timeout is not None and float(requested_timeout) != timeout_seconds:
+        raise ValueError(
+            "connection timeout override diverges from store policy: "
+            f"logical_store={logical_name!r} requested={requested_timeout!r} "
+            f"declared={timeout_seconds!r}"
+        )
+    kwargs["timeout"] = (
+        _SQLITE_DEFAULT_TIMEOUT_SECONDS if requested_timeout is None else float(requested_timeout)
+    )
+    return sqlite3.connect(database, **kwargs)

--- a/src/pinky_daemon/store_manifest.py
+++ b/src/pinky_daemon/store_manifest.py
@@ -6,7 +6,7 @@ import os
 from collections.abc import Callable
 from pathlib import Path
 
-from pinky_daemon.store_catalog import StoreIntegrityTarget
+from pinky_daemon.store_catalog import StoreIntegrityTarget, default_store_connection_policy
 
 FLEET_MANIFEST_KIND = "fleet"
 STANDALONE_TENANT_MANIFEST_KIND = "standalone-tenant"
@@ -14,18 +14,21 @@ StoreManifest = dict[str, StoreIntegrityTarget]
 StoreManifestProvider = Callable[[str | os.PathLike[str]], StoreManifest]
 
 
-def _authoritative(
+def _store(
     logical_name: str,
     path: str,
     *,
+    criticality: str,
+    recovery: str = "snapshot",
     journal_mode: str | None = None,
 ) -> StoreIntegrityTarget:
     return StoreIntegrityTarget(
         logical_name=logical_name,
         path=path,
-        criticality="authoritative",
-        recovery="snapshot",
+        criticality=criticality,
+        recovery=recovery,
         journal_mode=journal_mode,
+        connection_policy=default_store_connection_policy(logical_name),
     )
 
 
@@ -37,41 +40,76 @@ def derive_fleet_store_manifest(
     data_dir = Path(base).parent
     agents_path = base.replace(".db", "_agents.db")
     return {
-        "sessions": _authoritative("sessions", base.replace(".db", "_sessions.db")),
-        "session_events": _authoritative("session_events", base.replace(".db", "_sessions.db")),
-        "conversations": _authoritative("conversations", base),
-        "analytics": _authoritative("analytics", base.replace(".db", "_analytics.db")),
-        "agents": _authoritative("agents", agents_path, journal_mode="truncate"),
-        "agent_signing_keys": _authoritative(
+        "sessions": _store(
+            "sessions", base.replace(".db", "_sessions.db"), criticality="delivery"
+        ),
+        "session_events": _store(
+            "session_events", base.replace(".db", "_sessions.db"), criticality="telemetry"
+        ),
+        "conversations": _store("conversations", base, criticality="memory"),
+        "analytics": _store(
+            "analytics", base.replace(".db", "_analytics.db"), criticality="telemetry"
+        ),
+        "agents": _store(
+            "agents", agents_path, criticality="delivery", journal_mode="truncate"
+        ),
+        "agent_signing_keys": _store(
             "agent_signing_keys",
             agents_path,
+            criticality="authority",
             journal_mode="truncate",
         ),
-        "audit": _authoritative("audit", base.replace(".db", "_audit.db")),
-        "agent_comms": _authoritative("agent_comms", base.replace(".db", "_agent_comms.db")),
-        "activity": _authoritative("activity", base.replace(".db", "_activity.db")),
-        "message_context": _authoritative(
-            "message_context", base.replace(".db", "_message_context.db")
+        "audit": _store("audit", base.replace(".db", "_audit.db"), criticality="memory"),
+        "agent_comms": _store(
+            "agent_comms", base.replace(".db", "_agent_comms.db"), criticality="delivery"
         ),
-        "dream_state": _authoritative("dream_state", base.replace(".db", "_dream_state.db")),
-        "skills": _authoritative("skills", base.replace(".db", "_skills.db")),
-        "plugins": _authoritative("plugins", base.replace(".db", "_plugins.db")),
-        "outreach_config": _authoritative("outreach_config", base.replace(".db", "_outreach.db")),
-        "tasks": _authoritative("tasks", base.replace(".db", "_tasks.db")),
-        "research": _authoritative("research", base.replace(".db", "_research.db")),
-        "presentations": _authoritative("presentations", base.replace(".db", "_presentations.db")),
-        "apps": _authoritative("apps", base.replace(".db", "_apps.db")),
-        "triggers": _authoritative("triggers", base.replace(".db", "_triggers.db")),
-        "mesh": _authoritative("mesh", base.replace(".db", "_mesh.db")),
-        "kb": _authoritative("kb", os.fspath(data_dir / "kb" / "kb.db")),
-        "librarian_state": StoreIntegrityTarget(
-            logical_name="librarian_state",
-            path=base.replace(".db", "_librarian_state.db"),
-            criticality="derived",
+        "activity": _store(
+            "activity", base.replace(".db", "_activity.db"), criticality="telemetry"
+        ),
+        "message_context": _store(
+            "message_context",
+            base.replace(".db", "_message_context.db"),
+            criticality="delivery",
+        ),
+        "dream_state": _store(
+            "dream_state", base.replace(".db", "_dream_state.db"), criticality="memory"
+        ),
+        "skills": _store(
+            "skills", base.replace(".db", "_skills.db"), criticality="authority"
+        ),
+        "plugins": _store(
+            "plugins", base.replace(".db", "_plugins.db"), criticality="authority"
+        ),
+        "outreach_config": _store(
+            "outreach_config", base.replace(".db", "_outreach.db"), criticality="authority"
+        ),
+        "tasks": _store("tasks", base.replace(".db", "_tasks.db"), criticality="memory"),
+        "research": _store(
+            "research", base.replace(".db", "_research.db"), criticality="memory"
+        ),
+        "presentations": _store(
+            "presentations", base.replace(".db", "_presentations.db"), criticality="memory"
+        ),
+        "apps": _store("apps", base.replace(".db", "_apps.db"), criticality="memory"),
+        "triggers": _store(
+            "triggers", base.replace(".db", "_triggers.db"), criticality="delivery"
+        ),
+        "mesh": _store("mesh", base.replace(".db", "_mesh.db"), criticality="delivery"),
+        "kb": _store(
+            "kb", os.fspath(data_dir / "kb" / "kb.db"), criticality="memory"
+        ),
+        "librarian_state": _store(
+            "librarian_state",
+            base.replace(".db", "_librarian_state.db"),
+            criticality="telemetry",
             recovery="rebuild",
         ),
-        "voice": _authoritative("voice", os.fspath(data_dir / "voice_calls.db")),
-        "user_profiles": _authoritative("user_profiles", os.fspath(data_dir / "user_profiles.db")),
+        "voice": _store(
+            "voice", os.fspath(data_dir / "voice_calls.db"), criticality="delivery"
+        ),
+        "user_profiles": _store(
+            "user_profiles", os.fspath(data_dir / "user_profiles.db"), criticality="memory"
+        ),
     }
 
 
@@ -81,9 +119,10 @@ def derive_standalone_tenant_store_manifest(
     """Return the explicit one-store manifest for a tenant-owned keystore."""
     path = os.path.realpath(os.fspath(db_path))
     return {
-        "agent_signing_keys": _authoritative(
+        "agent_signing_keys": _store(
             "agent_signing_keys",
             path,
+            criticality="authority",
             journal_mode="delete",
         ),
     }

--- a/src/pinky_daemon/store_shutdown.py
+++ b/src/pinky_daemon/store_shutdown.py
@@ -1,0 +1,148 @@
+"""Bounded, class-ordered finalization for daemon SQLite stores."""
+
+from __future__ import annotations
+
+import threading
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+
+_CRITICALITY_ORDER = {
+    "telemetry": 0,
+    "derived": 0,
+    "memory": 1,
+    "authority": 2,
+    "authoritative": 2,
+    "delivery": 3,
+}
+
+
+@dataclass(frozen=True, slots=True)
+class StoreShutdownFailure:
+    """One registered store finalizer that did not finish successfully."""
+
+    logical_name: str
+    reason: str
+
+
+@dataclass(frozen=True, slots=True)
+class StoreShutdownReport:
+    """Structured outcome from one aggregate shutdown attempt."""
+
+    attempted: tuple[str, ...]
+    finalized: tuple[str, ...]
+    failures: tuple[StoreShutdownFailure, ...]
+
+    @property
+    def ok(self) -> bool:
+        return not self.failures
+
+
+class StoreShutdownError(RuntimeError):
+    """Raised after every finalizer was attempted and at least one failed."""
+
+    def __init__(self, report: StoreShutdownReport) -> None:
+        self.report = report
+        details = ", ".join(
+            f"{failure.logical_name}: {failure.reason}" for failure in report.failures
+        )
+        super().__init__(f"Store shutdown failed after bounded attempts: {details}")
+
+
+@dataclass(frozen=True, slots=True)
+class _Finalizer:
+    logical_name: str
+    criticality: str
+    callback: Callable[[], None]
+    sequence: int
+
+
+class StoreShutdownCoordinator:
+    """Run store finalizers in dependency order within one aggregate deadline.
+
+    Each callback receives a fair share of the remaining aggregate budget. A
+    callback that exceeds its share remains on a daemon thread, is reported as
+    unfinalized, and cannot prevent later stores from being attempted.
+    """
+
+    def __init__(self, *, deadline_seconds: float) -> None:
+        if deadline_seconds <= 0:
+            raise ValueError("store shutdown deadline must be positive")
+        self._deadline_seconds = deadline_seconds
+        self._finalizers: list[_Finalizer] = []
+
+    def register(
+        self,
+        logical_name: str,
+        criticality: str,
+        finalizer: Callable[[], None],
+    ) -> None:
+        if criticality not in _CRITICALITY_ORDER:
+            raise ValueError(f"unknown store criticality: {criticality!r}")
+        self._finalizers.append(
+            _Finalizer(
+                logical_name=logical_name,
+                criticality=criticality,
+                callback=finalizer,
+                sequence=len(self._finalizers),
+            )
+        )
+
+    def shutdown(self) -> StoreShutdownReport:
+        ordered = sorted(
+            self._finalizers,
+            key=lambda item: (_CRITICALITY_ORDER[item.criticality], -item.sequence),
+        )
+        deadline = time.monotonic() + self._deadline_seconds
+        attempted: list[str] = []
+        finalized: list[str] = []
+        failures: list[StoreShutdownFailure] = []
+
+        for index, item in enumerate(ordered):
+            attempted.append(item.logical_name)
+            callback_errors: list[BaseException] = []
+
+            def run_finalizer(
+                current: _Finalizer = item,
+                errors: list[BaseException] = callback_errors,
+            ) -> None:
+                try:
+                    current.callback()
+                except BaseException as exc:  # surfaced structurally on the caller
+                    errors.append(exc)
+
+            worker = threading.Thread(
+                target=run_finalizer,
+                name=f"store-shutdown-{item.logical_name}",
+                daemon=True,
+            )
+            worker.start()
+            remaining_stores = len(ordered) - index
+            remaining_seconds = max(0.0, deadline - time.monotonic())
+            worker.join(remaining_seconds / remaining_stores)
+            if worker.is_alive():
+                failures.append(
+                    StoreShutdownFailure(
+                        logical_name=item.logical_name,
+                        reason="aggregate deadline share exceeded; store never finalized",
+                    )
+                )
+            elif callback_errors:
+                exc = callback_errors[0]
+                failures.append(
+                    StoreShutdownFailure(
+                        logical_name=item.logical_name,
+                        reason=f"{type(exc).__name__}: {exc}",
+                    )
+                )
+            else:
+                finalized.append(item.logical_name)
+
+        report = StoreShutdownReport(
+            attempted=tuple(attempted),
+            finalized=tuple(finalized),
+            failures=tuple(failures),
+        )
+        if failures:
+            raise StoreShutdownError(report)
+        return report

--- a/src/pinky_daemon/store_snapshot.py
+++ b/src/pinky_daemon/store_snapshot.py
@@ -95,7 +95,7 @@ class StoreSnapshotService:
         *,
         on_outcome: Callable[[SnapshotResult], None] | None = None,
     ) -> list[SnapshotResult]:
-        """Snapshot one named store or every authoritative filesystem store.
+        """Snapshot one named store or every snapshot-recovery filesystem store.
 
         The global lock serializes backup work across all service instances. A
         single catalog snapshot is selected and grouped before any source is
@@ -181,7 +181,7 @@ class StoreSnapshotService:
             requested = [
                 record
                 for record in records
-                if record.criticality == "authoritative" and not record.is_memory
+                if record.recovery == "snapshot" and not record.is_memory
             ]
             selected_paths = {record.resolved_path for record in requested}
 

--- a/src/pinky_daemon/task_store.py
+++ b/src/pinky_daemon/task_store.py
@@ -22,7 +22,12 @@ import time
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from pinky_daemon.store_catalog import StoreCatalog
+from pinky_daemon.store_catalog import (
+    StoreCatalog,
+    apply_store_connection_policy,
+    open_store_connection,
+    store_connection_policy,
+)
 
 
 def _log(msg: str) -> None:
@@ -202,11 +207,19 @@ class TaskStore:
         """Return the calling thread's connection, creating it on first use."""
         connection = getattr(self._thread_local, "connection", None)
         if connection is None:
-            connection = sqlite3.connect(self._db_path)
+            connection = open_store_connection(
+                self._catalog,
+                "tasks",
+                self._db_path,
+                owner=type(self).__name__,
+            )
             journal_mode = str(
                 connection.execute("PRAGMA journal_mode=WAL").fetchone()[0]
             ).lower()
-            connection.execute("PRAGMA busy_timeout=30000")
+            apply_store_connection_policy(
+                connection,
+                store_connection_policy(self._catalog, "tasks"),
+            )
             connection.execute("PRAGMA foreign_keys=ON")
             if self._catalog is not None:
                 self._catalog.register(

--- a/src/pinky_daemon/trigger_store.py
+++ b/src/pinky_daemon/trigger_store.py
@@ -20,7 +20,11 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from pinky_daemon.db_journal import configure_rollback_journal
-from pinky_daemon.store_catalog import StoreCatalog
+from pinky_daemon.store_catalog import (
+    StoreCatalog,
+    open_store_connection,
+    store_connection_policy,
+)
 
 
 def _log(msg: str) -> None:
@@ -95,11 +99,19 @@ class TriggerStore:
         """Return the calling thread's connection, creating it on first use."""
         connection = getattr(self._thread_local, "connection", None)
         if connection is None:
-            connection = sqlite3.connect(self._db_path)
+            connection = open_store_connection(
+                self._catalog,
+                "triggers",
+                self._db_path,
+                owner=type(self).__name__,
+            )
             # #889: rollback (TRUNCATE) journal mode, NOT WAL — an external sqlite
             # client's open/close can't unlink -wal/-shm out from under the daemon.
             # Sets busy_timeout internally. See pinky_daemon.db_journal.
-            journal_mode = configure_rollback_journal(connection, busy_ms=30000)
+            journal_mode = configure_rollback_journal(
+                connection,
+                policy=store_connection_policy(self._catalog, "triggers"),
+            )
             connection.execute("PRAGMA foreign_keys=ON")
             connection.row_factory = sqlite3.Row
             if self._catalog is not None:

--- a/src/pinky_daemon/user_profile_store.py
+++ b/src/pinky_daemon/user_profile_store.py
@@ -19,7 +19,11 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 
 from pinky_daemon.db_journal import configure_rollback_journal
-from pinky_daemon.store_catalog import StoreCatalog
+from pinky_daemon.store_catalog import (
+    StoreCatalog,
+    open_store_connection,
+    store_connection_policy,
+)
 
 
 @dataclass
@@ -98,14 +102,22 @@ class UserProfileStore:
         """Return the calling thread's connection, creating it on first use."""
         connection = getattr(self._thread_local, "connection", None)
         if connection is None:
-            connection = sqlite3.connect(self._db_path)
+            connection = open_store_connection(
+                self._catalog,
+                "user_profiles",
+                self._db_path,
+                owner=type(self).__name__,
+            )
             # #889: rollback (TRUNCATE) journal mode, NOT WAL. user_profiles.db is
             # cross-process/-thread concurrent-read (every agent's dream run opens a
             # fresh connection). With WAL, its deleted -wal/-shm broke WAL-index
             # coordination for fresh readers → SQLITE_IOERR across all reader connections (2026-08-17
             # dream failures). Rollback mode has no -wal/-shm to orphan; the busy_timeout
             # absorbs the whole-file-lock serialization. See pinky_daemon.db_journal.
-            journal_mode = configure_rollback_journal(connection, busy_ms=30000)
+            journal_mode = configure_rollback_journal(
+                connection,
+                policy=store_connection_policy(self._catalog, "user_profiles"),
+            )
             if self._catalog is not None:
                 self._catalog.register(
                     "user_profiles",

--- a/src/pinky_daemon/voice_store.py
+++ b/src/pinky_daemon/voice_store.py
@@ -21,7 +21,12 @@ import uuid
 from dataclasses import dataclass
 from pathlib import Path
 
-from pinky_daemon.store_catalog import StoreCatalog
+from pinky_daemon.store_catalog import (
+    StoreCatalog,
+    apply_store_connection_policy,
+    open_store_connection,
+    store_connection_policy,
+)
 
 
 def _log(msg: str) -> None:
@@ -236,11 +241,19 @@ class VoiceStore:
         """Return the calling thread's connection, creating it on first use."""
         connection = getattr(self._thread_local, "connection", None)
         if connection is None:
-            connection = sqlite3.connect(self._db_path)
+            connection = open_store_connection(
+                self._catalog,
+                "voice",
+                self._db_path,
+                owner=type(self).__name__,
+            )
             journal_mode = str(
                 connection.execute("PRAGMA journal_mode=WAL").fetchone()[0]
             ).lower()
-            connection.execute("PRAGMA busy_timeout=30000")
+            apply_store_connection_policy(
+                connection,
+                store_connection_policy(self._catalog, "voice"),
+            )
             connection.execute("PRAGMA foreign_keys=ON")
             connection.row_factory = sqlite3.Row
             if self._catalog is not None:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -8347,10 +8347,10 @@ class TestGoogleOAuthStateValidation:
                 params={"code": "auth-code", "state": "stale-nonce"},
                 follow_redirects=False,
             )
-        assert resp.status_code == 400
-        assert "expired" in resp.text.lower()
-        # Expired state must be purged so it can't be retried.
-        assert app.state.agents.get_setting("GOOGLE_OAUTH_STATE_stale-nonce") == ""
+            assert resp.status_code == 400
+            assert "expired" in resp.text.lower()
+            # Expired state must be purged so it can't be retried.
+            assert app.state.agents.get_setting("GOOGLE_OAUTH_STATE_stale-nonce") == ""
 
     def test_callback_rejects_replayed_state(self):
         """A state nonce must be single-use. After one consume, a second hit
@@ -8406,9 +8406,9 @@ class TestGoogleOAuthStateValidation:
                     params={"code": "bad-code", "state": "single-use"},
                     follow_redirects=False,
                 )
-        assert resp.status_code == 400
-        assert "oauth error" in resp.text.lower()
-        assert app.state.agents.get_setting("GOOGLE_OAUTH_STATE_single-use") == ""
+                assert resp.status_code == 400
+                assert "oauth error" in resp.text.lower()
+                assert app.state.agents.get_setting("GOOGLE_OAUTH_STATE_single-use") == ""
 
     def test_direct_auth_url_persists_state(self):
         """The direct-auth-url endpoint must persist a single-use state nonce
@@ -8432,13 +8432,13 @@ class TestGoogleOAuthStateValidation:
                     create_session_cookie(os.environ["PINKY_SESSION_SECRET"]),
                 )
                 resp = client.get("/calendar/google/direct-auth-url")
-        assert resp.status_code == 200
-        body = resp.json()
-        assert body["state"] == "xyz"
-        assert "accounts.google.com" in body["auth_url"]
-        # State key must be present and non-empty (timestamp).
-        stored = app.state.agents.get_setting("GOOGLE_OAUTH_STATE_xyz")
-        assert stored != ""
+                assert resp.status_code == 200
+                body = resp.json()
+                assert body["state"] == "xyz"
+                assert "accounts.google.com" in body["auth_url"]
+                # State key must be present and non-empty (timestamp).
+                stored = app.state.agents.get_setting("GOOGLE_OAUTH_STATE_xyz")
+                assert stored != ""
 
     def test_direct_auth_url_requires_credentials(self):
         """Without stored client credentials, direct-auth must 400 — there's
@@ -8544,10 +8544,10 @@ class TestGoogleOAuthStateValidation:
                 params={"code": "auth-code", "state": "naive-nonce"},
                 follow_redirects=False,
             )
-        assert resp.status_code == 400
-        assert "corrupt state" in resp.text.lower()
-        # Still purged, even though it was malformed — can't be retried.
-        assert app.state.agents.get_setting("GOOGLE_OAUTH_STATE_naive-nonce") == ""
+            assert resp.status_code == 400
+            assert "corrupt state" in resp.text.lower()
+            # Still purged, even though it was malformed — can't be retried.
+            assert app.state.agents.get_setting("GOOGLE_OAUTH_STATE_naive-nonce") == ""
 
 
 class TestBuildStreamingWakeContextReasonGating:

--- a/tests/test_no_direct_db_open.py
+++ b/tests/test_no_direct_db_open.py
@@ -240,12 +240,10 @@ def _assert_direct_opens_allowed(
     assert not failures, "\n\n".join(failures)
 
 
-def test_daemon_direct_sqlite_opens_are_owned_or_allowlisted() -> None:
+def test_daemon_direct_sqlite_opens_are_centralized_in_storage_authority() -> None:
     _assert_direct_opens_allowed(
         _scan_daemon_sources(),
-        owner_modules=(
-            APPROVED_STORAGE_OWNER_MODULES | APPROVED_STORAGE_AUTHORITY_MODULES
-        ),
+        owner_modules=APPROVED_STORAGE_AUTHORITY_MODULES,
         allowlist=DIRECT_OPEN_ALLOWLIST,
     )
 
@@ -259,9 +257,7 @@ def test_connector_exception_mapping_is_exactly_empty_and_authority_is_separate(
             "src/pinky_daemon/store_snapshot.py",
         }
     )
-    assert APPROVED_STORAGE_OWNER_MODULES.isdisjoint(
-        APPROVED_STORAGE_AUTHORITY_MODULES
-    )
+    assert APPROVED_STORAGE_OWNER_MODULES.isdisjoint(APPROVED_STORAGE_AUTHORITY_MODULES)
 
 
 def test_scanner_resolves_sqlite_import_aliases() -> None:

--- a/tests/test_storage_observability.py
+++ b/tests/test_storage_observability.py
@@ -141,10 +141,12 @@ def test_admin_watchdog_exposes_bounded_boot_preflight_inventory_and_reconcile_m
     assert inventory["physical_count"] == 22
     assert set(inventory["stores"]) == manifest_names
     assert {details["criticality"] for details in inventory["stores"].values()} == {
-        "authoritative",
-        "derived",
+        "delivery",
+        "authority",
+        "memory",
+        "telemetry",
     }
-    assert inventory["stores"]["librarian_state"]["criticality"] == "derived"
+    assert inventory["stores"]["librarian_state"]["criticality"] == "telemetry"
     assert {details["journal_mode"] for details in inventory["stores"].values()} <= {
         "delete",
         "truncate",

--- a/tests/test_storage_repository_seams.py
+++ b/tests/test_storage_repository_seams.py
@@ -719,7 +719,7 @@ def test_fleet_and_standalone_manifest_providers_are_explicit_and_non_guessing(
         "agent_signing_keys": StoreIntegrityTarget(
             logical_name="agent_signing_keys",
             path=os.fspath(keystore),
-            criticality="authoritative",
+            criticality="authority",
             recovery="snapshot",
             journal_mode="delete",
         )

--- a/tests/test_store_catalog.py
+++ b/tests/test_store_catalog.py
@@ -6,7 +6,12 @@ from pathlib import Path
 
 import pytest
 
-from pinky_daemon.store_catalog import StoreCatalog, StoreCatalogError, StoreRecord
+from pinky_daemon.store_catalog import (
+    StoreCatalog,
+    StoreCatalogError,
+    StoreRecord,
+    default_store_connection_policy,
+)
 
 
 def _register(
@@ -42,6 +47,7 @@ def test_register_snapshot_round_trip(tmp_path: Path) -> None:
             criticality="authoritative",
             dev_ino=(stat.st_dev, stat.st_ino),
             is_memory=False,
+            connection_policy=default_store_connection_policy("tasks"),
         )
     ]
 
@@ -704,7 +710,8 @@ def test_librarian_runner_participates_in_alias_validation(tmp_path: Path) -> No
         record for record in catalog.snapshot() if record.logical_name == "librarian_state"
     )
     assert record.owner == "LibrarianRunner"
-    assert record.criticality == "derived"
+    assert record.criticality == "telemetry"
+    assert record.recovery == "rebuild"
     with pytest.raises(StoreCatalogError, match="same physical file"):
         catalog.validate()
 
@@ -759,7 +766,7 @@ def test_create_api_registers_all_authoritative_stores_and_validates_once(
     assert {record.journal_mode for record in records} == {"truncate", "wal"}
     assert (
         next(record for record in records if record.logical_name == "librarian_state").criticality
-        == "derived"
+        == "telemetry"
     )
     session_records = [
         record for record in records if record.logical_name in {"sessions", "session_events"}

--- a/tests/test_store_lifecycle.py
+++ b/tests/test_store_lifecycle.py
@@ -1,0 +1,371 @@
+"""Lane A contracts for store criticality, connection policy, and shutdown."""
+
+from __future__ import annotations
+
+import os
+import signal
+import sqlite3
+import subprocess
+import sys
+import textwrap
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from pinky_daemon.store_authority import assert_no_open_store_descriptors
+from pinky_daemon.store_catalog import StoreCatalog, StoreCatalogError, StoreIntegrityTarget
+from pinky_daemon.store_manifest import derive_fleet_store_manifest
+from pinky_daemon.store_snapshot import StoreSnapshotService
+
+_EXPECTED_CRITICALITY = {
+    "sessions": "delivery",
+    "session_events": "telemetry",
+    "conversations": "memory",
+    "analytics": "telemetry",
+    "agents": "delivery",
+    "agent_signing_keys": "authority",
+    "audit": "memory",
+    "agent_comms": "delivery",
+    "activity": "telemetry",
+    "message_context": "delivery",
+    "dream_state": "memory",
+    "skills": "authority",
+    "plugins": "authority",
+    "outreach_config": "authority",
+    "tasks": "memory",
+    "research": "memory",
+    "presentations": "memory",
+    "apps": "memory",
+    "triggers": "delivery",
+    "mesh": "delivery",
+    "kb": "memory",
+    "librarian_state": "telemetry",
+    "voice": "delivery",
+    "user_profiles": "memory",
+}
+
+_EXPECTED_SNAPSHOT_LOGICAL_NAMES = frozenset(_EXPECTED_CRITICALITY) - {"librarian_state"}
+
+_THIRTY_SECOND_BUSY_STORES = {
+    "sessions",
+    "session_events",
+    "conversations",
+    "audit",
+    "agent_comms",
+    "activity",
+    "dream_state",
+    "skills",
+    "outreach_config",
+    "tasks",
+    "research",
+    "presentations",
+    "triggers",
+    "voice",
+    "user_profiles",
+}
+
+
+def _target(
+    logical_name: str,
+    path: Path,
+    criticality: str,
+    *,
+    recovery: str = "snapshot",
+    journal_mode: str = "wal",
+) -> StoreIntegrityTarget:
+    return StoreIntegrityTarget(
+        logical_name=logical_name,
+        path=os.fspath(path),
+        criticality=criticality,
+        recovery=recovery,
+        journal_mode=journal_mode,
+    )
+
+
+def _register_manifest_member(
+    catalog: StoreCatalog,
+    target: StoreIntegrityTarget,
+    *,
+    owner: str | None = None,
+) -> None:
+    path = Path(target.path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.touch(exist_ok=True)
+    catalog.register(
+        target.logical_name,
+        path,
+        journal_mode=target.journal_mode or "wal",
+        owner=owner or f"{target.logical_name}-owner",
+    )
+
+
+def test_fleet_manifest_declares_exact_criticality_and_connection_policy(tmp_path: Path) -> None:
+    manifest = derive_fleet_store_manifest(tmp_path / "conversations.db")
+
+    assert {name: target.criticality for name, target in manifest.items()} == _EXPECTED_CRITICALITY
+    assert {
+        name
+        for name, target in manifest.items()
+        if target.connection_policy.busy_timeout_ms == 30_000
+    } == _THIRTY_SECOND_BUSY_STORES
+    assert {
+        name
+        for name, target in manifest.items()
+        if target.connection_policy.busy_timeout_ms == 5_000
+    } == set(manifest) - _THIRTY_SECOND_BUSY_STORES
+    assert {target.connection_policy.rollback_retries for target in manifest.values()} == {6}
+    assert {
+        target.connection_policy.rollback_retry_delay_seconds for target in manifest.values()
+    } == {0.2}
+
+
+def test_post_construction_absent_telemetry_degrades_loud(tmp_path: Path) -> None:
+    manifest = {
+        "delivery": _target("delivery", tmp_path / "delivery.db", "delivery"),
+        "telemetry": _target(
+            "telemetry",
+            tmp_path / "telemetry.db",
+            "telemetry",
+            recovery="rebuild",
+        ),
+    }
+    catalog = StoreCatalog(expected_root=tmp_path, silence_allowlist={}, manifest=manifest)
+    _register_manifest_member(catalog, manifest["delivery"])
+
+    warnings = catalog.validate()
+
+    assert len(warnings) == 1
+    assert "telemetry" in warnings[0]
+    assert "degraded" in warnings[0]
+
+
+def test_post_construction_absent_delivery_refuses_boot(tmp_path: Path) -> None:
+    manifest = {
+        "delivery": _target("delivery", tmp_path / "delivery.db", "delivery"),
+        "telemetry": _target(
+            "telemetry",
+            tmp_path / "telemetry.db",
+            "telemetry",
+            recovery="rebuild",
+        ),
+    }
+    catalog = StoreCatalog(expected_root=tmp_path, silence_allowlist={}, manifest=manifest)
+    _register_manifest_member(catalog, manifest["telemetry"])
+
+    with pytest.raises(StoreCatalogError, match=r"delivery.*post-construction"):
+        catalog.validate()
+
+
+def test_missing_shared_path_member_inherits_the_cohorts_strongest_class(tmp_path: Path) -> None:
+    shared = tmp_path / "sessions.db"
+    manifest = {
+        "sessions": _target("sessions", shared, "delivery"),
+        "session_events": _target(
+            "session_events",
+            shared,
+            "telemetry",
+            recovery="snapshot",
+        ),
+    }
+    catalog = StoreCatalog(expected_root=tmp_path, silence_allowlist={}, manifest=manifest)
+    _register_manifest_member(catalog, manifest["sessions"], owner="shared-owner")
+
+    with pytest.raises(StoreCatalogError, match=r"session_events.*delivery"):
+        catalog.validate()
+
+
+def test_p03_default_snapshot_logical_name_set_is_identical_after_reclassification(
+    tmp_path: Path,
+) -> None:
+    manifest = derive_fleet_store_manifest(tmp_path / "conversations.db")
+    assert {
+        name for name, target in manifest.items() if target.recovery == "snapshot"
+    } == _EXPECTED_SNAPSHOT_LOGICAL_NAMES
+    catalog = StoreCatalog(expected_root=tmp_path, silence_allowlist={}, manifest=manifest)
+    for target in manifest.values():
+        _register_manifest_member(catalog, target)
+
+    selected = StoreSnapshotService(catalog)._select(None)
+    selected_logical_names = {
+        logical_name for physical_store in selected for logical_name in physical_store.logical_names
+    }
+
+    assert selected_logical_names == _EXPECTED_SNAPSHOT_LOGICAL_NAMES
+
+
+def test_catalog_shutdown_is_class_ordered_lifo_and_leaves_no_writer_fd(
+    tmp_path: Path,
+) -> None:
+    declarations = [
+        ("delivery_old", "delivery"),
+        ("telemetry_old", "telemetry"),
+        ("authority", "authority"),
+        ("memory", "memory"),
+        ("telemetry_new", "telemetry"),
+        ("delivery_new", "delivery"),
+    ]
+    manifest = {
+        name: _target(name, tmp_path / f"{name}.db", criticality)
+        for name, criticality in declarations
+    }
+    catalog = StoreCatalog(expected_root=tmp_path, silence_allowlist={}, manifest=manifest)
+    paths: list[Path] = []
+    for name, _criticality in declarations:
+        target = manifest[name]
+        path = Path(target.path)
+        paths.append(path)
+        connection = catalog.open_connection(name, path, owner=f"{name}-owner")
+        mode = str(connection.execute("PRAGMA journal_mode=WAL").fetchone()[0]).lower()
+        connection.execute("CREATE TABLE payload (value TEXT NOT NULL)")
+        connection.execute("INSERT INTO payload(value) VALUES ('committed')")
+        connection.commit()
+        catalog.register(name, path, journal_mode=mode, owner=f"{name}-owner")
+
+    report = catalog.shutdown(deadline_seconds=2.0)
+
+    assert report.ok is True
+    assert report.failures == ()
+    assert report.finalized == (
+        "telemetry_new",
+        "telemetry_old",
+        "memory",
+        "authority",
+        "delivery_new",
+        "delivery_old",
+    )
+    assert_no_open_store_descriptors(paths)
+    for path in paths:
+        assert not Path(os.fspath(path) + "-wal").exists()
+        assert not Path(os.fspath(path) + "-shm").exists()
+        assert not Path(os.fspath(path) + "-journal").exists()
+
+
+def test_shutdown_deadline_is_loud_and_remaining_stores_are_attempted() -> None:
+    try:
+        from pinky_daemon.store_shutdown import StoreShutdownCoordinator, StoreShutdownError
+    except ImportError:
+        pytest.fail("central store shutdown coordinator is not implemented")
+
+    release = threading.Event()
+    attempted: list[str] = []
+
+    def blocked() -> None:
+        attempted.append("blocked_telemetry")
+        release.wait()
+
+    def finalize(name: str):
+        def _finalize() -> None:
+            attempted.append(name)
+
+        return _finalize
+
+    coordinator = StoreShutdownCoordinator(deadline_seconds=0.18)
+    coordinator.register("delivery", "delivery", finalize("delivery"))
+    coordinator.register("memory", "memory", finalize("memory"))
+    coordinator.register("blocked_telemetry", "telemetry", blocked)
+    started = time.monotonic()
+
+    with pytest.raises(StoreShutdownError) as exc_info:
+        coordinator.shutdown()
+    elapsed = time.monotonic() - started
+    release.set()
+
+    assert elapsed < 0.5
+    assert attempted == ["blocked_telemetry", "memory", "delivery"]
+    assert exc_info.value.report.attempted == (
+        "blocked_telemetry",
+        "memory",
+        "delivery",
+    )
+    assert [failure.logical_name for failure in exc_info.value.report.failures] == [
+        "blocked_telemetry"
+    ]
+    assert "deadline" in str(exc_info.value).lower()
+    assert "blocked_telemetry" in str(exc_info.value)
+
+
+_SIGNAL_CHILD = textwrap.dedent(
+    """
+    import os
+    import signal
+    import sys
+    import time
+    from pathlib import Path
+
+    from pinky_daemon.store_catalog import StoreCatalog, StoreIntegrityTarget
+
+    database = Path(sys.argv[1])
+    graceful = sys.argv[2] == "graceful"
+    target = StoreIntegrityTarget(
+        logical_name="signal_store",
+        path=os.fspath(database),
+        criticality="delivery",
+        recovery="snapshot",
+        journal_mode="delete",
+    )
+    catalog = StoreCatalog(
+        expected_root=database.parent,
+        silence_allowlist={},
+        manifest={"signal_store": target},
+    )
+    connection = catalog.open_connection(
+        "signal_store",
+        database,
+        owner="signal-owner",
+    )
+    mode = str(connection.execute("PRAGMA journal_mode=DELETE").fetchone()[0]).lower()
+    connection.execute("CREATE TABLE IF NOT EXISTS payload (value TEXT NOT NULL)")
+    connection.commit()
+    catalog.register(
+        "signal_store",
+        database,
+        journal_mode=mode,
+        owner="signal-owner",
+    )
+    connection.execute("BEGIN IMMEDIATE")
+    connection.execute("INSERT INTO payload(value) VALUES ('inflight')")
+
+    if graceful:
+        def stop(_signum, _frame):
+            catalog.shutdown(deadline_seconds=1.0)
+            raise SystemExit(0)
+
+        signal.signal(signal.SIGTERM, stop)
+
+    print("READY", flush=True)
+    while True:
+        time.sleep(1)
+    """
+)
+
+
+def _run_signal_child(path: Path, mode: str) -> int:
+    process = subprocess.Popen(
+        [sys.executable, "-c", _SIGNAL_CHILD, os.fspath(path), mode],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    assert process.stdout is not None
+    ready = process.stdout.readline().strip()
+    if ready != "READY":
+        assert process.stderr is not None
+        pytest.fail(f"signal child failed before readiness: {process.stderr.read()}")
+    process.send_signal(signal.SIGTERM)
+    return process.wait(timeout=5)
+
+
+def test_graceful_shutdown_clears_recovery_work_while_raw_sigterm_retains_it(
+    tmp_path: Path,
+) -> None:
+    graceful_path = tmp_path / "graceful.db"
+    assert _run_signal_child(graceful_path, "graceful") == 0
+    assert not Path(os.fspath(graceful_path) + "-journal").exists()
+    with sqlite3.connect(graceful_path) as connection:
+        assert connection.execute("PRAGMA quick_check").fetchall() == [("ok",)]
+
+    raw_path = tmp_path / "raw.db"
+    assert _run_signal_child(raw_path, "raw") == -signal.SIGTERM
+    assert Path(os.fspath(raw_path) + "-journal").exists()

--- a/tests/test_store_lifecycle_quiescence.py
+++ b/tests/test_store_lifecycle_quiescence.py
@@ -1,0 +1,92 @@
+"""Shutdown-quiescence regressions supplementing the review probes."""
+
+from __future__ import annotations
+
+import asyncio
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from pinky_daemon import pollers
+from pinky_daemon.store_catalog import StoreCatalog, StoreIntegrityTarget
+from pinky_daemon.store_shutdown import StoreShutdownError
+
+
+@pytest.mark.asyncio
+async def test_delivery_quiescence_waits_for_a_mid_write_handler() -> None:
+    """Store finalization cannot begin while an admitted delivery writer is active."""
+    writer_entered = asyncio.Event()
+    release_writer = asyncio.Event()
+    writer_exited = asyncio.Event()
+    finalizer_entered = asyncio.Event()
+
+    async def writer() -> None:
+        writer_entered.set()
+        await release_writer.wait()
+        writer_exited.set()
+
+    delivery = pollers._deliver_in_background(writer(), "review mid-write")
+    await writer_entered.wait()
+    quiesce = getattr(pollers, "quiesce_delivery_tasks", None)
+    if quiesce is None:
+        release_writer.set()
+        await delivery
+        pytest.fail("pollers.quiesce_delivery_tasks is required")
+
+    async def quiesce_then_finalize() -> None:
+        await quiesce()
+        assert writer_exited.is_set()
+        finalizer_entered.set()
+
+    shutdown_task = asyncio.create_task(quiesce_then_finalize())
+    await asyncio.sleep(0)
+    assert not finalizer_entered.is_set()
+
+    release_writer.set()
+    await shutdown_task
+
+    assert finalizer_entered.is_set()
+    assert delivery.done()
+    assert not pollers._DELIVERY_TASKS
+
+
+@pytest.mark.parametrize("failure_stage", ["commit", "close"])
+def test_real_finalizer_failure_remains_loud(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    failure_stage: str,
+) -> None:
+    """Only the precise already-closed end state may be treated as success."""
+    path = tmp_path / f"real-{failure_stage}-failure.db"
+    manifest = {
+        "delivery": StoreIntegrityTarget(
+            logical_name="delivery",
+            path=str(path),
+            criticality="delivery",
+            journal_mode="delete",
+        )
+    }
+    catalog = StoreCatalog(
+        expected_root=tmp_path,
+        silence_allowlist={},
+        manifest=manifest,
+    )
+    connection = catalog.open_connection("delivery", path, owner="review-owner")
+    connection.execute("CREATE TABLE payload (value TEXT NOT NULL)")
+    connection.commit()
+    catalog.register("delivery", path, journal_mode="delete", owner="review-owner")
+
+    connection_type = type(connection)
+    original_close = connection_type.close
+
+    def fail(_connection) -> None:
+        raise sqlite3.OperationalError(f"forced real {failure_stage} failure")
+
+    monkeypatch.setattr(connection_type, failure_stage, fail)
+    try:
+        with pytest.raises(StoreShutdownError, match=f"forced real {failure_stage} failure"):
+            catalog.shutdown(deadline_seconds=2)
+    finally:
+        if failure_stage == "close":
+            original_close(connection)

--- a/tests/test_store_lifecycle_quiescence.py
+++ b/tests/test_store_lifecycle_quiescence.py
@@ -4,13 +4,111 @@ from __future__ import annotations
 
 import asyncio
 import sqlite3
+from concurrent.futures import Future
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
 from pinky_daemon import pollers
 from pinky_daemon.store_catalog import StoreCatalog, StoreIntegrityTarget
 from pinky_daemon.store_shutdown import StoreShutdownError
+
+
+@pytest.mark.asyncio
+async def test_quiescence_drains_an_already_fetched_telegram_batch() -> None:
+    """Stopping ingress must not strand the remainder of an offset-advanced batch."""
+    first_callback_entered = asyncio.Event()
+    release_first_callback = asyncio.Event()
+    finalizer_entered = asyncio.Event()
+    delivered: list[str] = []
+    callback_count = 0
+
+    messages = [
+        SimpleNamespace(
+            chat_id="chat",
+            sender="sender",
+            metadata={},
+            content=content,
+            timestamp=1.0,
+            message_id=content,
+        )
+        for content in ("first", "second")
+    ]
+
+    class Adapter:
+        @staticmethod
+        def get_me():
+            return {"username": "quiescence"}
+
+        @staticmethod
+        def get_updates(*, timeout: int):
+            assert timeout == 30
+            return messages
+
+    class Handler:
+        @staticmethod
+        async def handle(message) -> None:
+            delivered.append(message.content)
+
+    async def event_callback(**_event) -> None:
+        nonlocal callback_count
+        callback_count += 1
+        if callback_count == 1:
+            first_callback_entered.set()
+            await release_first_callback.wait()
+
+    poller = pollers.TelegramPoller(
+        Adapter(),
+        Handler(),
+        poll_interval=0,
+        event_callback=event_callback,
+    )
+    start_poller = getattr(
+        pollers,
+        "start_poller",
+        lambda current: asyncio.create_task(current.start()),
+    )
+    poller_task = start_poller(poller)
+    await first_callback_entered.wait()
+    poller.stop()
+
+    async def quiesce_then_finalize() -> None:
+        await pollers.quiesce_delivery_tasks()
+        finalizer_entered.set()
+
+    shutdown_task = asyncio.create_task(quiesce_then_finalize())
+    await asyncio.sleep(0)
+    finalized_before_batch_drain = finalizer_entered.is_set()
+
+    release_first_callback.set()
+    await asyncio.wait_for(poller_task, timeout=2)
+    await asyncio.wait_for(shutdown_task, timeout=2)
+
+    assert not finalized_before_batch_drain
+    assert delivered == ["first", "second"]
+    assert callback_count == 2
+
+
+def test_abandoned_telegram_batch_drop_after_stop_is_loud(capsys) -> None:
+    """An unsafe late watchdog result is dropped with platform and count."""
+
+    class Adapter:
+        @staticmethod
+        def get_me():
+            return {"username": "quiescence"}
+
+    poller = pollers.TelegramPoller(Adapter(), object())
+    poller.stop()
+    abandoned = Future()
+    abandoned.set_result([object(), object()])
+
+    poller._on_abandoned_poll_done(abandoned)
+
+    stderr = capsys.readouterr().err
+    assert "abandoned poll" in stderr
+    assert "platform=telegram" in stderr
+    assert "dropping 2" in stderr
 
 
 @pytest.mark.asyncio

--- a/tests/test_store_lifecycle_quiescence.py
+++ b/tests/test_store_lifecycle_quiescence.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import sqlite3
+import threading
 from concurrent.futures import Future
 from pathlib import Path
 from types import SimpleNamespace
@@ -13,6 +14,53 @@ import pytest
 from pinky_daemon import pollers
 from pinky_daemon.store_catalog import StoreCatalog, StoreIntegrityTarget
 from pinky_daemon.store_shutdown import StoreShutdownError
+
+
+@pytest.mark.asyncio
+async def test_stop_promptly_unblocks_an_inflight_telegram_poll() -> None:
+    """Stopping must recycle the poll client instead of awaiting its long-poll deadline."""
+    poll_entered = threading.Event()
+    poll_released = threading.Event()
+    recycle_calls = 0
+
+    class Adapter:
+        @staticmethod
+        def get_me():
+            return {"username": "quiescence"}
+
+        @staticmethod
+        def get_updates(*, timeout: int):
+            assert timeout == 30
+            poll_entered.set()
+            poll_released.wait()
+            raise pollers.TelegramError("poll client recycled")
+
+        @staticmethod
+        def recycle() -> None:
+            nonlocal recycle_calls
+            recycle_calls += 1
+            poll_released.set()
+
+    poller = pollers.TelegramPoller(
+        Adapter(),
+        object(),
+        poll_interval=30,
+    )
+    poller_task = pollers.start_poller(poller)
+    assert await asyncio.to_thread(poll_entered.wait, 1)
+
+    poller.stop()
+    try:
+        await asyncio.wait_for(asyncio.shield(poller_task), timeout=0.5)
+    finally:
+        poll_released.set()
+        for _ in range(3):
+            await asyncio.sleep(0)
+        if not poller_task.done():
+            poller_task.cancel()
+        await asyncio.gather(poller_task, return_exceptions=True)
+
+    assert recycle_calls == 1
 
 
 @pytest.mark.asyncio

--- a/tests/test_store_lifecycle_quiescence.py
+++ b/tests/test_store_lifecycle_quiescence.py
@@ -17,6 +17,69 @@ from pinky_daemon.store_shutdown import StoreShutdownError
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "poller_kind",
+    ["telegram", "broker_telegram", "imessage", "slack"],
+)
+async def test_stop_before_scheduled_start_is_sticky_for_every_other_poller(
+    poller_kind: str,
+) -> None:
+    """A scheduled start may never reopen ingress after an explicit stop."""
+    startup_calls = 0
+
+    class Adapter:
+        bot_token = "xoxb-quiescence"
+        can_receive = False
+
+        @staticmethod
+        def get_me():
+            nonlocal startup_calls
+            startup_calls += 1
+            return {"username": "quiescence"}
+
+        @staticmethod
+        def get_bot_info():
+            nonlocal startup_calls
+            startup_calls += 1
+            return {}
+
+        @staticmethod
+        def recycle() -> None:
+            return None
+
+    adapter = Adapter()
+    if poller_kind == "telegram":
+        current = pollers.TelegramPoller(adapter, object())
+    elif poller_kind == "broker_telegram":
+        current = pollers.BrokerTelegramPoller(
+            adapter,
+            "quiescence",
+            object(),
+        )
+    elif poller_kind == "imessage":
+        current = pollers.BrokeriMessagePoller(
+            adapter,
+            "quiescence",
+            object(),
+        )
+    else:
+        current = pollers.BrokerSlackPoller(
+            adapter,
+            "quiescence",
+            object(),
+            app_token="xapp-quiescence",
+        )
+
+    poller_task = pollers.start_poller(current)
+    current.stop()
+    await asyncio.wait_for(poller_task, timeout=0.5)
+
+    assert startup_calls == 0
+    assert not current.is_running
+    assert not current._accepting_deliveries
+
+
+@pytest.mark.asyncio
 async def test_stop_promptly_unblocks_an_inflight_telegram_poll() -> None:
     """Stopping must recycle the poll client instead of awaiting its long-poll deadline."""
     poll_entered = threading.Event()

--- a/tests/test_store_lifecycle_rereview.py
+++ b/tests/test_store_lifecycle_rereview.py
@@ -1,0 +1,150 @@
+"""Review-only probes for the Lane A remediation head."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import pytest
+
+from pinky_daemon import pollers
+
+
+@pytest.mark.asyncio
+async def test_slack_listener_cannot_publish_after_delivery_quiescence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A Slack listener admitted before stop must be part of the writer drain."""
+    listener_entered = asyncio.Event()
+    release_listener = asyncio.Event()
+    client_closed = asyncio.Event()
+    delivered = asyncio.Event()
+
+    class Adapter:
+        bot_token = "xoxb-review"
+
+    class Broker:
+        @staticmethod
+        async def handle_inbound(_message) -> None:
+            delivered.set()
+
+    class Client:
+        @staticmethod
+        async def close() -> None:
+            client_closed.set()
+
+    poller = pollers.BrokerSlackPoller(
+        Adapter(),
+        "review-agent",
+        Broker(),
+        app_token="xapp-review",
+    )
+    poller._running = True
+    poller._bot_user_id = "U_SELF"
+    poller._client = Client()
+
+    async def blocked_user_name(_user_id: str) -> str:
+        listener_entered.set()
+        await release_listener.wait()
+        return "peer"
+
+    async def empty_channel_title(_channel_id: str) -> str:
+        return ""
+
+    async def unchanged_text(text: str) -> str:
+        return text
+
+    monkeypatch.setattr(poller, "_resolve_user_name", blocked_user_name)
+    monkeypatch.setattr(poller, "_resolve_channel_title", empty_channel_title)
+    monkeypatch.setattr(poller, "_resolve_text_refs", unchanged_text)
+
+    listener_task = asyncio.create_task(
+        poller._handle_event(
+            {
+                "event": {
+                    "type": "message",
+                    "user": "U_PEER",
+                    "channel": "C_REVIEW",
+                    "channel_type": "im",
+                    "text": "late",
+                    "ts": "1.0",
+                }
+            }
+        )
+    )
+    try:
+        await asyncio.wait_for(listener_entered.wait(), timeout=1)
+        poller.stop()
+
+        await asyncio.wait_for(pollers.quiesce_delivery_tasks(), timeout=1)
+        assert client_closed.is_set()
+
+        release_listener.set()
+        await asyncio.wait_for(listener_task, timeout=1)
+        await asyncio.sleep(0)
+
+        assert not delivered.is_set()
+    finally:
+        release_listener.set()
+        await asyncio.gather(listener_task, return_exceptions=True)
+        await pollers.quiesce_delivery_tasks()
+
+
+@pytest.mark.asyncio
+async def test_discord_stop_before_scheduled_start_keeps_ingress_closed() -> None:
+    """A stop issued before the start task's first turn must not be overwritten."""
+    delivered = asyncio.Event()
+    fetch_count = 0
+
+    class Adapter:
+        @staticmethod
+        def get_me() -> dict[str, str]:
+            return {"id": "BOT", "username": "review"}
+
+        @staticmethod
+        def get_channel(_channel_id: str):
+            return SimpleNamespace(title="", chat_type="dm")
+
+        @staticmethod
+        def get_messages(_channel_id: str, *, limit: int, after: str = ""):
+            nonlocal fetch_count
+            if limit == 1:
+                return []
+            fetch_count += 1
+            if fetch_count > 1:
+                return []
+            return [
+                SimpleNamespace(
+                    sender="peer",
+                    content="late",
+                    timestamp=datetime.now(timezone.utc),
+                    message_id="1",
+                    reply_to="",
+                    metadata={"author_id": "PEER", "is_bot": False},
+                )
+            ]
+
+    class Broker:
+        @staticmethod
+        async def handle_inbound(_message) -> None:
+            delivered.set()
+
+    poller = pollers.BrokerDiscordPoller(
+        Adapter(),
+        "review-agent",
+        Broker(),
+        watched_channels=["C_REVIEW"],
+    )
+    pollers.start_poller(poller)
+    poller.stop()
+
+    try:
+        try:
+            await asyncio.wait_for(delivered.wait(), timeout=0.5)
+        except TimeoutError:
+            pass
+        assert not delivered.is_set()
+    finally:
+        poller.stop()
+        await asyncio.wait_for(pollers.quiesce_delivery_tasks(), timeout=1)

--- a/tests/test_store_lifecycle_review.py
+++ b/tests/test_store_lifecycle_review.py
@@ -1,0 +1,197 @@
+"""Adversarial review probes for Lane A shutdown centralization."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sqlite3
+import threading
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from pinky_daemon.pollers import TelegramPoller
+from pinky_daemon.store_authority import assert_no_open_store_descriptors
+from pinky_daemon.store_catalog import StoreCatalog, StoreIntegrityTarget
+
+
+def _target(
+    logical_name: str,
+    path: Path,
+    criticality: str,
+    *,
+    journal_mode: str = "wal",
+) -> StoreIntegrityTarget:
+    return StoreIntegrityTarget(
+        logical_name=logical_name,
+        path=os.fspath(path),
+        criticality=criticality,
+        journal_mode=journal_mode,
+    )
+
+
+def test_review_owner_close_after_shutdown_snapshot_is_already_finalized(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    """An owner close racing after the snapshot must not create a false failure."""
+    path = tmp_path / "owner-close.db"
+    manifest = {"delivery": _target("delivery", path, "delivery")}
+    catalog = StoreCatalog(
+        expected_root=tmp_path,
+        silence_allowlist={},
+        manifest=manifest,
+    )
+    connection = catalog.open_connection("delivery", path, owner="owner")
+    mode = str(connection.execute("PRAGMA journal_mode=WAL").fetchone()[0]).lower()
+    connection.execute("CREATE TABLE payload (value TEXT NOT NULL)")
+    connection.commit()
+    catalog.register("delivery", path, journal_mode=mode, owner="owner")
+
+    authority = catalog._connection_authority
+    authority_type = type(authority)
+    original_finalize = authority_type._finalize
+    finalizer_entered = threading.Event()
+    release_finalizer = threading.Event()
+
+    def delayed_finalize(handle) -> None:
+        finalizer_entered.set()
+        assert release_finalizer.wait(timeout=2)
+        original_finalize(handle)
+
+    monkeypatch.setattr(authority_type, "_finalize", staticmethod(delayed_finalize))
+    outcome: dict[str, object] = {}
+
+    def run_shutdown() -> None:
+        try:
+            outcome["report"] = catalog.shutdown(deadline_seconds=2)
+        except BaseException as exc:
+            outcome["error"] = exc
+
+    shutdown_thread = threading.Thread(target=run_shutdown)
+    shutdown_thread.start()
+    assert finalizer_entered.wait(timeout=2)
+    connection.close()
+    release_finalizer.set()
+    shutdown_thread.join(timeout=2)
+
+    assert not shutdown_thread.is_alive()
+    assert "error" not in outcome
+    assert outcome["report"].finalized == ("delivery",)
+
+
+def test_review_shared_wal_file_tolerates_one_finalizer_per_handle(tmp_path: Path) -> None:
+    """Two logical handles on one WAL file may both checkpoint and close."""
+    path = tmp_path / "sessions.db"
+    manifest = {
+        "sessions": _target("sessions", path, "delivery"),
+        "session_events": _target("session_events", path, "telemetry"),
+    }
+    catalog = StoreCatalog(
+        expected_root=tmp_path,
+        silence_allowlist={},
+        manifest=manifest,
+    )
+    for logical_name in manifest:
+        connection = catalog.open_connection(logical_name, path, owner="shared-owner")
+        mode = str(connection.execute("PRAGMA journal_mode=WAL").fetchone()[0]).lower()
+        connection.execute("CREATE TABLE IF NOT EXISTS payload (value TEXT NOT NULL)")
+        connection.commit()
+        catalog.register(logical_name, path, journal_mode=mode, owner="shared-owner")
+
+    report = catalog.shutdown(deadline_seconds=2)
+
+    assert report.ok
+    assert report.finalized == ("session_events", "sessions")
+    assert_no_open_store_descriptors([path])
+    assert not Path(os.fspath(path) + "-wal").exists()
+    assert not Path(os.fspath(path) + "-shm").exists()
+
+
+def test_review_authority_open_applies_the_declared_busy_timeout(tmp_path: Path) -> None:
+    """The authority seam itself must establish its manifest connection policy."""
+    path = tmp_path / "tasks.db"
+    manifest = {"tasks": _target("tasks", path, "memory")}
+    catalog = StoreCatalog(
+        expected_root=tmp_path,
+        silence_allowlist={},
+        manifest=manifest,
+    )
+
+    connection = catalog.open_connection("tasks", path, owner="review-owner")
+    try:
+        row = connection.execute("PRAGMA busy_timeout").fetchone()
+        assert row == (30_000,)
+    finally:
+        connection.close()
+
+
+def test_review_shutdown_commits_an_explicit_inflight_transaction(tmp_path: Path) -> None:
+    """Pin the dispatch spec's final-commit behavior, not merely journal cleanup."""
+    path = tmp_path / "commit.db"
+    manifest = {
+        "delivery": _target("delivery", path, "delivery", journal_mode="delete")
+    }
+    catalog = StoreCatalog(
+        expected_root=tmp_path,
+        silence_allowlist={},
+        manifest=manifest,
+    )
+    connection = catalog.open_connection("delivery", path, owner="owner")
+    mode = str(connection.execute("PRAGMA journal_mode=DELETE").fetchone()[0]).lower()
+    connection.execute("CREATE TABLE payload (value TEXT NOT NULL)")
+    connection.commit()
+    catalog.register("delivery", path, journal_mode=mode, owner="owner")
+    connection.execute("BEGIN IMMEDIATE")
+    connection.execute("INSERT INTO payload(value) VALUES ('inflight')")
+
+    catalog.shutdown(deadline_seconds=2)
+
+    with sqlite3.connect(path) as reader:
+        assert reader.execute("SELECT value FROM payload").fetchall() == [("inflight",)]
+
+
+@pytest.mark.asyncio
+async def test_review_poller_stop_is_a_delivery_publication_barrier() -> None:
+    """A poll completing after stop must not publish a new writer coroutine."""
+    poll_entered = threading.Event()
+    release_poll = threading.Event()
+    delivered = asyncio.Event()
+
+    class Adapter:
+        @staticmethod
+        def get_me():
+            return {"username": "review"}
+
+        @staticmethod
+        def get_updates(*, timeout: int):
+            assert timeout == 30
+            poll_entered.set()
+            assert release_poll.wait(timeout=2)
+            return [
+                SimpleNamespace(
+                    chat_id="chat",
+                    sender="sender",
+                    metadata={},
+                    content="late",
+                    timestamp=1.0,
+                    message_id="message",
+                )
+            ]
+
+    class Handler:
+        @staticmethod
+        async def handle(_message) -> None:
+            delivered.set()
+
+    poller = TelegramPoller(Adapter(), Handler(), poll_interval=0)
+    poller_task = asyncio.create_task(poller.start())
+    assert await asyncio.to_thread(poll_entered.wait, 2)
+
+    poller.stop()
+    release_poll.set()
+    await asyncio.wait_for(poller_task, timeout=2)
+    await asyncio.sleep(0)
+
+    assert not delivered.is_set()


### PR DESCRIPTION
## Summary

- route SQLite owner opens through a manifest-backed store catalog while preserving effective busy timeouts, journal transitions, transaction lifetimes, and rollback-transition retries
- classify stores for boot policy and class-ordered LIFO shutdown, decouple snapshot recovery selection, and bound attempt-all finalization with loud structured failures
- quiesce admitted delivery writers before store finalization, including active long polls, already-fetched batches, Slack message and interactive listeners, and stop-before-start races across every poller class

## Validation

- exact head: `d58ba01c1f5308de45052605753b9faba4ddfff0`
- lifecycle review, rereview, and quiescence tests: 17 passed
- focused storage, poller, and Slack suite: 223 passed
- full suite: 5,572 passed and 1 skipped; the sole failure is the existing environment-only live-scrape check because the optional Camoufox runtime is absent, reproduced identically at the base revision
- Ruff and `git diff --check` passed

## Residuals and harness notes

Poller instances are intentionally one-shot after `stop()`; a caller that needs to restart constructs a new instance. The synchronous interactive direct-call path retains an entry-only admission fence: there is no await between its fence and publication today, and any future await there must add task retention. Managed-handle bookkeeping still records the manifest target rather than a deliberately divergent actual-open path, and tenant catalogs still close directly because their current handles are short-lived or descriptor-only; those shapes remain follow-up work. Full-suite verification used a scrubbed environment, a trusted temporary directory, and repository `PYTHONPATH` so the signal-control subprocess imported the checkout under test.

## Screenshots

Not applicable: this changes daemon-internal storage shutdown and delivery quiescence, with no UI surface.

## Release

No deployment or production restart is included; this will ride a later release cut.

🤖 Opened by Kuzya