### PR TITLE
feat(storage): add bounded SQLite runtime observability

### DIFF
--- a/src/pinky_daemon/api.py
+++ b/src/pinky_daemon/api.py
@@ -1736,6 +1736,7 @@ def create_api(
     store_catalog = DaemonStoreCatalog(expected_root=_data_dir)
     store_catalog.configure_manifest(store_manifest)
     storage_observability = StorageObservability(store_manifest)
+    store_catalog.configure_observability(storage_observability)
     try:
         store_catalog.preflight_integrity(
             store_manifest.values(),
@@ -1745,7 +1746,10 @@ def create_api(
         store_catalog.close()
         storage_observability.record_boot_failure()
         raise
-    store_snapshot_service = StoreSnapshotService(store_catalog)
+    store_snapshot_service = StoreSnapshotService(
+        store_catalog,
+        observability=storage_observability,
+    )
 
     app = FastAPI(
         title="Pinky",
@@ -1755,6 +1759,14 @@ def create_api(
     app.state.store_snapshot_service = store_snapshot_service
     app.state.storage_observability = storage_observability
     app.state.ferry_listener = FerryListenerState.from_config(FerryConfig.from_env())
+
+    @app.middleware("http")
+    async def _activate_storage_runtime(request: Request, call_next):
+        # ``create_api`` is still constructor time. The first ASGI request is
+        # the serving boundary for test harnesses that do not run lifespan;
+        # production also enables at startup before background work begins.
+        storage_observability.enable_runtime()
+        return await call_next(request)
 
     @app.exception_handler(RequestValidationError)
     async def _request_validation_response(
@@ -12395,6 +12407,8 @@ npm run build</pre>
         """Start broker pollers, streaming sessions, scheduler, and autonomy."""
         nonlocal shared_mcp_manager
 
+        storage_observability.enable_runtime()
+
         # Lock down SQLite file permissions to owner-only. Runs here (not in
         # create_api) so every store's __init__ has already created its DB
         # file; the sweep is idempotent and best-effort.
@@ -14201,5 +14215,6 @@ npm run build</pre>
         _log(f"ERROR startup: store catalog validation failed: {exc}")
         raise
     storage_observability.record_boot_success(store_catalog.snapshot(), warnings)
+    storage_observability.arm_runtime()
 
     return app

--- a/src/pinky_daemon/storage_observability.py
+++ b/src/pinky_daemon/storage_observability.py
@@ -2,10 +2,15 @@
 
 from __future__ import annotations
 
+import bisect
 import logging
+import math
+import os
 import threading
+from dataclasses import dataclass, field
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING
+from time import monotonic_ns as _monotonic_ns
+from typing import TYPE_CHECKING, Callable
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -14,6 +19,78 @@ if TYPE_CHECKING:
     from pinky_daemon.store_snapshot import SnapshotResult
 
 logger = logging.getLogger("pinky.storage")
+
+HISTOGRAM_BOUNDS_MS = (1, 5, 10, 25, 50, 100, 250, 500, 1_000, 5_000, 30_000)
+BUSY_STREAK_THRESHOLD = 3
+LOCK_WAIT_THRESHOLD_MS = 250
+
+
+@dataclass(slots=True)
+class _BoundedHistogram:
+    bucket_counts: list[int] = field(default_factory=lambda: [0] * (len(HISTOGRAM_BOUNDS_MS) + 1))
+    count: int = 0
+
+    def record(self, upper_bound_ms: int) -> None:
+        bucket = bisect.bisect_left(HISTOGRAM_BOUNDS_MS, upper_bound_ms)
+        self.bucket_counts[bucket] += 1
+        self.count += 1
+
+    def snapshot(self) -> dict[str, object]:
+        return {
+            "count": self.count,
+            "bucket_counts": list(self.bucket_counts),
+            "overflow_count": self.bucket_counts[-1],
+            "p95_upper_bound_ms": self._quantile_upper_bound(0.95),
+            "p99_upper_bound_ms": self._quantile_upper_bound(0.99),
+        }
+
+    def _quantile_upper_bound(self, quantile: float) -> int | None:
+        if self.count == 0:
+            return None
+        rank = math.ceil(quantile * self.count)
+        observed = 0
+        for index, count in enumerate(self.bucket_counts):
+            observed += count
+            if observed >= rank:
+                if index == len(HISTOGRAM_BOUNDS_MS):
+                    return None
+                return HISTOGRAM_BOUNDS_MS[index]
+        raise AssertionError("histogram count diverged from its fixed buckets")
+
+
+@dataclass(slots=True)
+class _WriterQueueDepth:
+    cohort_id: str
+    current: int = 0
+    high_water: int = 0
+
+
+@dataclass(slots=True)
+class _RuntimeStoreMetrics:
+    writer_queue_depth: _WriterQueueDepth
+    busy_results_total: int = 0
+    locked_results_total: int = 0
+    busy_streak_current: int = 0
+    busy_streak_max: int = 0
+    busy_event_latched: bool = False
+    lock_wait_event_latched: bool = False
+    lock_wait: _BoundedHistogram = field(default_factory=_BoundedHistogram)
+    transaction_duration: _BoundedHistogram = field(default_factory=_BoundedHistogram)
+    committed_total: int = 0
+    rolled_back_total: int = 0
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeOperation:
+    """One enabled SQLite call whose timer and queue slot must finish exactly once."""
+
+    logical_name: str
+    started_ns: int
+    lock_bearing: bool
+
+
+def _elapsed_upper_bound_ms(started_ns: int, finished_ns: int) -> int:
+    return max(0, math.ceil((finished_ns - started_ns) / 1_000_000))
 
 
 def _timestamp() -> str:
@@ -30,9 +107,17 @@ def emit_storage_event(event: str, /, **fields: str | int) -> None:
 class StorageObservability:
     """Current-boot metrics exposed through the existing watchdog endpoint."""
 
-    def __init__(self, manifest: dict[str, StoreIntegrityTarget]) -> None:
+    def __init__(
+        self,
+        manifest: dict[str, StoreIntegrityTarget],
+        *,
+        clock_ns: Callable[[], int] | None = None,
+    ) -> None:
         self._lock = threading.RLock()
         self._manifest = dict(manifest)
+        self._clock_ns = clock_ns
+        self._runtime_armed = False
+        self._runtime_enabled = False
         self._preflight = {logical_name: "pending" for logical_name in self._manifest}
         self._boot_gate: dict[str, object] = {
             "outcome": "pending",
@@ -53,6 +138,221 @@ class StorageObservability:
             }
             for logical_name in self._manifest
         }
+        queue_depths: dict[str, _WriterQueueDepth] = {}
+        self._runtime: dict[str, _RuntimeStoreMetrics] = {}
+        for logical_name, target in self._manifest.items():
+            physical_path = os.path.realpath(os.fspath(target.path))
+            depth = queue_depths.get(physical_path)
+            if depth is None:
+                depth = _WriterQueueDepth(cohort_id=f"store-{len(queue_depths) + 1:02d}")
+                queue_depths[physical_path] = depth
+            self._runtime[logical_name] = _RuntimeStoreMetrics(writer_queue_depth=depth)
+        self._corruption_preflight_refusals_total = 0
+        self._corruption_quick_check_failures_total = 0
+        self._corruption = {
+            logical_name: {
+                "preflight_refusals": 0,
+                "quick_check_failures": 0,
+            }
+            for logical_name in self._manifest
+        }
+
+    def enable_runtime(self) -> None:
+        """Enable synchronous runtime recording after boot-time construction."""
+        with self._lock:
+            self._runtime_enabled = True
+
+    def arm_runtime(self) -> None:
+        """Mark boot complete so the next catalog/ASGI service boundary can enable."""
+        with self._lock:
+            self._runtime_armed = True
+
+    def enable_runtime_if_armed(self) -> None:
+        """Activate recording only after the owning API completed its boot gate."""
+        with self._lock:
+            if self._runtime_armed:
+                self._runtime_enabled = True
+
+    def begin_runtime_operation(
+        self,
+        logical_name: str,
+        *,
+        lock_bearing: bool,
+    ) -> RuntimeOperation | None:
+        """Start one operation without reading the clock while recording is disabled."""
+        with self._lock:
+            if not self._runtime_enabled or logical_name not in self._runtime:
+                return None
+        started_ns = self._read_clock_ns()
+        if lock_bearing:
+            with self._lock:
+                depth = self._runtime[logical_name].writer_queue_depth
+                depth.current += 1
+                depth.high_water = max(depth.high_water, depth.current)
+        return RuntimeOperation(
+            logical_name=logical_name,
+            started_ns=started_ns,
+            lock_bearing=lock_bearing,
+        )
+
+    def finish_runtime_operation(
+        self,
+        operation: RuntimeOperation,
+        *,
+        succeeded: bool,
+        sqlite_primary_error_code: int | None = None,
+    ) -> int:
+        """Finish one timed call and always release its physical writer queue slot."""
+        try:
+            finished_ns = self._read_clock_ns()
+        finally:
+            if operation.lock_bearing:
+                with self._lock:
+                    depth = self._runtime[operation.logical_name].writer_queue_depth
+                    depth.current -= 1
+                    if depth.current < 0:
+                        raise AssertionError("writer queue depth became negative")
+
+        upper_bound_ms = _elapsed_upper_bound_ms(operation.started_ns, finished_ns)
+        busy_event = False
+        wait_event = False
+        wait_observed_ms = 0
+        with self._lock:
+            metrics = self._runtime[operation.logical_name]
+            if operation.lock_bearing:
+                metrics.lock_wait.record(upper_bound_ms)
+                if upper_bound_ms > LOCK_WAIT_THRESHOLD_MS:
+                    if not metrics.lock_wait_event_latched:
+                        metrics.lock_wait_event_latched = True
+                        wait_event = True
+                        wait_observed_ms = upper_bound_ms
+                else:
+                    metrics.lock_wait_event_latched = False
+
+            if sqlite_primary_error_code == 5:
+                metrics.busy_results_total += 1
+                metrics.busy_streak_current += 1
+                metrics.busy_streak_max = max(
+                    metrics.busy_streak_max,
+                    metrics.busy_streak_current,
+                )
+                if (
+                    metrics.busy_streak_current >= BUSY_STREAK_THRESHOLD
+                    and not metrics.busy_event_latched
+                ):
+                    metrics.busy_event_latched = True
+                    busy_event = True
+            elif sqlite_primary_error_code == 6:
+                metrics.locked_results_total += 1
+            elif succeeded and operation.lock_bearing:
+                metrics.busy_streak_current = 0
+                metrics.busy_event_latched = False
+
+        if busy_event:
+            emit_storage_event(
+                "contention",
+                logical_name=operation.logical_name,
+                kind="busy_streak",
+                observed=BUSY_STREAK_THRESHOLD,
+                threshold=BUSY_STREAK_THRESHOLD,
+            )
+        if wait_event:
+            emit_storage_event(
+                "contention",
+                logical_name=operation.logical_name,
+                kind="lock_wait_upper_bound",
+                observed_ms=wait_observed_ms,
+                threshold_ms=LOCK_WAIT_THRESHOLD_MS,
+            )
+        return finished_ns
+
+    def record_transaction_duration(
+        self,
+        logical_name: str,
+        started_ns: int,
+        finished_ns: int,
+        *,
+        outcome: str | None = None,
+    ) -> None:
+        """Record one completed transaction using an already-read end timestamp."""
+        upper_bound_ms = _elapsed_upper_bound_ms(started_ns, finished_ns)
+        with self._lock:
+            metrics = self._runtime[logical_name]
+            metrics.transaction_duration.record(upper_bound_ms)
+            if outcome == "committed":
+                metrics.committed_total += 1
+            elif outcome == "rolled_back":
+                metrics.rolled_back_total += 1
+
+    def finish_transaction(
+        self,
+        logical_name: str,
+        started_ns: int,
+        *,
+        outcome: str,
+    ) -> None:
+        """Read one load-bearing end time for commit/rollback method calls."""
+        self.record_transaction_duration(
+            logical_name,
+            started_ns,
+            self._read_clock_ns(),
+            outcome=outcome,
+        )
+
+    def start_transaction(self) -> int | None:
+        """Start timing a transaction that became active before runtime enablement."""
+        with self._lock:
+            if not self._runtime_enabled:
+                return None
+        return self._read_clock_ns()
+
+    def record_preflight_refusal(
+        self,
+        logical_names: Iterable[str],
+        *,
+        quick_check_failed: bool,
+    ) -> None:
+        """Count one rejected physical store and fan it out to its logical aliases."""
+        names = tuple(dict.fromkeys(logical_names))
+        with self._lock:
+            self._corruption_preflight_refusals_total += 1
+            if quick_check_failed:
+                self._corruption_quick_check_failures_total += 1
+            for logical_name in names:
+                metrics = self._corruption.get(logical_name)
+                if metrics is None:
+                    continue
+                metrics["preflight_refusals"] += 1
+                if quick_check_failed:
+                    metrics["quick_check_failures"] += 1
+        emit_storage_event(
+            "corruption",
+            source="preflight",
+            logical_name=names[0] if names else "unknown",
+            logical_count=len(names),
+        )
+
+    def record_snapshot_quick_check_failure(self, logical_names: Iterable[str]) -> None:
+        """Count one failed destination copy and fan it out to its logical aliases."""
+        names = tuple(dict.fromkeys(logical_names))
+        with self._lock:
+            self._corruption_quick_check_failures_total += 1
+            for logical_name in names:
+                metrics = self._corruption.get(logical_name)
+                if metrics is not None:
+                    metrics["quick_check_failures"] += 1
+        emit_storage_event(
+            "corruption",
+            source="snapshot",
+            logical_name=names[0] if names else "unknown",
+            logical_count=len(names),
+        )
+
+    def _read_clock_ns(self) -> int:
+        clock_ns = self._clock_ns
+        if clock_ns is not None:
+            return clock_ns()
+        return _monotonic_ns()
 
     def record_preflight(self, logical_name: str, outcome: str) -> None:
         timestamp = _timestamp()
@@ -142,4 +442,44 @@ class StorageObservability:
                 },
                 "reconcile_warning_count": self._reconcile_warning_count,
                 "snapshots": {name: dict(metrics) for name, metrics in self._snapshots.items()},
+                "runtime": {
+                    "enabled": self._runtime_enabled,
+                    "histogram_bounds_ms": list(HISTOGRAM_BOUNDS_MS),
+                    "thresholds": {
+                        "busy_streak": BUSY_STREAK_THRESHOLD,
+                        "lock_wait_upper_bound_ms": LOCK_WAIT_THRESHOLD_MS,
+                    },
+                    "stores": {
+                        name: self._runtime_store_snapshot(metrics)
+                        for name, metrics in self._runtime.items()
+                    },
+                },
+                "corruption": {
+                    "preflight_refusals_total": self._corruption_preflight_refusals_total,
+                    "quick_check_failures_total": self._corruption_quick_check_failures_total,
+                    "stores": {name: dict(metrics) for name, metrics in self._corruption.items()},
+                },
             }
+
+    @staticmethod
+    def _runtime_store_snapshot(metrics: _RuntimeStoreMetrics) -> dict[str, object]:
+        depth = metrics.writer_queue_depth
+        return {
+            "busy_results_total": metrics.busy_results_total,
+            "locked_results_total": metrics.locked_results_total,
+            "busy_streak": {
+                "current": metrics.busy_streak_current,
+                "max": metrics.busy_streak_max,
+            },
+            "lock_wait_upper_bound_ms": metrics.lock_wait.snapshot(),
+            "transaction_duration_ms": metrics.transaction_duration.snapshot(),
+            "transactions": {
+                "committed_total": metrics.committed_total,
+                "rolled_back_total": metrics.rolled_back_total,
+            },
+            "writer_queue_depth": {
+                "cohort_id": depth.cohort_id,
+                "current": depth.current,
+                "high_water": depth.high_water,
+            },
+        }

--- a/src/pinky_daemon/storage_observability.py
+++ b/src/pinky_daemon/storage_observability.py
@@ -226,7 +226,7 @@ class StorageObservability:
                         metrics.lock_wait_event_latched = True
                         wait_event = True
                         wait_observed_ms = upper_bound_ms
-                else:
+                elif succeeded:
                     metrics.lock_wait_event_latched = False
 
             if sqlite_primary_error_code == 5:

--- a/src/pinky_daemon/store_catalog.py
+++ b/src/pinky_daemon/store_catalog.py
@@ -102,10 +102,7 @@ def _sql_is_lock_bearing(statement: str, token: str) -> bool:
     """Classify bounded SQL, including assignment-form mutating PRAGMAs."""
     if token != "PRAGMA":
         return token not in _READ_ONLY_SQL_TOKENS
-    for character in statement[:64]:
-        if character == "=":
-            return True
-    return False
+    return "=" in statement
 
 
 def _sqlite_header_journal_mode(header: bytes) -> str | None:

--- a/src/pinky_daemon/store_catalog.py
+++ b/src/pinky_daemon/store_catalog.py
@@ -14,10 +14,13 @@ import threading
 from collections.abc import Callable, Iterable, Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from urllib.parse import parse_qsl
 
 from pinky_daemon.store_shutdown import StoreShutdownCoordinator, StoreShutdownReport
+
+if TYPE_CHECKING:
+    from pinky_daemon.storage_observability import RuntimeOperation, StorageObservability
 
 logger = logging.getLogger("pinky.store_catalog")
 
@@ -65,6 +68,34 @@ _SQLITE_SIDECAR_SUFFIXES = ("-wal", "-shm", "-journal")
 _IGNORED_DIRECTORY_KINDS = frozenset({"snapshot", "snapshots", "temp", "temporary", "tmp"})
 _SQLITE_HEADER_PREFIX = b"SQLite format 3\x00"
 _SQLITE_HEADER_JOURNAL_BYTES = slice(18, 20)
+_READ_ONLY_SQL_TOKENS = frozenset({"EXPLAIN", "PRAGMA", "SELECT", "VALUES"})
+_ROLLBACK_SQL_TOKENS = frozenset({"ROLLBACK"})
+
+
+def _first_sql_token(statement: str) -> str:
+    """Classify from at most 64 bytes of SQL without a regex or full-string scan."""
+    prefix = statement[:64]
+    index = 0
+    while index < len(prefix):
+        while index < len(prefix) and prefix[index].isspace():
+            index += 1
+        if prefix.startswith("--", index):
+            newline = prefix.find("\n", index + 2)
+            if newline < 0:
+                return ""
+            index = newline + 1
+            continue
+        if prefix.startswith("/*", index):
+            comment_end = prefix.find("*/", index + 2)
+            if comment_end < 0:
+                return ""
+            index = comment_end + 2
+            continue
+        break
+    token_start = index
+    while index < len(prefix) and (prefix[index].isalnum() or prefix[index] == "_"):
+        index += 1
+    return prefix[token_start:index].upper()
 
 
 def _sqlite_header_journal_mode(header: bytes) -> str | None:
@@ -306,13 +337,241 @@ class StoreCatalogError(RuntimeError):
 
 
 class _ManagedSQLiteConnection(sqlite3.Connection):
-    """Connection subclass that removes itself from the live-handle ledger."""
+    """Catalog connection with optional synchronous runtime recording."""
 
     _store_authority: _StoreConnectionAuthority | None = None
     _store_handle_id: int | None = None
+    _store_logical_name: str | None = None
+    _store_observability: StorageObservability | None = None
+    _store_transaction_started_ns: int | None = None
+    _store_closed = False
+
+    @property
+    def in_transaction(self) -> bool:
+        """Preserve the final false state for post-close ledger inspection."""
+        if self._store_closed:
+            return False
+        descriptor = sqlite3.Connection.in_transaction
+        return bool(descriptor.__get__(self, type(self)))
+
+    def execute(
+        self,
+        sql: str,
+        parameters: Any = (),
+        /,
+    ) -> sqlite3.Cursor:
+        execute = super().execute
+        return self._run_observed_statement(sql, lambda: execute(sql, parameters))
+
+    def executemany(
+        self,
+        sql: str,
+        seq_of_parameters: Iterable[Any],
+        /,
+    ) -> sqlite3.Cursor:
+        executemany = super().executemany
+        return self._run_observed_statement(
+            sql,
+            lambda: executemany(sql, seq_of_parameters),
+        )
+
+    def executescript(self, sql_script: str, /) -> sqlite3.Cursor:
+        executescript = super().executescript
+        return self._run_observed_statement(sql_script, lambda: executescript(sql_script))
+
+    def commit(self) -> None:
+        observability = self._store_observability
+        logical_name = self._store_logical_name
+        if observability is None or logical_name is None or not self.in_transaction:
+            return super().commit()
+        started_ns = self._store_transaction_started_ns
+        if started_ns is None:
+            started_ns = observability.start_transaction()
+        try:
+            super().commit()
+        except BaseException:
+            if not self.in_transaction:
+                self._store_transaction_started_ns = None
+            raise
+        if started_ns is not None and not self.in_transaction:
+            observability.finish_transaction(
+                logical_name,
+                started_ns,
+                outcome="committed",
+            )
+            self._store_transaction_started_ns = None
+
+    def rollback(self) -> None:
+        observability = self._store_observability
+        logical_name = self._store_logical_name
+        if observability is None or logical_name is None or not self.in_transaction:
+            return super().rollback()
+        started_ns = self._store_transaction_started_ns
+        if started_ns is None:
+            started_ns = observability.start_transaction()
+        try:
+            super().rollback()
+        except BaseException:
+            if not self.in_transaction:
+                self._store_transaction_started_ns = None
+            raise
+        if started_ns is not None and not self.in_transaction:
+            observability.finish_transaction(
+                logical_name,
+                started_ns,
+                outcome="rolled_back",
+            )
+            self._store_transaction_started_ns = None
+
+    def __enter__(self) -> _ManagedSQLiteConnection:
+        super().__enter__()
+        return self
+
+    def __exit__(self, exc_type, exc, traceback) -> bool:
+        observability = self._store_observability
+        logical_name = self._store_logical_name
+        transaction_active = self.in_transaction
+        started_ns = self._store_transaction_started_ns
+        if observability is not None and transaction_active and started_ns is None:
+            started_ns = observability.start_transaction()
+            self._store_transaction_started_ns = started_ns
+        try:
+            suppressed = super().__exit__(exc_type, exc, traceback)
+        except BaseException:
+            if not self.in_transaction:
+                self._finish_context_transaction(
+                    observability,
+                    logical_name,
+                    started_ns,
+                    outcome="rolled_back",
+                )
+            raise
+        if transaction_active and not self.in_transaction:
+            self._finish_context_transaction(
+                observability,
+                logical_name,
+                started_ns,
+                outcome="committed" if exc_type is None else "rolled_back",
+            )
+        return bool(suppressed)
+
+    def _run_observed_statement(
+        self,
+        statement: str,
+        call: Callable[[], sqlite3.Cursor],
+    ) -> sqlite3.Cursor:
+        observability = self._store_observability
+        logical_name = self._store_logical_name
+        if observability is None or logical_name is None:
+            return call()
+        token = _first_sql_token(statement)
+        operation = observability.begin_runtime_operation(
+            logical_name,
+            lock_bearing=token not in _READ_ONLY_SQL_TOKENS,
+        )
+        if operation is None:
+            return call()
+
+        transaction_before = self.in_transaction
+        try:
+            cursor = call()
+        except BaseException as exc:
+            primary_error_code = None
+            if isinstance(exc, sqlite3.Error):
+                error_code = getattr(exc, "sqlite_errorcode", None)
+                if error_code is not None:
+                    primary_error_code = int(error_code) & 0xFF
+            finished_ns = observability.finish_runtime_operation(
+                operation,
+                succeeded=False,
+                sqlite_primary_error_code=primary_error_code,
+            )
+            self._record_transaction_transition(
+                operation,
+                finished_ns,
+                token,
+                transaction_before=transaction_before,
+                transaction_after=self.in_transaction,
+                succeeded=False,
+            )
+            raise
+
+        finished_ns = observability.finish_runtime_operation(operation, succeeded=True)
+        self._record_transaction_transition(
+            operation,
+            finished_ns,
+            token,
+            transaction_before=transaction_before,
+            transaction_after=self.in_transaction,
+            succeeded=True,
+        )
+        return cursor
+
+    def _record_transaction_transition(
+        self,
+        operation: RuntimeOperation,
+        finished_ns: int,
+        sql_token: str,
+        *,
+        transaction_before: bool,
+        transaction_after: bool,
+        succeeded: bool,
+    ) -> None:
+        observability = self._store_observability
+        logical_name = self._store_logical_name
+        if observability is None or logical_name is None:
+            return
+        if not transaction_before and transaction_after:
+            self._store_transaction_started_ns = operation.started_ns
+            return
+        if transaction_before and not transaction_after:
+            started_ns = self._store_transaction_started_ns
+            if started_ns is not None:
+                outcome = (
+                    "rolled_back"
+                    if sql_token in _ROLLBACK_SQL_TOKENS or not succeeded
+                    else "committed"
+                )
+                observability.record_transaction_duration(
+                    logical_name,
+                    started_ns,
+                    finished_ns,
+                    outcome=outcome,
+                )
+            self._store_transaction_started_ns = None
+            return
+        if (
+            not transaction_before
+            and not transaction_after
+            and succeeded
+            and operation.lock_bearing
+        ):
+            observability.record_transaction_duration(
+                logical_name,
+                operation.started_ns,
+                finished_ns,
+            )
+
+    def _finish_context_transaction(
+        self,
+        observability: StorageObservability | None,
+        logical_name: str | None,
+        started_ns: int | None,
+        *,
+        outcome: str,
+    ) -> None:
+        if (
+            observability is not None
+            and logical_name is not None
+            and started_ns is not None
+            and self._store_transaction_started_ns is not None
+        ):
+            observability.finish_transaction(logical_name, started_ns, outcome=outcome)
+        self._store_transaction_started_ns = None
 
     def close(self) -> None:
         super().close()
+        self._store_closed = True
         authority = self._store_authority
         handle_id = self._store_handle_id
         if authority is not None and handle_id is not None:
@@ -399,6 +658,8 @@ class _StoreConnectionAuthority:
             )
             connection._store_authority = self
             connection._store_handle_id = handle_id
+            connection._store_logical_name = logical_name
+            connection._store_observability = self._catalog._observability
             self._handles[handle_id] = handle
             return connection
 
@@ -529,6 +790,7 @@ class StoreCatalog:
         *,
         silence_allowlist: Mapping[str, str] | None = None,
         manifest: Mapping[str, StoreIntegrityTarget] | None = None,
+        observability: StorageObservability | None = None,
     ) -> None:
         root = os.getcwd() if expected_root is None else os.fspath(expected_root)
         self._expected_root = os.path.realpath(root)
@@ -537,6 +799,7 @@ class StoreCatalog:
         )
         self._silence_allowlist = dict(configured_allowlist)
         self._manifest = dict(manifest or {})
+        self._observability = observability
         self._entries: list[_CatalogEntry] = []
         self._observations: list[StoreObservation] = []
         self._lock = threading.RLock()
@@ -560,6 +823,13 @@ class StoreCatalog:
             if self._entries:
                 raise StoreCatalogError("store manifest cannot change after registration")
             self._manifest = dict(manifest)
+
+    def configure_observability(self, observability: StorageObservability) -> None:
+        """Attach the optional recorder before catalog-owned connections open."""
+        with self._lock:
+            if self._entries:
+                raise StoreCatalogError("storage observability cannot change after registration")
+            self._observability = observability
 
     def connection_policy(self, logical_name: str) -> StoreConnectionPolicy:
         """Return the catalog-declared connection policy for one store."""
@@ -602,6 +872,8 @@ class StoreCatalog:
         **kwargs: Any,
     ) -> sqlite3.Connection:
         """Open and track one connection under the catalog's declared policy."""
+        if self._observability is not None:
+            self._observability.enable_runtime_if_armed()
         return self._connection_authority.open(
             logical_name,
             database,
@@ -1019,6 +1291,7 @@ class StoreCatalog:
                 self._raise_integrity_error(matching_targets, absolute_path, exc)
 
             retain_bound_file = False
+            quick_check_failed = False
             try:
                 header_journal_mode = bound_file.header_journal_mode()
                 rollback_required = any(
@@ -1051,7 +1324,11 @@ class StoreCatalog:
                         journal_row = connection.execute("PRAGMA journal_mode").fetchone()
                         if journal_row and journal_row[0]:
                             observed_journal_mode = str(journal_row[0]).lower()
-                    rows = connection.execute("PRAGMA quick_check").fetchall()
+                    try:
+                        rows = connection.execute("PRAGMA quick_check").fetchall()
+                    except sqlite3.Error:
+                        quick_check_failed = True
+                        raise
                 finally:
                     connection.close()
 
@@ -1118,7 +1395,12 @@ class StoreCatalog:
                     outcomes,
                     on_outcome,
                 )
-                self._raise_integrity_error(matching_targets, absolute_path, exc)
+                self._raise_integrity_error(
+                    matching_targets,
+                    absolute_path,
+                    exc,
+                    quick_check_failed=quick_check_failed,
+                )
             else:
                 if rows != [("ok",)]:
                     self._record_integrity_outcomes(
@@ -1131,6 +1413,7 @@ class StoreCatalog:
                         matching_targets,
                         absolute_path,
                         f"PRAGMA quick_check returned {rows!r}",
+                        quick_check_failed=True,
                     )
                 observation = StoreObservation(
                     logical_names=logical_names,
@@ -1179,12 +1462,19 @@ class StoreCatalog:
             if on_outcome is not None:
                 on_outcome(target.logical_name, outcome)
 
-    @staticmethod
     def _raise_integrity_error(
+        self,
         targets: list[StoreIntegrityTarget],
         resolved_path: str,
         detail: BaseException | str,
+        *,
+        quick_check_failed: bool = False,
     ) -> None:
+        if self._observability is not None:
+            self._observability.record_preflight_refusal(
+                (target.logical_name for target in targets),
+                quick_check_failed=quick_check_failed,
+            )
         logical_names = ", ".join(target.logical_name for target in targets)
         if isinstance(detail, BaseException):
             rendered_detail = f"{type(detail).__name__}: {detail}"
@@ -1666,9 +1956,7 @@ class DaemonStoreCatalog(StoreCatalog):
             newly_opened = matching_descriptors.difference(descriptors_before)
             sqlite_reused = matching_descriptors.intersection(descriptors_before)
             if not newly_opened and not sqlite_reused:
-                raise OSError(
-                    "pathname-opened WAL database does not match its pinned preflight fd"
-                )
+                raise OSError("pathname-opened WAL database does not match its pinned preflight fd")
             bound_file.require_path_unchanged()
         except BaseException:
             connection.close()
@@ -1681,8 +1969,7 @@ class DaemonStoreCatalog(StoreCatalog):
         resolved_parent = os.path.dirname(resolved_path)
         if not self._is_under_expected_root(resolved_path):
             raise PermissionError(
-                "WAL preflight path escapes the daemon-owned catalog root: "
-                f"{resolved_path!r}"
+                f"WAL preflight path escapes the daemon-owned catalog root: {resolved_path!r}"
             )
 
         daemon_uid = os.geteuid()

--- a/src/pinky_daemon/store_catalog.py
+++ b/src/pinky_daemon/store_catalog.py
@@ -98,6 +98,16 @@ def _first_sql_token(statement: str) -> str:
     return prefix[token_start:index].upper()
 
 
+def _sql_is_lock_bearing(statement: str, token: str) -> bool:
+    """Classify bounded SQL, including assignment-form mutating PRAGMAs."""
+    if token != "PRAGMA":
+        return token not in _READ_ONLY_SQL_TOKENS
+    for character in statement[:64]:
+        if character == "=":
+            return True
+    return False
+
+
 def _sqlite_header_journal_mode(header: bytes) -> str | None:
     if len(header) < 20 or not header.startswith(_SQLITE_HEADER_PREFIX):
         return None
@@ -344,6 +354,7 @@ class _ManagedSQLiteConnection(sqlite3.Connection):
     _store_logical_name: str | None = None
     _store_observability: StorageObservability | None = None
     _store_transaction_started_ns: int | None = None
+    _store_boundary_observation_depth = 0
     _store_closed = False
 
     @property
@@ -380,80 +391,87 @@ class _ManagedSQLiteConnection(sqlite3.Connection):
         return self._run_observed_statement(sql_script, lambda: executescript(sql_script))
 
     def commit(self) -> None:
-        observability = self._store_observability
-        logical_name = self._store_logical_name
-        if observability is None or logical_name is None or not self.in_transaction:
-            return super().commit()
-        started_ns = self._store_transaction_started_ns
-        if started_ns is None:
-            started_ns = observability.start_transaction()
-        try:
-            super().commit()
-        except BaseException:
-            if not self.in_transaction:
-                self._store_transaction_started_ns = None
-            raise
-        if started_ns is not None and not self.in_transaction:
-            observability.finish_transaction(
-                logical_name,
-                started_ns,
-                outcome="committed",
-            )
-            self._store_transaction_started_ns = None
+        commit = super().commit
+        if self._store_boundary_observation_depth:
+            return commit()
+        self._run_observed_transaction_boundary(commit, sql_token="COMMIT")
 
     def rollback(self) -> None:
-        observability = self._store_observability
-        logical_name = self._store_logical_name
-        if observability is None or logical_name is None or not self.in_transaction:
-            return super().rollback()
-        started_ns = self._store_transaction_started_ns
-        if started_ns is None:
-            started_ns = observability.start_transaction()
-        try:
-            super().rollback()
-        except BaseException:
-            if not self.in_transaction:
-                self._store_transaction_started_ns = None
-            raise
-        if started_ns is not None and not self.in_transaction:
-            observability.finish_transaction(
-                logical_name,
-                started_ns,
-                outcome="rolled_back",
-            )
-            self._store_transaction_started_ns = None
+        rollback = super().rollback
+        if self._store_boundary_observation_depth:
+            return rollback()
+        self._run_observed_transaction_boundary(rollback, sql_token="ROLLBACK")
 
     def __enter__(self) -> _ManagedSQLiteConnection:
         super().__enter__()
         return self
 
     def __exit__(self, exc_type, exc, traceback) -> bool:
+        exit_context = super().__exit__
+        if self._store_boundary_observation_depth:
+            return bool(exit_context(exc_type, exc, traceback))
+        suppressed = self._run_observed_transaction_boundary(
+            lambda: exit_context(exc_type, exc, traceback),
+            sql_token="COMMIT" if exc_type is None else "ROLLBACK",
+        )
+        return bool(suppressed)
+
+    def _run_observed_transaction_boundary(
+        self,
+        call: Callable[[], Any],
+        *,
+        sql_token: str,
+    ) -> Any:
         observability = self._store_observability
         logical_name = self._store_logical_name
-        transaction_active = self.in_transaction
-        started_ns = self._store_transaction_started_ns
-        if observability is not None and transaction_active and started_ns is None:
-            started_ns = observability.start_transaction()
-            self._store_transaction_started_ns = started_ns
+        transaction_before = self.in_transaction
+        if observability is None or logical_name is None or not transaction_before:
+            return call()
+        operation = observability.begin_runtime_operation(
+            logical_name,
+            lock_bearing=sql_token not in _ROLLBACK_SQL_TOKENS,
+        )
+        if operation is None:
+            return call()
+        if self._store_transaction_started_ns is None:
+            self._store_transaction_started_ns = operation.started_ns
+
+        self._store_boundary_observation_depth += 1
         try:
-            suppressed = super().__exit__(exc_type, exc, traceback)
-        except BaseException:
-            if not self.in_transaction:
-                self._finish_context_transaction(
-                    observability,
-                    logical_name,
-                    started_ns,
-                    outcome="rolled_back",
-                )
-            raise
-        if transaction_active and not self.in_transaction:
-            self._finish_context_transaction(
-                observability,
-                logical_name,
-                started_ns,
-                outcome="committed" if exc_type is None else "rolled_back",
+            result = call()
+        except BaseException as exc:
+            primary_error_code = None
+            if isinstance(exc, sqlite3.Error):
+                error_code = getattr(exc, "sqlite_errorcode", None)
+                if error_code is not None:
+                    primary_error_code = int(error_code) & 0xFF
+            finished_ns = observability.finish_runtime_operation(
+                operation,
+                succeeded=False,
+                sqlite_primary_error_code=primary_error_code,
             )
-        return bool(suppressed)
+            self._record_transaction_transition(
+                operation,
+                finished_ns,
+                sql_token,
+                transaction_before=transaction_before,
+                transaction_after=self.in_transaction,
+                succeeded=False,
+            )
+            raise
+        finally:
+            self._store_boundary_observation_depth -= 1
+
+        finished_ns = observability.finish_runtime_operation(operation, succeeded=True)
+        self._record_transaction_transition(
+            operation,
+            finished_ns,
+            sql_token,
+            transaction_before=transaction_before,
+            transaction_after=self.in_transaction,
+            succeeded=True,
+        )
+        return result
 
     def _run_observed_statement(
         self,
@@ -467,7 +485,7 @@ class _ManagedSQLiteConnection(sqlite3.Connection):
         token = _first_sql_token(statement)
         operation = observability.begin_runtime_operation(
             logical_name,
-            lock_bearing=token not in _READ_ONLY_SQL_TOKENS,
+            lock_bearing=_sql_is_lock_bearing(statement, token),
         )
         if operation is None:
             return call()
@@ -552,32 +570,44 @@ class _ManagedSQLiteConnection(sqlite3.Connection):
                 finished_ns,
             )
 
-    def _finish_context_transaction(
-        self,
-        observability: StorageObservability | None,
-        logical_name: str | None,
-        started_ns: int | None,
-        *,
-        outcome: str,
-    ) -> None:
-        if (
-            observability is not None
-            and logical_name is not None
-            and started_ns is not None
-            and self._store_transaction_started_ns is not None
-        ):
-            observability.finish_transaction(logical_name, started_ns, outcome=outcome)
-        self._store_transaction_started_ns = None
-
     def close(self) -> None:
-        super().close()
+        transaction_active = self.in_transaction
+        observability = self._store_observability
+        logical_name = self._store_logical_name
+        started_ns = self._store_transaction_started_ns
+        if (
+            transaction_active
+            and started_ns is None
+            and observability is not None
+            and logical_name is not None
+        ):
+            started_ns = observability.start_transaction()
+        self._store_boundary_observation_depth += 1
+        try:
+            super().close()
+        finally:
+            self._store_boundary_observation_depth -= 1
         self._store_closed = True
-        authority = self._store_authority
-        handle_id = self._store_handle_id
-        if authority is not None and handle_id is not None:
-            authority._forget(handle_id)
-            self._store_authority = None
-            self._store_handle_id = None
+        try:
+            if (
+                transaction_active
+                and observability is not None
+                and logical_name is not None
+                and started_ns is not None
+            ):
+                observability.finish_transaction(
+                    logical_name,
+                    started_ns,
+                    outcome="rolled_back",
+                )
+        finally:
+            self._store_transaction_started_ns = None
+            authority = self._store_authority
+            handle_id = self._store_handle_id
+            if authority is not None and handle_id is not None:
+                authority._forget(handle_id)
+                self._store_authority = None
+                self._store_handle_id = None
 
 
 @dataclass(slots=True)
@@ -1375,6 +1405,7 @@ class StoreCatalog:
                         f"was unperformable: preflight={type(exc).__name__}: {exc}; "
                         "reconciliation="
                         f"{type(reconciliation_error).__name__}: {reconciliation_error}",
+                        quick_check_failed=quick_check_failed,
                     )
                 if failure_path_state == "absent":
                     observation = StoreObservation.absent(logical_names, absolute_path)

--- a/src/pinky_daemon/store_snapshot.py
+++ b/src/pinky_daemon/store_snapshot.py
@@ -12,9 +12,12 @@ import uuid
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Callable, Literal
+from typing import TYPE_CHECKING, Callable, Literal
 
 from pinky_daemon.store_catalog import StoreCatalog, StoreRecord
+
+if TYPE_CHECKING:
+    from pinky_daemon.storage_observability import StorageObservability
 
 BACKUP_PAGES = 64
 BACKUP_SLEEP_SECONDS = 0.01
@@ -86,8 +89,14 @@ class _SelectedStore:
 class StoreSnapshotService:
     """Produce verified copies without exposing live database files to callers."""
 
-    def __init__(self, catalog: StoreCatalog) -> None:
+    def __init__(
+        self,
+        catalog: StoreCatalog,
+        *,
+        observability: StorageObservability | None = None,
+    ) -> None:
         self._catalog = catalog
+        self._observability = observability
 
     def create_snapshots(
         self,
@@ -265,7 +274,12 @@ class StoreSnapshotService:
 
         try:
             try:
-                self._backup_and_verify(store.resolved_path, temp_path, source_identity)
+                self._backup_and_verify(
+                    store.resolved_path,
+                    temp_path,
+                    source_identity,
+                    store.logical_names,
+                )
             except (FileNotFoundError, sqlite3.OperationalError):
                 if not os.path.exists(store.resolved_path):
                     return SnapshotResult(
@@ -300,6 +314,7 @@ class StoreSnapshotService:
         source_path: str,
         destination_path: Path,
         expected_identity: tuple[int, int],
+        logical_names: tuple[str, ...] = (),
     ) -> None:
         source: sqlite3.Connection | None = None
         destination: sqlite3.Connection | None = None
@@ -322,8 +337,15 @@ class StoreSnapshotService:
                 sleep=BACKUP_SLEEP_SECONDS,
             )
             self._assert_source_identity(source_path, expected_identity)
-            check_rows = destination.execute("PRAGMA quick_check").fetchall()
+            try:
+                check_rows = destination.execute("PRAGMA quick_check").fetchall()
+            except sqlite3.Error:
+                if self._observability is not None:
+                    self._observability.record_snapshot_quick_check_failure(logical_names)
+                raise
             if check_rows != [("ok",)]:
+                if self._observability is not None:
+                    self._observability.record_snapshot_quick_check_failure(logical_names)
                 raise StoreSnapshotVerificationError(f"snapshot quick_check failed: {check_rows!r}")
         finally:
             if destination is not None:

--- a/tests/test_storage_observability.py
+++ b/tests/test_storage_observability.py
@@ -124,6 +124,8 @@ def test_admin_watchdog_exposes_bounded_boot_preflight_inventory_and_reconcile_m
         "inventory",
         "reconcile_warning_count",
         "snapshots",
+        "runtime",
+        "corruption",
     }
     assert storage["boot_gate"]["outcome"] == "warn"
     expected_warning_count = len(DEFAULT_FILESYSTEM_SILENCE_ALLOWLIST)

--- a/tests/test_storage_runtime_metrics.py
+++ b/tests/test_storage_runtime_metrics.py
@@ -1,0 +1,865 @@
+"""Lane B contracts for bounded, honest SQLite runtime observability."""
+
+from __future__ import annotations
+
+import json
+import logging
+import math
+import os
+import sqlite3
+import threading
+import time
+from dataclasses import replace
+from pathlib import Path
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from pinky_daemon import api as api_module
+from pinky_daemon import storage_observability as observability_module
+from pinky_daemon import store_catalog as catalog_module
+from pinky_daemon import store_snapshot as snapshot_module
+from pinky_daemon.auth import build_internal_auth_headers
+from pinky_daemon.storage_observability import StorageObservability
+from pinky_daemon.store_catalog import (
+    BoundSQLiteFile,
+    StoreCatalog,
+    StoreCatalogError,
+    StoreConnectionPolicy,
+    StoreIntegrityTarget,
+)
+from pinky_daemon.store_manifest import (
+    derive_fleet_store_manifest,
+    derive_standalone_tenant_store_manifest,
+)
+from pinky_daemon.store_snapshot import StoreSnapshotService
+
+HISTOGRAM_BOUNDS_MS = [1, 5, 10, 25, 50, 100, 250, 500, 1_000, 5_000, 30_000]
+HISTOGRAM_BUCKET_COUNT = len(HISTOGRAM_BOUNDS_MS) + 1
+
+
+class _PairClock:
+    """Return start/end pairs with deterministic elapsed milliseconds."""
+
+    def __init__(self, durations_ms: list[int]) -> None:
+        self._durations_ns = [duration * 1_000_000 for duration in durations_ms]
+        self._now_ns = 0
+        self._start = True
+
+    def __call__(self) -> int:
+        if self._start:
+            self._start = False
+            return self._now_ns
+        if not self._durations_ns:
+            raise AssertionError("runtime instrumentation read the clock too many times")
+        self._now_ns += self._durations_ns.pop(0)
+        self._start = True
+        return self._now_ns
+
+    def assert_exhausted(self) -> None:
+        assert self._start
+        assert self._durations_ns == []
+
+
+class _TickClock:
+    """Advance one millisecond per read for exact transaction buckets."""
+
+    def __init__(self) -> None:
+        self._now_ns = 0
+
+    def __call__(self) -> int:
+        value = self._now_ns
+        self._now_ns += 1_000_000
+        return value
+
+
+def _target(
+    logical_name: str,
+    path: Path,
+    *,
+    timeout_ms: int = 5_000,
+) -> StoreIntegrityTarget:
+    return StoreIntegrityTarget(
+        logical_name=logical_name,
+        path=os.fspath(path),
+        criticality="memory",
+        connection_policy=StoreConnectionPolicy(busy_timeout_ms=timeout_ms),
+    )
+
+
+def _shared_manifest(path: Path, *, timeout_ms: int = 5_000) -> dict[str, StoreIntegrityTarget]:
+    return {
+        "sessions": _target("sessions", path, timeout_ms=timeout_ms),
+        "session_events": _target("session_events", path, timeout_ms=timeout_ms),
+    }
+
+
+def _register_operator(app: Any, tmp_path: Path) -> str:
+    app.state.agents.register(
+        "runtime-metrics-operator",
+        model="opus",
+        role="operator",
+        working_dir=os.fspath(tmp_path / "operator"),
+    )
+    return app.state.agents.get_signing_key("runtime-metrics-operator")
+
+
+def _signed_headers(key: str, *, method: str, path: str) -> dict[str, str]:
+    return build_internal_auth_headers(
+        key,
+        agent_name="runtime-metrics-operator",
+        method=method,
+        path=path,
+    )
+
+
+def _storage_status(client: TestClient, key: str) -> dict[str, Any]:
+    response = client.get(
+        "/admin/watchdog",
+        headers=_signed_headers(key, method="GET", path="/admin/watchdog"),
+    )
+    assert response.status_code == 200
+    return response.json()["storage"]
+
+
+def _runtime(observability: StorageObservability) -> dict[str, Any]:
+    snapshot = observability.snapshot()
+    assert "runtime" in snapshot, "runtime SQLite metrics are not implemented"
+    return snapshot["runtime"]
+
+
+def _assert_histogram_shape(histogram: dict[str, Any], *, count: int) -> None:
+    assert set(histogram) == {
+        "count",
+        "bucket_counts",
+        "overflow_count",
+        "p95_upper_bound_ms",
+        "p99_upper_bound_ms",
+    }
+    assert histogram["count"] == count
+    assert len(histogram["bucket_counts"]) == HISTOGRAM_BUCKET_COUNT
+    assert sum(histogram["bucket_counts"]) == count
+    assert histogram["overflow_count"] == histogram["bucket_counts"][-1]
+    if count == 0:
+        assert histogram["p95_upper_bound_ms"] is None
+        assert histogram["p99_upper_bound_ms"] is None
+
+
+def _contention_events(caplog: pytest.LogCaptureFixture, kind: str) -> list[str]:
+    return [
+        record.getMessage()
+        for record in caplog.records
+        if record.getMessage().startswith("storage_event event=contention ")
+        and f"kind={kind}" in record.getMessage()
+    ]
+
+
+def _primary_error_code(error: sqlite3.Error) -> int | None:
+    error_code = getattr(error, "sqlite_errorcode", None)
+    return None if error_code is None else int(error_code) & 0xFF
+
+
+def _wait_for_depth(
+    observability: StorageObservability,
+    logical_name: str,
+    expected: int,
+    *,
+    timeout: float = 1.0,
+) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        depth = _runtime(observability)["stores"][logical_name]["writer_queue_depth"]
+        if depth["current"] == expected:
+            return
+        time.sleep(0.005)
+    depth = _runtime(observability)["stores"][logical_name]["writer_queue_depth"]
+    assert depth["current"] == expected
+
+
+# A + B + H: real SQLite contention, exact outcome counters, event latch, and endpoint.
+def test_real_busy_results_are_exact_and_busy_event_rearms_only_after_lock_success(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    monkeypatch.setenv("PINKY_SESSION_SECRET", "runtime-metrics-secret")
+    original_manifest = api_module._derive_api_store_manifest
+
+    def short_busy_manifest(db_path: str | os.PathLike[str]) -> dict[str, StoreIntegrityTarget]:
+        manifest = original_manifest(db_path)
+        task = manifest["tasks"]
+        manifest["tasks"] = replace(
+            task,
+            connection_policy=replace(task.connection_policy, busy_timeout_ms=25),
+        )
+        return manifest
+
+    monkeypatch.setattr(api_module, "_derive_api_store_manifest", short_busy_manifest)
+    caplog.set_level(logging.INFO, logger="pinky.storage")
+    app = api_module.create_api(db_path=os.fspath(tmp_path / "conversations.db"))
+    key = _register_operator(app, tmp_path)
+    client = TestClient(app)
+    task_path = next(
+        record.resolved_path
+        for record in app.state.store_catalog.snapshot()
+        if record.logical_name == "tasks"
+    )
+    managed = app.state.store_catalog.open_connection(
+        "tasks",
+        task_path,
+        owner="runtime-metrics-test",
+    )
+    blocker = sqlite3.connect(task_path, timeout=0.025)
+
+    def observe_busy() -> None:
+        with pytest.raises(sqlite3.OperationalError) as caught:
+            managed.execute("BEGIN IMMEDIATE")
+        assert _primary_error_code(caught.value) == sqlite3.SQLITE_BUSY
+
+    try:
+        blocker.execute("BEGIN EXCLUSIVE")
+        for _ in range(4):
+            observe_busy()
+        assert len(_contention_events(caplog, "busy_streak")) == 1
+
+        blocker.rollback()
+        assert managed.execute("SELECT 1").fetchone() == (1,)
+        blocker.execute("BEGIN EXCLUSIVE")
+        for _ in range(2):
+            observe_busy()
+        assert len(_contention_events(caplog, "busy_streak")) == 1
+
+        blocker.rollback()
+        managed.execute("BEGIN IMMEDIATE")
+        managed.rollback()
+        blocker.execute("BEGIN EXCLUSIVE")
+        for _ in range(3):
+            observe_busy()
+        blocker.rollback()
+        managed.execute("BEGIN IMMEDIATE")
+        managed.rollback()
+
+        storage = _storage_status(client, key)
+    finally:
+        if blocker.in_transaction:
+            blocker.rollback()
+        blocker.close()
+        managed.close()
+        client.close()
+
+    task_metrics = storage["runtime"]["stores"]["tasks"]
+    assert task_metrics["busy_results_total"] == 9
+    assert task_metrics["locked_results_total"] == 0
+    assert task_metrics["busy_streak"] == {"current": 0, "max": 6}
+    wait_histogram = task_metrics["lock_wait_upper_bound_ms"]
+    assert wait_histogram["count"] >= task_metrics["busy_results_total"]
+    assert sum(wait_histogram["bucket_counts"]) == wait_histogram["count"]
+
+    events = _contention_events(caplog, "busy_streak")
+    assert len(events) == 2
+    assert all("observed=3" in event and "threshold=3" in event for event in events)
+    assert all(task_path not in event for event in events)
+    assert all("BEGIN" not in event and "database is locked" not in event for event in events)
+
+
+# B: deterministic lock-wait threshold, one event per episode, and successful rearm.
+def test_lock_wait_upper_bound_event_latches_and_rearms_on_short_lock_operation(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    path = tmp_path / "tasks.db"
+    manifest = {"tasks": _target("tasks", path)}
+    clock = _PairClock([300, 301, 1, 100, 400])
+    observability = StorageObservability(manifest, clock_ns=clock)
+    catalog = StoreCatalog(
+        tmp_path,
+        manifest=manifest,
+        observability=observability,
+    )
+    connection = catalog.open_connection("tasks", path, owner="runtime-metrics-test")
+    connection.execute("CREATE TABLE seed(value INTEGER)")
+    caplog.set_level(logging.INFO, logger="pinky.storage")
+    observability.enable_runtime()
+
+    try:
+        connection.execute("CREATE TABLE first(value INTEGER)")
+        connection.execute("CREATE TABLE second(value INTEGER)")
+        assert connection.execute("SELECT 1").fetchone() == (1,)
+        connection.execute("CREATE TABLE short(value INTEGER)")
+        connection.execute("CREATE TABLE fourth(value INTEGER)")
+    finally:
+        connection.close()
+
+    clock.assert_exhausted()
+    wait_histogram = _runtime(observability)["stores"]["tasks"]["lock_wait_upper_bound_ms"]
+    _assert_histogram_shape(wait_histogram, count=4)
+    assert wait_histogram["bucket_counts"][5] == 1  # 100ms
+    assert wait_histogram["bucket_counts"][7] == 3  # 300/301/400ms
+    events = _contention_events(caplog, "lock_wait_upper_bound")
+    assert len(events) == 2
+    assert all("threshold_ms=250" in event for event in events)
+    assert all("observed_ms=" in event for event in events)
+    assert all(os.fspath(path) not in event for event in events)
+
+
+# C: fixed non-cumulative histogram memory under deterministic churn.
+def test_histograms_remain_fixed_cardinality_under_ten_thousand_samples(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "churn.db"
+    manifest = {"tasks": _target("tasks", path)}
+    durations = [1] * 9_500 + [250] * 399 + [30_000] * 100 + [30_001]
+    clock = _PairClock(durations.copy())
+    observability = StorageObservability(manifest, clock_ns=clock)
+    catalog = StoreCatalog(
+        tmp_path,
+        manifest=manifest,
+        observability=observability,
+    )
+    connection = catalog.open_connection("tasks", path, owner="runtime-metrics-test")
+    observability.enable_runtime()
+
+    try:
+        for _ in durations:
+            connection.execute("CREATE TABLE IF NOT EXISTS churn(value INTEGER)")
+    finally:
+        connection.close()
+
+    clock.assert_exhausted()
+    store_metrics = _runtime(observability)["stores"]["tasks"]
+    expected_buckets = [0] * HISTOGRAM_BUCKET_COUNT
+    expected_buckets[0] = 9_500
+    expected_buckets[6] = 399
+    expected_buckets[10] = 100
+    expected_buckets[11] = 1
+    for metric_name in ("lock_wait_upper_bound_ms", "transaction_duration_ms"):
+        histogram = store_metrics[metric_name]
+        _assert_histogram_shape(histogram, count=10_000)
+        assert histogram["bucket_counts"] == expected_buckets
+        assert histogram["overflow_count"] == 1
+        assert histogram["p95_upper_bound_ms"] == 1
+        assert histogram["p99_upper_bound_ms"] == 30_000
+
+    encoded = json.dumps(observability.snapshot(), sort_keys=True)
+    assert "samples" not in encoded
+    assert "30001" not in encoded
+
+
+# D: a disabled catalog has no timer, task, sampler, clock read, or runtime event.
+def test_disabled_recorder_path_has_no_clock_or_background_worker_cost(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    def forbidden_clock() -> int:
+        raise AssertionError("disabled storage recorder read the monotonic clock")
+
+    monkeypatch.setattr(observability_module, "_monotonic_ns", forbidden_clock, raising=False)
+    threads_before = {thread.ident for thread in threading.enumerate()}
+    caplog.set_level(logging.INFO, logger="pinky.storage")
+    catalog = StoreCatalog(tmp_path)
+    connection = catalog.open_connection(
+        "tasks",
+        tmp_path / "disabled.db",
+        owner="disabled-runtime-test",
+    )
+    try:
+        connection.execute("CREATE TABLE item(value INTEGER)")
+        connection.commit()
+    finally:
+        connection.close()
+
+    assert {thread.ident for thread in threading.enumerate()} == threads_before
+    assert _contention_events(caplog, "busy_streak") == []
+    assert _contention_events(caplog, "lock_wait_upper_bound") == []
+
+
+def test_serving_endpoint_adds_exact_runtime_and_corruption_keys_but_starts_idle(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("PINKY_SESSION_SECRET", "idle-runtime-secret")
+    base = tmp_path / "conversations.db"
+    app = api_module.create_api(db_path=os.fspath(base))
+    key = _register_operator(app, tmp_path)
+    client = TestClient(app)
+    try:
+        storage = _storage_status(client, key)
+    finally:
+        client.close()
+
+    assert set(storage) == {
+        "boot_gate",
+        "preflight",
+        "inventory",
+        "reconcile_warning_count",
+        "snapshots",
+        "runtime",
+        "corruption",
+    }
+    runtime = storage["runtime"]
+    assert set(runtime) == {"enabled", "histogram_bounds_ms", "thresholds", "stores"}
+    assert runtime["enabled"] is True
+    assert runtime["histogram_bounds_ms"] == HISTOGRAM_BOUNDS_MS
+    assert runtime["thresholds"] == {
+        "busy_streak": 3,
+        "lock_wait_upper_bound_ms": 250,
+    }
+    assert len(runtime["stores"]) == 24
+    assert set(runtime["stores"]) == set(api_module._derive_api_store_manifest(base))
+
+    cohort_ids = set()
+    for metrics in runtime["stores"].values():
+        assert set(metrics) == {
+            "busy_results_total",
+            "locked_results_total",
+            "busy_streak",
+            "lock_wait_upper_bound_ms",
+            "transaction_duration_ms",
+            "transactions",
+            "writer_queue_depth",
+        }
+        assert metrics["busy_results_total"] == 0
+        assert metrics["locked_results_total"] == 0
+        assert metrics["busy_streak"] == {"current": 0, "max": 0}
+        _assert_histogram_shape(metrics["lock_wait_upper_bound_ms"], count=0)
+        _assert_histogram_shape(metrics["transaction_duration_ms"], count=0)
+        assert metrics["transactions"] == {"committed_total": 0, "rolled_back_total": 0}
+        depth = metrics["writer_queue_depth"]
+        assert set(depth) == {"cohort_id", "current", "high_water"}
+        assert depth["current"] == 0
+        assert depth["high_water"] == 0
+        assert isinstance(depth["cohort_id"], str) and depth["cohort_id"]
+        cohort_ids.add(depth["cohort_id"])
+
+    assert len(cohort_ids) == 22
+    assert (
+        runtime["stores"]["sessions"]["writer_queue_depth"]
+        == runtime["stores"]["session_events"]["writer_queue_depth"]
+    )
+    assert (
+        runtime["stores"]["agents"]["writer_queue_depth"]
+        == runtime["stores"]["agent_signing_keys"]["writer_queue_depth"]
+    )
+    corruption = storage["corruption"]
+    assert set(corruption) == {
+        "preflight_refusals_total",
+        "quick_check_failures_total",
+        "stores",
+    }
+    assert corruption["preflight_refusals_total"] == 0
+    assert corruption["quick_check_failures_total"] == 0
+    assert set(corruption["stores"]) == set(runtime["stores"])
+    assert all(
+        metrics == {"preflight_refusals": 0, "quick_check_failures": 0}
+        for metrics in corruption["stores"].values()
+    )
+    encoded = json.dumps(storage, sort_keys=True)
+    assert os.path.realpath(base) not in encoded
+    assert "idle-runtime-secret" not in encoded
+
+
+# Requirement 2: bounded first-token classification, never a full SQL regex/scan.
+def test_sql_classification_reads_only_a_bounded_prefix(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class BoundedStatement(str):
+        def __new__(cls, value: str):
+            instance = super().__new__(cls, value)
+            instance.slices = []
+            return instance
+
+        def __getitem__(self, key: object) -> str:
+            assert isinstance(key, slice), "classification indexed the full statement"
+            assert key.stop is not None and key.stop <= 64
+            self.slices.append(key)
+            return super().__getitem__(key)
+
+        def lstrip(self, *args: object, **kwargs: object) -> str:
+            raise AssertionError("classification stripped the full statement")
+
+        def split(self, *args: object, **kwargs: object) -> list[str]:
+            raise AssertionError("classification split the full statement")
+
+        def upper(self) -> str:
+            raise AssertionError("classification uppercased the full statement")
+
+    class NoRegex:
+        def __getattr__(self, name: str) -> Any:
+            raise AssertionError(f"classification used regex operation {name}")
+
+    path = tmp_path / "classification.db"
+    manifest = {"tasks": _target("tasks", path)}
+    observability = StorageObservability(manifest)
+    catalog = StoreCatalog(
+        tmp_path,
+        manifest=manifest,
+        observability=observability,
+    )
+    connection = catalog.open_connection("tasks", path, owner="classification-test")
+    observability.enable_runtime()
+    monkeypatch.setattr(catalog_module, "re", NoRegex())
+    statement = BoundedStatement("SELECT 1 /*" + ("x" * 100_000) + "*/")
+    try:
+        assert connection.execute(statement).fetchone() == (1,)
+    finally:
+        connection.close()
+
+    assert statement.slices, "managed execution never classified the SQL statement"
+    wait_histogram = _runtime(observability)["stores"]["tasks"]["lock_wait_upper_bound_ms"]
+    assert wait_histogram["count"] == 0
+
+
+# E + requirement 3: transaction durations and context-manager exact-once accounting.
+def test_transaction_timing_and_context_manager_counts_are_exact(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "transactions.db"
+    manifest = {"tasks": _target("tasks", path)}
+    observability = StorageObservability(manifest, clock_ns=_TickClock())
+    catalog = StoreCatalog(
+        tmp_path,
+        manifest=manifest,
+        observability=observability,
+    )
+    connection = catalog.open_connection("tasks", path, owner="transaction-test")
+    connection.execute("CREATE TABLE item(value INTEGER)")
+    connection.commit()
+    observability.enable_runtime()
+
+    connection.execute("BEGIN")
+    connection.execute("INSERT INTO item VALUES (1)")
+    connection.commit()
+    connection.execute("BEGIN")
+    connection.execute("INSERT INTO item VALUES (2)")
+    connection.rollback()
+    with connection:
+        connection.execute("INSERT INTO item VALUES (3)")
+    with pytest.raises(RuntimeError, match="roll back this context"):
+        with connection:
+            connection.execute("INSERT INTO item VALUES (4)")
+            raise RuntimeError("roll back this context")
+
+    autocommit = catalog.open_connection(
+        "tasks",
+        path,
+        owner="autocommit-transaction-test",
+        isolation_level=None,
+    )
+    try:
+        autocommit.execute("INSERT INTO item VALUES (5)")
+        autocommit.executescript("INSERT INTO item VALUES (6); INSERT INTO item VALUES (7);")
+    finally:
+        autocommit.close()
+        connection.close()
+
+    metrics = _runtime(observability)["stores"]["tasks"]
+    assert metrics["transactions"] == {"committed_total": 2, "rolled_back_total": 2}
+    histogram = metrics["transaction_duration_ms"]
+    _assert_histogram_shape(histogram, count=6)
+    assert histogram["bucket_counts"][0] == 2  # autocommit + executescript, 1ms each
+    assert histogram["bucket_counts"][1] == 4  # explicit/context transactions, <=5ms
+    assert connection.in_transaction is False
+
+
+# F + requirements 1/5: shared physical lane depth without recorder serialization.
+def test_shared_writer_lane_depth_is_non_summable_and_returns_to_zero(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "sessions.db"
+    manifest = _shared_manifest(path, timeout_ms=1_000)
+    observability = StorageObservability(manifest)
+    catalog = StoreCatalog(
+        tmp_path,
+        manifest=manifest,
+        observability=observability,
+    )
+    holder = catalog.open_connection("sessions", path, owner="shared-session-owner")
+    waiter = catalog.open_connection("session_events", path, owner="shared-session-owner")
+    holder.execute("CREATE TABLE event(value INTEGER)")
+    holder.commit()
+    observability.enable_runtime()
+    acquired = threading.Event()
+    release_waiter = threading.Event()
+    worker_errors: list[BaseException] = []
+
+    def wait_for_writer() -> None:
+        try:
+            waiter.execute("BEGIN IMMEDIATE")
+            acquired.set()
+            assert release_waiter.wait(1.0)
+            waiter.rollback()
+        except BaseException as exc:
+            worker_errors.append(exc)
+            acquired.set()
+
+    holder.execute("BEGIN IMMEDIATE")
+    worker = threading.Thread(target=wait_for_writer, name="storage-writer-depth-test")
+    worker.start()
+    try:
+        _wait_for_depth(observability, "sessions", 1)
+        holder.rollback()
+        assert acquired.wait(1.0)
+        _wait_for_depth(observability, "sessions", 0)
+        runtime = _runtime(observability)
+        sessions_depth = runtime["stores"]["sessions"]["writer_queue_depth"]
+        events_depth = runtime["stores"]["session_events"]["writer_queue_depth"]
+        assert sessions_depth == events_depth
+        assert sessions_depth["high_water"] == 1
+        assert set(sessions_depth) == {"cohort_id", "current", "high_water"}
+        assert os.fspath(path) not in json.dumps(sessions_depth)
+    finally:
+        release_waiter.set()
+        worker.join(2.0)
+        if holder.in_transaction:
+            holder.rollback()
+        holder.close()
+        waiter.close()
+
+    assert not worker.is_alive()
+    assert worker_errors == []
+
+
+def test_writer_lane_depth_decrements_in_finally_after_raising_call(tmp_path: Path) -> None:
+    path = tmp_path / "sessions-raising.db"
+    manifest = _shared_manifest(path, timeout_ms=25)
+    observability = StorageObservability(manifest)
+    catalog = StoreCatalog(
+        tmp_path,
+        manifest=manifest,
+        observability=observability,
+    )
+    holder = catalog.open_connection("sessions", path, owner="shared-session-owner")
+    waiter = catalog.open_connection("session_events", path, owner="shared-session-owner")
+    holder.execute("CREATE TABLE event(value INTEGER)")
+    holder.commit()
+    observability.enable_runtime()
+    errors: list[sqlite3.OperationalError] = []
+
+    def fail_for_writer() -> None:
+        try:
+            waiter.execute("BEGIN IMMEDIATE")
+        except sqlite3.OperationalError as exc:
+            errors.append(exc)
+
+    holder.execute("BEGIN IMMEDIATE")
+    worker = threading.Thread(target=fail_for_writer, name="storage-writer-error-test")
+    worker.start()
+    worker.join(2.0)
+    try:
+        assert not worker.is_alive()
+        assert len(errors) == 1
+        assert _primary_error_code(errors[0]) == sqlite3.SQLITE_BUSY
+        runtime = _runtime(observability)
+        depth = runtime["stores"]["session_events"]["writer_queue_depth"]
+        assert depth["current"] == 0
+        assert depth["high_water"] == 1
+    finally:
+        holder.rollback()
+        holder.close()
+        waiter.close()
+
+
+def test_extended_sqlite_locked_is_counted_separately_from_busy(tmp_path: Path) -> None:
+    path = tmp_path / "shared-cache.db"
+    uri = f"file:{path}?cache=shared"
+    manifest = {"tasks": _target("tasks", path, timeout_ms=25)}
+    observability = StorageObservability(manifest)
+    catalog = StoreCatalog(
+        tmp_path,
+        manifest=manifest,
+        observability=observability,
+    )
+    holder = catalog.open_connection("tasks", uri, owner="locked-test", uri=True)
+    waiter = catalog.open_connection("tasks", uri, owner="locked-test", uri=True)
+    holder.execute("CREATE TABLE item(value INTEGER)")
+    holder.execute("INSERT INTO item VALUES (1)")
+    holder.commit()
+    observability.enable_runtime()
+
+    holder.execute("BEGIN IMMEDIATE")
+    holder.execute("UPDATE item SET value = 2")
+    try:
+        with pytest.raises(sqlite3.OperationalError) as caught:
+            waiter.execute("UPDATE item SET value = 3")
+        assert _primary_error_code(caught.value) == sqlite3.SQLITE_LOCKED
+    finally:
+        holder.rollback()
+        holder.close()
+        waiter.close()
+
+    metrics = _runtime(observability)["stores"]["tasks"]
+    assert metrics["busy_results_total"] == 0
+    assert metrics["locked_results_total"] == 1
+
+
+# G: one physical preflight refusal, per-logical fanout, exact quick_check subset.
+@pytest.mark.parametrize("quick_check", [sqlite3.DatabaseError("private-detail"), [("bad",)]])
+def test_preflight_corruption_counts_physical_once_and_shared_aliases_once(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    quick_check: sqlite3.DatabaseError | list[tuple[str]],
+) -> None:
+    path = tmp_path / "shared-corrupt.db"
+    seed = sqlite3.connect(path)
+    seed.execute("CREATE TABLE item(value INTEGER)")
+    seed.commit()
+    seed.close()
+    manifest = _shared_manifest(path)
+    observability = StorageObservability(manifest)
+    catalog = StoreCatalog(
+        tmp_path,
+        manifest=manifest,
+        observability=observability,
+    )
+
+    class FakeQuickCheckConnection:
+        def execute(self, statement: str) -> FakeQuickCheckConnection:
+            assert statement == "PRAGMA quick_check"
+            if isinstance(quick_check, sqlite3.DatabaseError):
+                raise quick_check
+            return self
+
+        def fetchall(self) -> list[tuple[str]]:
+            assert isinstance(quick_check, list)
+            return quick_check
+
+        def close(self) -> None:
+            return None
+
+    monkeypatch.setattr(
+        BoundSQLiteFile,
+        "connect_read_only",
+        lambda _bound_file: FakeQuickCheckConnection(),
+    )
+    caplog.set_level(logging.INFO, logger="pinky.storage")
+
+    with pytest.raises(StoreCatalogError):
+        catalog.preflight_integrity(manifest.values())
+
+    corruption = observability.snapshot()["corruption"]
+    assert corruption["preflight_refusals_total"] == 1
+    assert corruption["quick_check_failures_total"] == 1
+    for logical_name in ("sessions", "session_events"):
+        assert corruption["stores"][logical_name] == {
+            "preflight_refusals": 1,
+            "quick_check_failures": 1,
+        }
+    events = [
+        record.getMessage()
+        for record in caplog.records
+        if record.getMessage().startswith("storage_event event=corruption ")
+    ]
+    assert any("source=preflight" in event for event in events)
+    assert all(os.fspath(path) not in event for event in events)
+    assert all("private-detail" not in event and "bad" not in event for event in events)
+
+
+def test_snapshot_destination_quick_check_failure_is_counted_live_without_json(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = tmp_path / "sessions.db"
+    seed = sqlite3.connect(path)
+    seed.execute("CREATE TABLE item(value INTEGER)")
+    seed.execute("INSERT INTO item VALUES (1)")
+    seed.commit()
+    seed.close()
+    manifest = _shared_manifest(path)
+    observability = StorageObservability(manifest)
+    catalog = StoreCatalog(
+        tmp_path,
+        manifest=manifest,
+        observability=observability,
+    )
+    for logical_name in manifest:
+        catalog.register(
+            logical_name,
+            path,
+            journal_mode="delete",
+            owner="shared-session-owner",
+        )
+
+    real_connect = sqlite3.connect
+
+    class FailedRows:
+        def fetchall(self) -> list[tuple[str]]:
+            return [("snapshot-private-corruption",)]
+
+    class BadQuickCheckConnection(sqlite3.Connection):
+        def execute(
+            self,
+            sql: str,
+            parameters: Any = (),
+            /,
+        ) -> sqlite3.Cursor | FailedRows:
+            if sql == "PRAGMA quick_check":
+                return FailedRows()
+            return super().execute(sql, parameters)
+
+    def connect_with_bad_destination(database: Any, *args: Any, **kwargs: Any) -> Any:
+        if os.fspath(database).endswith(".tmp"):
+            kwargs["factory"] = BadQuickCheckConnection
+        return real_connect(database, *args, **kwargs)
+
+    monkeypatch.setattr(snapshot_module.sqlite3, "connect", connect_with_bad_destination)
+    service = StoreSnapshotService(catalog, observability=observability)
+    [result] = service.create_snapshots("sessions")
+
+    assert result.status == "failed"
+    corruption = observability.snapshot()["corruption"]
+    assert corruption["preflight_refusals_total"] == 0
+    assert corruption["quick_check_failures_total"] == 1
+    for logical_name in ("sessions", "session_events"):
+        assert corruption["stores"][logical_name] == {
+            "preflight_refusals": 0,
+            "quick_check_failures": 1,
+        }
+    encoded = json.dumps(corruption, sort_keys=True)
+    assert os.fspath(path) not in encoded
+    assert "snapshot-private-corruption" not in encoded
+    assert list(tmp_path.rglob("*.json")) == []
+
+
+# H: Lane A policy/retry behavior and the 24-name manifest remain exact.
+def test_manifest_cardinality_alias_origin_and_connection_policy_are_unchanged(
+    tmp_path: Path,
+) -> None:
+    fleet = derive_fleet_store_manifest(tmp_path / "conversations.db")
+    tenant = derive_standalone_tenant_store_manifest(tmp_path / "tenant-keys.db")
+
+    assert len(fleet) == 24
+    assert set(fleet).intersection(tenant) == {"agent_signing_keys"}
+    assert fleet["agents"].path == fleet["agent_signing_keys"].path
+    assert fleet["sessions"].path == fleet["session_events"].path
+    timeout_counts = {
+        timeout_ms: sum(
+            target.connection_policy.busy_timeout_ms == timeout_ms for target in fleet.values()
+        )
+        for timeout_ms in (5_000, 30_000)
+    }
+    assert timeout_counts == {5_000: 9, 30_000: 15}
+    assert {target.connection_policy.rollback_retries for target in fleet.values()} == {6}
+    assert {target.connection_policy.rollback_retry_delay_seconds for target in fleet.values()} == {
+        0.2
+    }
+
+
+def test_runtime_wrapper_does_not_add_retry_sleep_or_journal_mode_writes() -> None:
+    source = Path(catalog_module.__file__).read_text(encoding="utf-8")
+    managed_start = source.index("class _ManagedSQLiteConnection")
+    managed_end = source.index("\n\n@dataclass", managed_start)
+    managed_source = source[managed_start:managed_end]
+
+    assert "sleep(" not in managed_source
+    assert "rollback_retries" not in managed_source
+    assert "journal_mode=" not in managed_source.lower()
+    assert "set_busy_handler" not in source
+
+
+def test_histogram_quantile_rank_contract_is_nearest_rank() -> None:
+    assert math.ceil(0.95 * 10_000) == 9_500
+    assert math.ceil(0.99 * 10_000) == 9_900

--- a/tests/test_storage_runtime_metrics_review.py
+++ b/tests/test_storage_runtime_metrics_review.py
@@ -1,0 +1,288 @@
+"""Independent adversarial probes for the Lane B exact-head review."""
+
+from __future__ import annotations
+
+import logging
+import os
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from pinky_daemon import store_snapshot as snapshot_module
+from pinky_daemon.storage_observability import StorageObservability
+from pinky_daemon.store_catalog import (
+    BoundSQLiteFile,
+    StoreCatalog,
+    StoreCatalogError,
+    StoreConnectionPolicy,
+    StoreIntegrityTarget,
+)
+from pinky_daemon.store_snapshot import StoreSnapshotService
+
+
+def _target(
+    logical_name: str,
+    path: Path,
+    *,
+    timeout_ms: int = 25,
+) -> StoreIntegrityTarget:
+    return StoreIntegrityTarget(
+        logical_name=logical_name,
+        path=os.fspath(path),
+        criticality="memory",
+        journal_mode="delete",
+        connection_policy=StoreConnectionPolicy(busy_timeout_ms=timeout_ms),
+    )
+
+
+def _primary_error_code(error: sqlite3.Error) -> int | None:
+    error_code = getattr(error, "sqlite_errorcode", None)
+    return None if error_code is None else int(error_code) & 0xFF
+
+
+class _PairClock:
+    def __init__(self, durations_ms: list[int]) -> None:
+        self._durations_ns = [duration * 1_000_000 for duration in durations_ms]
+        self._now_ns = 0
+        self._start = True
+
+    def __call__(self) -> int:
+        if self._start:
+            self._start = False
+            return self._now_ns
+        if not self._durations_ns:
+            raise AssertionError("review probe clock was read too many times")
+        self._now_ns += self._durations_ns.pop(0)
+        self._start = True
+        return self._now_ns
+
+
+def test_review_busy_commit_and_context_exit_are_counted_exactly(tmp_path: Path) -> None:
+    path = tmp_path / "commit-contention.db"
+    manifest = {"tasks": _target("tasks", path)}
+    observability = StorageObservability(manifest)
+    catalog = StoreCatalog(tmp_path, manifest=manifest, observability=observability)
+    managed = catalog.open_connection("tasks", path, owner="lane-b-review")
+    managed.execute("CREATE TABLE item(value INTEGER)")
+    managed.commit()
+    reader = sqlite3.connect(path, timeout=0.025)
+    observability.enable_runtime()
+
+    try:
+        for boundary in ("commit", "context-exit"):
+            reader.execute("BEGIN")
+            assert reader.execute("SELECT COUNT(*) FROM item").fetchone() == (0,)
+            if boundary == "commit":
+                managed.execute("INSERT INTO item VALUES (1)")
+                with pytest.raises(sqlite3.OperationalError) as caught:
+                    managed.commit()
+            else:
+                with pytest.raises(sqlite3.OperationalError) as caught:
+                    with managed:
+                        managed.execute("INSERT INTO item VALUES (1)")
+            assert _primary_error_code(caught.value) == sqlite3.SQLITE_BUSY
+            reader.rollback()
+            if managed.in_transaction:
+                managed.rollback()
+    finally:
+        if reader.in_transaction:
+            reader.rollback()
+        if managed.in_transaction:
+            managed.rollback()
+        reader.close()
+        managed.close()
+
+    metrics = observability.snapshot()["runtime"]["stores"]["tasks"]
+    assert metrics["busy_results_total"] == 2
+    assert metrics["transactions"]["rolled_back_total"] == 2
+
+
+def test_review_failed_short_wait_does_not_rearm_threshold_event(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    path = tmp_path / "wait-latch.db"
+    manifest = {"tasks": _target("tasks", path)}
+    clock = _PairClock([300, 1, 400, 1, 400])
+    observability = StorageObservability(manifest, clock_ns=clock)
+    observability.enable_runtime()
+    caplog.set_level(logging.INFO, logger="pinky.storage")
+
+    for succeeded, error_code in (
+        (False, sqlite3.SQLITE_BUSY),
+        (False, sqlite3.SQLITE_BUSY),
+        (False, sqlite3.SQLITE_BUSY),
+        (True, None),
+        (False, sqlite3.SQLITE_BUSY),
+    ):
+        operation = observability.begin_runtime_operation("tasks", lock_bearing=True)
+        assert operation is not None
+        observability.finish_runtime_operation(
+            operation,
+            succeeded=succeeded,
+            sqlite_primary_error_code=error_code,
+        )
+
+    wait_events = [
+        record.getMessage()
+        for record in caplog.records
+        if "kind=lock_wait_upper_bound" in record.getMessage()
+    ]
+    assert len(wait_events) == 2
+
+
+def test_review_close_records_implicit_transaction_rollback(tmp_path: Path) -> None:
+    path = tmp_path / "close-rollback.db"
+    manifest = {"tasks": _target("tasks", path)}
+    observability = StorageObservability(manifest)
+    catalog = StoreCatalog(tmp_path, manifest=manifest, observability=observability)
+    connection = catalog.open_connection("tasks", path, owner="lane-b-review")
+    connection.execute("CREATE TABLE item(value INTEGER)")
+    connection.commit()
+    observability.enable_runtime()
+
+    connection.execute("INSERT INTO item VALUES (1)")
+    assert connection.in_transaction is True
+    connection.close()
+
+    metrics = observability.snapshot()["runtime"]["stores"]["tasks"]
+    assert metrics["transactions"]["rolled_back_total"] == 1
+    assert metrics["transaction_duration_ms"]["count"] == 1
+    assert connection._store_transaction_started_ns is None
+    verifier = sqlite3.connect(path)
+    try:
+        assert verifier.execute("SELECT COUNT(*) FROM item").fetchone() == (0,)
+    finally:
+        verifier.close()
+
+
+def test_review_quick_check_error_survives_reconciliation_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = tmp_path / "combined-preflight-failure.db"
+    seed = sqlite3.connect(path)
+    seed.execute("CREATE TABLE item(value INTEGER)")
+    seed.commit()
+    seed.close()
+    manifest = {"tasks": _target("tasks", path)}
+    observability = StorageObservability(manifest)
+    catalog = StoreCatalog(tmp_path, manifest=manifest, observability=observability)
+
+    class FailingQuickCheck:
+        def __init__(self) -> None:
+            self.statement = ""
+
+        def execute(self, statement: str) -> FailingQuickCheck:
+            self.statement = statement
+            return self
+
+        def fetchone(self) -> tuple[str]:
+            assert self.statement == "PRAGMA journal_mode"
+            return ("delete",)
+
+        def fetchall(self) -> list[tuple[str]]:
+            assert self.statement == "PRAGMA quick_check"
+            raise sqlite3.DatabaseError("review quick-check failure")
+
+        def close(self) -> None:
+            return None
+
+    monkeypatch.setattr(
+        BoundSQLiteFile,
+        "connect_read_only",
+        lambda _bound_file: FailingQuickCheck(),
+    )
+
+    def fail_reconciliation(_bound_file: BoundSQLiteFile) -> str:
+        raise OSError("review reconciliation failure")
+
+    monkeypatch.setattr(
+        BoundSQLiteFile,
+        "path_state",
+        fail_reconciliation,
+    )
+
+    with pytest.raises(StoreCatalogError):
+        catalog.preflight_integrity(manifest.values())
+
+    corruption = observability.snapshot()["corruption"]
+    assert corruption["preflight_refusals_total"] == 1
+    assert corruption["quick_check_failures_total"] == 1
+    assert corruption["stores"]["tasks"] == {
+        "preflight_refusals": 1,
+        "quick_check_failures": 1,
+    }
+
+
+def test_review_mutating_pragma_is_classified_lock_bearing(tmp_path: Path) -> None:
+    path = tmp_path / "mutating-pragma.db"
+    manifest = {"tasks": _target("tasks", path)}
+    clock = _PairClock([1])
+    observability = StorageObservability(manifest, clock_ns=clock)
+    catalog = StoreCatalog(tmp_path, manifest=manifest, observability=observability)
+    connection = catalog.open_connection("tasks", path, owner="lane-b-review")
+    observability.enable_runtime()
+    try:
+        connection.execute("PRAGMA user_version=1")
+    finally:
+        connection.close()
+
+    metrics = observability.snapshot()["runtime"]["stores"]["tasks"]
+    assert metrics["lock_wait_upper_bound_ms"]["count"] == 1
+
+
+def test_review_snapshot_quick_check_exception_is_counted_once(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = tmp_path / "snapshot-source.db"
+    seed = sqlite3.connect(path)
+    seed.execute("CREATE TABLE item(value INTEGER)")
+    seed.execute("INSERT INTO item VALUES (1)")
+    seed.commit()
+    seed.close()
+    manifest = {
+        "sessions": _target("sessions", path),
+        "session_events": _target("session_events", path),
+    }
+    observability = StorageObservability(manifest)
+    catalog = StoreCatalog(tmp_path, manifest=manifest, observability=observability)
+    for logical_name in manifest:
+        catalog.register(
+            logical_name,
+            path,
+            journal_mode="delete",
+            owner="lane-b-review",
+        )
+
+    real_connect = sqlite3.connect
+
+    class BadQuickCheckConnection(sqlite3.Connection):
+        def execute(
+            self,
+            sql: str,
+            parameters: Any = (),
+            /,
+        ) -> sqlite3.Cursor:
+            if sql == "PRAGMA quick_check":
+                raise sqlite3.DatabaseError("review snapshot quick-check failure")
+            return super().execute(sql, parameters)
+
+    def connect_with_bad_destination(database: Any, *args: Any, **kwargs: Any) -> Any:
+        if os.fspath(database).endswith(".tmp"):
+            kwargs["factory"] = BadQuickCheckConnection
+        return real_connect(database, *args, **kwargs)
+
+    monkeypatch.setattr(snapshot_module.sqlite3, "connect", connect_with_bad_destination)
+    [result] = StoreSnapshotService(catalog, observability=observability).create_snapshots(
+        "sessions"
+    )
+
+    assert result.status == "failed"
+    corruption = observability.snapshot()["corruption"]
+    assert corruption["quick_check_failures_total"] == 1
+    for logical_name in manifest:
+        assert corruption["stores"][logical_name]["quick_check_failures"] == 1

--- a/tests/test_storage_runtime_metrics_round2_review.py
+++ b/tests/test_storage_runtime_metrics_round2_review.py
@@ -1,0 +1,132 @@
+"""Round-2 adversarial probes for the Lane B remediation review."""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+from pathlib import Path
+
+from pinky_daemon.storage_observability import StorageObservability
+from pinky_daemon.store_catalog import StoreCatalog, StoreIntegrityTarget
+
+
+class _PairClock:
+    def __init__(self, durations_ms: list[int]) -> None:
+        self._durations_ns = [duration * 1_000_000 for duration in durations_ms]
+        self._now_ns = 0
+        self._start = True
+
+    def __call__(self) -> int:
+        if self._start:
+            self._start = False
+            return self._now_ns
+        if not self._durations_ns:
+            raise AssertionError("round-2 review clock was read too many times")
+        self._now_ns += self._durations_ns.pop(0)
+        self._start = True
+        return self._now_ns
+
+
+def _target(path: Path) -> StoreIntegrityTarget:
+    return StoreIntegrityTarget(
+        logical_name="tasks",
+        path=os.fspath(path),
+        criticality="memory",
+    )
+
+
+def test_assignment_form_pragma_remains_lock_bearing_past_bounded_prefix(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "long-assignment-pragma.db"
+    manifest = {"tasks": _target(path)}
+    observability = StorageObservability(manifest, clock_ns=_PairClock([1]))
+    catalog = StoreCatalog(tmp_path, manifest=manifest, observability=observability)
+    connection = catalog.open_connection("tasks", path, owner="lane-b-round2-review")
+    observability.enable_runtime()
+
+    # SQLite accepts arbitrary whitespace before the assignment operator. The
+    # statement is still assignment-form even when '=' falls beyond byte 64.
+    statement = "PRAGMA user_version" + (" " * 80) + "=1"
+    try:
+        connection.execute(statement)
+    finally:
+        connection.close()
+
+    verifier = sqlite3.connect(path)
+    try:
+        assert verifier.execute("PRAGMA user_version").fetchone() == (1,)
+    finally:
+        verifier.close()
+
+    metrics = observability.snapshot()["runtime"]["stores"]["tasks"]
+    assert metrics["lock_wait_upper_bound_ms"]["count"] == 1
+
+
+class _BoundarySpy(StorageObservability):
+    def __init__(self, manifest: dict[str, StoreIntegrityTarget]) -> None:
+        super().__init__(manifest)
+        self.lock_bearing_operations: list[bool] = []
+
+    def begin_runtime_operation(
+        self,
+        logical_name: str,
+        *,
+        lock_bearing: bool,
+    ):
+        operation = super().begin_runtime_operation(
+            logical_name,
+            lock_bearing=lock_bearing,
+        )
+        if operation is not None:
+            self.lock_bearing_operations.append(lock_bearing)
+        return operation
+
+
+def test_transaction_boundaries_honor_the_binding_semantic_split_exactly_once(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "boundary-split.db"
+    manifest = {"tasks": _target(path)}
+    observability = _BoundarySpy(manifest)
+    catalog = StoreCatalog(tmp_path, manifest=manifest, observability=observability)
+    connection = catalog.open_connection("tasks", path, owner="lane-b-round2-review")
+    connection.execute("CREATE TABLE item(value INTEGER)")
+    connection.commit()
+    observability.enable_runtime()
+
+    connection.execute("BEGIN")
+    connection.execute("INSERT INTO item VALUES (1)")
+    connection.commit()
+    connection.execute("BEGIN")
+    connection.execute("INSERT INTO item VALUES (2)")
+    connection.rollback()
+    with connection:
+        connection.execute("INSERT INTO item VALUES (3)")
+    try:
+        with connection:
+            connection.execute("INSERT INTO item VALUES (4)")
+            raise RuntimeError("force context rollback")
+    except RuntimeError:
+        pass
+    connection.close()
+
+    assert observability.lock_bearing_operations == [
+        True,
+        True,
+        True,  # BEGIN, INSERT, direct commit
+        True,
+        True,
+        False,  # BEGIN, INSERT, direct rollback
+        True,
+        True,  # INSERT, context-manager commit
+        True,
+        False,  # INSERT, context-manager rollback
+    ]
+    metrics = observability.snapshot()["runtime"]["stores"]["tasks"]
+    assert metrics["transactions"] == {
+        "committed_total": 2,
+        "rolled_back_total": 2,
+    }
+    assert metrics["transaction_duration_ms"]["count"] == 4
+    assert metrics["writer_queue_depth"]["current"] == 0


### PR DESCRIPTION
## Summary

- instrument catalog-owned SQLite connections with bounded, process-local BUSY/LOCKED counters, lock-wait and transaction histograms, transaction outcomes, and non-summable physical writer-cohort depth
- expose additive `runtime` and `corruption` sections through the existing storage watchdog payload, with fixed-cardinality logical-store keys and path-free output
- count preflight and snapshot-destination quick-check failures, and emit threshold-latched contention/corruption events without changing SQLite retry, timeout, or journal-mode behavior
- activate runtime collection only after the storage boot gate completes, keeping constructor/preflight work out of serving-process runtime metrics

## Residuals

Three known non-gating limitations remain: mutation-capable call-form `PRAGMA` statements that omit `=` are classified as non-lock-bearing and can undercount lock-wait samples; a failed commit retains the transaction start timestamp so a later successful rollback records the full transaction lifetime, by design; and connection-close implicit rollback contributes transaction duration/outcome only, without a separate runtime-operation or lock-wait sample.

## Harness notes

- `pytest -q tests/test_storage_runtime_metrics_round2_review.py`: 2 passed
- `pytest -q tests/test_storage_runtime_metrics_review.py`: 6 passed
- combined runtime, observability, and review harnesses: 29 passed
- `pytest -q tests/test_no_direct_db_open.py`: 8 passed
- snapshot destination quick-check regression: 1 passed
- Ruff check, Ruff format check, and Git diff whitespace checks passed
- full repository suite: 5,596 passed, 1 skipped, 1 failed; the sole failure was the live scrape test because the optional Camoufox browser binary was not installed
- one passing shared-MCP test emitted an existing localhost:8890 bind-thread warning; it did not add a test failure

## UI

No screenshots: this changes the daemon's observability/API payload and its backend contract tests, with no rendered UI surface.

🤖 Opened by Kuzya
