### PR TITLE
Fix folded prompt acceptance in tmux sessions

### DIFF
--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -9341,7 +9341,13 @@ class TmuxSession(TransportReplacementMixin):
         if self._wake_context_reload_guard is guard:
             self._wake_context_reload_guard = None
 
-    def _on_transcript_entry(self, entry: dict) -> None:
+    def _on_transcript_entry(
+        self,
+        entry: dict,
+        *,
+        entry_offset: int | None = None,
+        source_identity: tuple[int, int] | None = None,
+    ) -> None:
         """Consume transcript evidence strong enough for exact-turn receipts."""
         entry_type = entry.get("type")
         if entry_type == "queue-operation":
@@ -9418,6 +9424,29 @@ class TmuxSession(TransportReplacementMixin):
                     self._mark_transport_accepted(turn)
                 else:
                     for folded_turn in self._folded_acceptance_turns(prompt):
+                        folded_meta = next(
+                            (
+                                meta
+                                for meta in self._inflight_metas
+                                if meta.turn is folded_turn
+                            ),
+                            None,
+                        )
+                        if folded_meta is None:
+                            continue
+                        ticket_identity = (
+                            folded_meta.transcript_file_identity_at_paste
+                        )
+                        ticket_offset = folded_meta.transcript_offset_at_paste
+                        if (
+                            source_identity is None
+                            or ticket_identity is None
+                            or source_identity != ticket_identity
+                            or entry_offset is None
+                            or ticket_offset is None
+                            or entry_offset < ticket_offset
+                        ):
+                            continue
                         self._mark_transport_accepted(folded_turn)
 
     @staticmethod

--- a/src/pinky_daemon/tmux_session.py
+++ b/src/pinky_daemon/tmux_session.py
@@ -7601,27 +7601,72 @@ class TmuxSession(TransportReplacementMixin):
                     incomplete.add(key)
                 rows[key] = found
 
-            used: set[tuple[_TranscriptSourceKey, int]] = set()
+            # Phase 1 is the pre-#1163 exact allocator byte-for-byte: each
+            # candidate claims its oldest distinct exact row, including an
+            # already accepted candidate whose row must not be donated to a
+            # later duplicate. Exact-reserved rows are wholly unavailable to
+            # containment, even for a different nested prompt.
+            exact_rows: set[tuple[_TranscriptSourceKey, int]] = set()
+            claims: list[tuple[int, int, bytes] | None] = [None] * len(candidates)
+            for index, (entry, source) in enumerate(
+                zip(candidates, sources, strict=True)
+            ):
+                if source is None:
+                    continue
+                key, allocation_start, _proof_available, _fallback = source
+                for row_offset, row_end, prompt, raw in rows.get(key, []):
+                    occurrence = (key, row_offset)
+                    if (
+                        row_offset >= allocation_start
+                        and occurrence not in exact_rows
+                        and prompt == entry.turn.prompt
+                    ):
+                        exact_rows.add(occurrence)
+                        claims[index] = (row_offset, row_end, raw)
+                        break
+
+            # Phase 2 allocates full-prompt occurrences inside folded rows to
+            # candidates still lacking an exact row. One folded row may prove
+            # several turns, but every character span is globally owned by at
+            # most one candidate. Candidate order remains the existing FIFO.
+            occupied_spans: dict[
+                tuple[_TranscriptSourceKey, int],
+                list[tuple[int, int]],
+            ] = {}
+            for index, (entry, source) in enumerate(
+                zip(candidates, sources, strict=True)
+            ):
+                candidate_prompt = entry.turn.prompt
+                if (
+                    claims[index] is not None
+                    or source is None
+                    or not candidate_prompt
+                ):
+                    continue
+                key, allocation_start, _proof_available, _fallback = source
+                for row_offset, row_end, prompt, raw in rows.get(key, []):
+                    row_key = (key, row_offset)
+                    if row_offset < allocation_start or row_key in exact_rows:
+                        continue
+                    spans = occupied_spans.setdefault(row_key, [])
+                    claimed_span = self._first_unoccupied_prompt_span(
+                        prompt,
+                        candidate_prompt,
+                        spans,
+                    )
+                    if claimed_span is None:
+                        continue
+                    spans.append(claimed_span)
+                    claims[index] = (row_offset, row_end, raw)
+                    break
+
             verdicts: list[bool | None] = []
-            for entry, source in zip(candidates, sources, strict=True):
-                claimed: tuple[int, int, bytes] | None = None
+            for index, (entry, source) in enumerate(
+                zip(candidates, sources, strict=True)
+            ):
+                claimed = claims[index]
                 if source is not None:
-                    (
-                        key,
-                        allocation_start,
-                        proof_available,
-                        fallback,
-                    ) = source
-                    for row_offset, row_end, prompt, raw in rows.get(key, []):
-                        occurrence = (key, row_offset)
-                        if (
-                            row_offset >= allocation_start
-                            and occurrence not in used
-                            and prompt == entry.turn.prompt
-                        ):
-                            used.add(occurrence)
-                            claimed = (row_offset, row_end, raw)
-                            break
+                    key, _allocation_start, proof_available, fallback = source
                 else:
                     key = None
                     proof_available = False
@@ -8296,6 +8341,7 @@ class TmuxSession(TransportReplacementMixin):
                     replay: list[_QueuedTurn] = []
                     drained_count = 0
                     dropped_count = 0
+                    ledger_suppressed_count = 0
                     terminal_fenced_count = 0
                     unavailable_count = sum(
                         consumed is None for consumed in consumption_verdicts
@@ -8316,6 +8362,68 @@ class TmuxSession(TransportReplacementMixin):
                         header = turn.prompt.splitlines()[0] if turn.prompt else ""
 
                         if consumed is False:
+                            ledgered = False
+                            if (
+                                turn.message_id
+                                and not turn.scheduler_serialized
+                                and self._registry is not None
+                            ):
+                                try:
+                                    ledgered = self._registry.is_turn_delivered(
+                                        self.agent_name,
+                                        turn.platform,
+                                        turn.chat_id,
+                                        turn.message_id,
+                                    )
+                                except Exception as exc:
+                                    # This is a duplicate-suppression backstop,
+                                    # never proof by itself. Registry uncertainty
+                                    # must fail open to today's replay behavior.
+                                    _log(
+                                        f"tmux[{self.agent_name}]: "
+                                        "PHANTOM_LEDGER_READ_FAILURE; failing "
+                                        "open to requeue "
+                                        f"(message_id={turn.message_id!r}, "
+                                        f"{type(exc).__name__}: {exc})"
+                                    )
+                            if ledgered:
+                                ledger_suppressed_count += 1
+                                scheduler_state = self._receipt_state_label(
+                                    turn.scheduler_delivery
+                                )
+                                submission_state = self._receipt_state_label(
+                                    turn.submission_receipt
+                                )
+                                _log(
+                                    f"tmux[{self.agent_name}]: "
+                                    "PHANTOM_SUPPRESSED_LEDGERED dropping "
+                                    "already-delivered phantom instead of "
+                                    "duplicate replay "
+                                    f"(platform={turn.platform!r}, "
+                                    f"chat_id={turn.chat_id!r}, "
+                                    f"message_id={turn.message_id!r}, "
+                                    f"scheduler_receipt={scheduler_state}, "
+                                    f"submission_receipt={submission_state}, "
+                                    f"prompt_header={header!r})"
+                                )
+                                ev = entry.completion_event
+                                if ev is not None and not ev.is_set():
+                                    ev.set()
+                                delivery = turn.scheduler_delivery
+                                if delivery is not None and not delivery.done():
+                                    delivery.set_result(False)
+                                self._resolve_submission_receipt(turn, False)
+                                log_watchdog_decision(
+                                    watchdog="inflight",
+                                    agent=self.agent_name,
+                                    decision="drop",
+                                    reason="phantom_suppressed_ledgered",
+                                    state=self.state.value,
+                                    progress_stale_s=age,
+                                    inflight_turns=depth,
+                                    inflight_active=False,
+                                )
+                                continue
                             if turn.scheduler_serialized:
                                 # The ordinary queue becomes the sole replay
                                 # owner before the turn is made visible there.
@@ -8420,6 +8528,12 @@ class TmuxSession(TransportReplacementMixin):
                         )
 
                     self._prepend_message_queue(replay)
+                    if ledger_suppressed_count:
+                        _log(
+                            f"tmux[{self.agent_name}]: "
+                            "PHANTOM_LEDGER_SUPPRESSION_SUMMARY "
+                            f"suppressed={ledger_suppressed_count}"
+                        )
                     _log(
                         f"tmux[{self.agent_name}]: inflight head aged {age:.1f}s "
                         f"but REPL is idle — reconciled {drained_count} phantom "
@@ -8983,6 +9097,56 @@ class TmuxSession(TransportReplacementMixin):
             unique.setdefault(id(turn), turn)
         return sorted(unique.values(), key=lambda turn: turn.queued_at)
 
+    @staticmethod
+    def _first_unoccupied_prompt_span(
+        content: str,
+        prompt: str,
+        occupied: list[tuple[int, int]],
+    ) -> tuple[int, int] | None:
+        """Return the first full prompt occurrence not overlapping a claim."""
+        if not prompt:
+            return None
+        search_from = 0
+        while True:
+            start = content.find(prompt, search_from)
+            if start < 0:
+                return None
+            end = start + len(prompt)
+            if all(
+                end <= used_start or start >= used_end
+                for used_start, used_end in occupied
+            ):
+                return start, end
+            search_from = start + 1
+
+    def _folded_acceptance_turns(self, content: str) -> list[_QueuedTurn]:
+        """Allocate one folded user-row occurrence per pending pane turn."""
+        occupied: list[tuple[int, int]] = []
+        matched: list[_QueuedTurn] = []
+        for turn in self._acceptance_candidates():
+            if not turn.pane_delivery_started or not turn.prompt:
+                continue
+            if (
+                not turn.transport_accepted
+                and turn.submission_receipt is not None
+                and turn.submission_receipt.done()
+                and not self._receipt_accepted(turn.submission_receipt)
+            ):
+                continue
+            span = self._first_unoccupied_prompt_span(
+                content,
+                turn.prompt,
+                occupied,
+            )
+            if span is None:
+                continue
+            occupied.append(span)
+            # Accepted occurrences still reserve their span so a replayed row
+            # cannot donate it, but _mark_transport_accepted must not run twice.
+            if not turn.transport_accepted:
+                matched.append(turn)
+        return matched
+
     def _match_acceptance_turn(
         self, prompt: str, *, for_enqueue: bool = False
     ) -> _QueuedTurn | None:
@@ -9249,9 +9413,12 @@ class TmuxSession(TransportReplacementMixin):
                     if not evidence.accepted_at_dequeue and not evidence.retired:
                         self._mark_transport_accepted(evidence.turn)
                     return
-                self._mark_transport_accepted(
-                    self._match_acceptance_content(prompt)
-                )
+                turn = self._match_acceptance_content(prompt)
+                if turn is not None:
+                    self._mark_transport_accepted(turn)
+                else:
+                    for folded_turn in self._folded_acceptance_turns(prompt):
+                        self._mark_transport_accepted(folded_turn)
 
     @staticmethod
     def _resolve_submission_receipt(
@@ -9261,6 +9428,20 @@ class TmuxSession(TransportReplacementMixin):
         receipt = turn.submission_receipt
         if receipt is not None and not receipt.done():
             receipt.set_result(accepted)
+
+    @staticmethod
+    def _receipt_state_label(receipt: asyncio.Future[bool] | None) -> str:
+        """Compact receipt state for anomalous-drop diagnostics."""
+        if receipt is None:
+            return "absent"
+        if not receipt.done():
+            return "pending"
+        if receipt.cancelled():
+            return "cancelled"
+        try:
+            return "accepted" if receipt.result() is True else "rejected"
+        except Exception:
+            return "error"
 
     @staticmethod
     def _receipt_accepted(receipt: asyncio.Future[bool]) -> bool:

--- a/src/pinky_daemon/tmux_transcript.py
+++ b/src/pinky_daemon/tmux_transcript.py
@@ -46,7 +46,9 @@ Two reasons:
 from __future__ import annotations
 
 import asyncio
+import inspect
 import json
+import os
 import sys
 import time
 from pathlib import Path
@@ -275,6 +277,29 @@ def _parse_ts(raw: str) -> float | None:
 # can do async work like awaiting the response_callback / cost_callback /
 # conversation_store writes without forcing a sync bridge.
 TurnCallback = Callable[[TurnResponse], Awaitable[None]]
+EntryCallback = Callable[..., None]
+_BoundEntryCallback = Callable[[dict, int, tuple[int, int]], None]
+
+
+def _bind_entry_callback(
+    callback: EntryCallback | None,
+) -> _BoundEntryCallback | None:
+    """Bind legacy entry-only or provenance-aware callback arity once."""
+    if callback is None:
+        return None
+    try:
+        inspect.signature(callback).bind(
+            {},
+            entry_offset=0,
+            source_identity=(0, 0),
+        )
+    except (TypeError, ValueError):
+        return lambda entry, _entry_offset, _source_identity: callback(entry)
+    return lambda entry, entry_offset, source_identity: callback(
+        entry,
+        entry_offset=entry_offset,
+        source_identity=source_identity,
+    )
 
 
 class TmuxTranscriptTailer:
@@ -307,7 +332,7 @@ class TmuxTranscriptTailer:
         active_poll_sec: float = _ACTIVE_POLL_SEC,
         path_discovery: Callable[[], Path | None] | None = None,
         on_usage: Callable[[dict], None] | None = None,
-        on_entry: Callable[[dict], None] | None = None,
+        on_entry: EntryCallback | None = None,
         on_bound_path_wedge: Callable[[Path, float], None] | None = None,
     ) -> None:
         self._path = Path(transcript_path)
@@ -351,7 +376,7 @@ class TmuxTranscriptTailer:
         self._on_usage = on_usage
         # Raw-entry hook used by TmuxSession to observe prompt acceptance.
         # Sync so reading a chunk has no new suspension point.
-        self._on_entry = on_entry
+        self._on_entry = _bind_entry_callback(on_entry)
 
         self._offset: int = 0
         # Bumped by every path-changing ``set_transcript_path``. Lets
@@ -732,42 +757,48 @@ class TmuxTranscriptTailer:
         """
         if not self._path.exists():
             return 0
-        self._bound_path_ever_materialized = True
-
         # Snapshot for the mid-chunk swap check below. The only awaits in
         # this method are the turn callbacks; everything else is sync, so
         # a concurrent ``set_transcript_path`` can only land while a
         # callback is in flight.
         generation = self._swap_generation
 
-        size = self._path.stat().st_size
-        if size < self._offset:
-            # File truncated or rotated underneath us. Reset to 0 and
-            # replay; downstream consumers should be idempotent against
-            # repeat turns, but in practice the buffer is empty on
-            # rotation so this just rebuilds state from scratch.
-            _log(
-                f"tmux_tailer[{self._agent_name}]: file shrank "
-                f"({size} < {self._offset}); resetting to 0"
-            )
-            self._offset = 0
-            self._buffer.drain()  # discard partial state
-            self._stats["rotations"] += 1
-
-        if size == self._offset:
-            return 0
-
         bytes_read = 0
-        # Read in text mode — Claude Code transcripts are UTF-8. Buffer
-        # may contain a partial trailing line if Claude Code is mid-write;
-        # we only advance offset by complete lines.
+        # Read bytes so offsets stay exact across UTF-8 and the opened
+        # descriptor can authoritatively identify every delivered row. Buffer
+        # may contain a partial trailing line if Claude Code is mid-write; we
+        # only advance offset by complete lines.
         #
         # ``_MAX_READ_CHUNK_BYTES`` caps single-read memory so a pathological
         # transcript path (or attacker-pointed file via the path-update
         # endpoint) can't OOM the daemon. If more data remains after the
         # cap, the wake_event is re-armed below so the next loop iteration
         # picks it up — slower but bounded.
-        with self._path.open("r", encoding="utf-8", errors="replace") as fh:
+        try:
+            handle = self._path.open("rb")
+        except FileNotFoundError:
+            return 0
+        with handle as fh:
+            opened = os.fstat(fh.fileno())
+            source_identity = (opened.st_dev, opened.st_ino)
+            size = opened.st_size
+            self._bound_path_ever_materialized = True
+            if size < self._offset:
+                # File truncated or rotated underneath us. Reset to 0 and
+                # replay; downstream consumers should be idempotent against
+                # repeat turns, but in practice the buffer is empty on
+                # rotation so this just rebuilds state from scratch.
+                _log(
+                    f"tmux_tailer[{self._agent_name}]: file shrank "
+                    f"({size} < {self._offset}); resetting to 0"
+                )
+                self._offset = 0
+                self._buffer.drain()  # discard partial state
+                self._stats["rotations"] += 1
+
+            if size == self._offset:
+                return 0
+
             fh.seek(self._offset)
             chunk = fh.read(_MAX_READ_CHUNK_BYTES)
             more_pending = (size - self._offset) > _MAX_READ_CHUNK_BYTES
@@ -775,35 +806,40 @@ class TmuxTranscriptTailer:
             # line (no trailing newline → don't consume).
             if not chunk:
                 return 0
-            if chunk.endswith("\n"):
+            if chunk.endswith(b"\n"):
                 complete = chunk
-                partial = ""
+                partial = b""
             else:
-                last_nl = chunk.rfind("\n")
+                last_nl = chunk.rfind(b"\n")
                 if last_nl == -1:
                     # No complete line yet. Don't advance offset.
                     return 0
                 complete = chunk[: last_nl + 1]
                 partial = chunk[last_nl + 1:]
 
-            for line in complete.splitlines():
+            for line in complete.split(b"\n")[:-1]:
+                entry_offset = self._offset + bytes_read
+                bytes_read += len(line) + 1
                 if not line.strip():
                     continue
                 self._stats["lines_read"] += 1
                 try:
-                    entry = json.loads(line)
+                    entry = json.loads(line.decode("utf-8", errors="replace"))
                 except json.JSONDecodeError:
                     self._stats["parse_errors"] += 1
                     _log(
                         f"tmux_tailer[{self._agent_name}]: skipping malformed "
-                        f"JSON at offset {self._offset}+{bytes_read}"
+                        f"JSON at offset {entry_offset}"
                     )
-                    bytes_read += len(line) + 1
                     continue
 
                 if self._on_entry is not None:
                     try:
-                        self._on_entry(dict(entry))
+                        self._on_entry(
+                            dict(entry),
+                            entry_offset,
+                            source_identity,
+                        )
                     except Exception as e:
                         self._stats["callback_errors"] += 1
                         _log(
@@ -824,8 +860,6 @@ class TmuxTranscriptTailer:
                         f"tmux_tailer[{self._agent_name}]: feed raised "
                         f"({type(e).__name__}: {e}); skipping entry"
                     )
-
-                bytes_read += len(line.encode("utf-8")) + 1  # +1 for the \n
 
                 # Mid-turn context surfacing: this entry refreshed the
                 # usage snapshot — hand it to the consumer NOW rather
@@ -869,7 +903,7 @@ class TmuxTranscriptTailer:
 
             # Advance past complete lines only. Partial line stays in the
             # file and we'll re-read it next loop.
-            self._offset += len(complete.encode("utf-8"))
+            self._offset += len(complete)
             # ``partial`` is dropped intentionally — next read picks it up.
             _ = partial
 

--- a/tests/test_murzik_1163_review_probes.py
+++ b/tests/test_murzik_1163_review_probes.py
@@ -1,0 +1,291 @@
+"""Adversarial reviewer probes for the #1163 folded-acceptance change."""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from pinky_daemon import tmux_session
+from pinky_daemon.streaming_session import StreamingSessionConfig
+from pinky_daemon.tmux_session import (
+    TmuxCommandResult,
+    TmuxSession,
+    _InflightMeta,
+    _QueuedTurn,
+    _TmuxControl,
+)
+from pinky_daemon.tmux_transcript import TmuxTranscriptTailer
+from pinky_daemon.transport_state import SessionState
+
+
+def _ok() -> TmuxCommandResult:
+    return TmuxCommandResult(returncode=0, stdout="", stderr="")
+
+
+def _make_session(*, registry: object | None = None) -> TmuxSession:
+    control = MagicMock(spec=_TmuxControl)
+    control.session_name = "pinky-review-probe"
+    control.tmux_binary = "tmux"
+    control.socket_name = ""
+    control.socket_path = None
+    control.has_session = AsyncMock(return_value=False)
+    control.new_session = AsyncMock(return_value=_ok())
+    control.kill_session = AsyncMock(return_value=_ok())
+    control.rename_session = AsyncMock(return_value=_ok())
+    control.send_keys = AsyncMock(return_value=_ok())
+    control.paste_text = AsyncMock(return_value=_ok())
+    control.capture_pane = AsyncMock(return_value=_ok())
+    control.resize_window = AsyncMock(return_value=_ok())
+    session = TmuxSession(
+        StreamingSessionConfig(
+            agent_name="dymok",
+            working_dir="/tmp/tmux-fold-review-probe",
+        ),
+        registry=registry,
+        tmux_control=control,
+    )
+    session._skip_wake_prompt_for_tests = True
+    session._state_machine._state = SessionState.CONNECTED
+    return session
+
+
+def _seed_inflight(session: TmuxSession, *, prompt: str, **turn_kwargs) -> _InflightMeta:
+    turn = _QueuedTurn(prompt=prompt, **turn_kwargs)
+    turn.pane_delivery_started = True
+    entry = _InflightMeta(
+        meta={
+            "platform": turn.platform,
+            "chat_id": turn.chat_id,
+            "message_id": turn.message_id,
+        },
+        completion_event=turn.completion_event,
+        internal=False,
+        dispatched_at=time.time(),
+        turn=turn,
+    )
+    session._inflight_metas.append(entry)
+    return entry
+
+
+def _bind_ticket(entry: _InflightMeta, transcript: Path) -> None:
+    stat = transcript.stat()
+    offset = stat.st_size
+    anchor_start = max(0, offset - 4096)
+    anchor = transcript.read_bytes()[anchor_start:offset]
+    entry.transcript_path_at_paste = transcript
+    entry.transcript_file_identity_at_paste = (stat.st_dev, stat.st_ino)
+    entry.transcript_offset_at_paste = offset
+    entry.transcript_anchor_start_at_paste = anchor_start
+    entry.transcript_anchor_at_paste = anchor
+    entry.transcript_ticket_captured_at_ns = time.time_ns()
+
+
+def _append_entry(transcript: Path, entry: dict) -> None:
+    with transcript.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(entry) + "\n")
+
+
+def test_span_search_advances_through_chained_overlaps() -> None:
+    """An overlapping first hit must not hide a later disjoint occurrence."""
+    assert TmuxSession._first_unoccupied_prompt_span(
+        "ababa", "ba", [(0, 3)]
+    ) == (3, 5)
+    assert TmuxSession._first_unoccupied_prompt_span(
+        "aaaa", "aa", [(0, 2)]
+    ) == (2, 4)
+
+
+@pytest.mark.asyncio
+async def test_live_fold_allocates_two_distinct_nonoverlapping_prompts(
+    tmp_path: Path,
+) -> None:
+    """One live folded row can settle several disjoint pending occurrences."""
+    transcript = tmp_path / "two-prompts.jsonl"
+    transcript.write_text('{"type":"system"}\n', encoding="utf-8")
+    session = _make_session()
+    first = _seed_inflight(session, prompt="first folded prompt")
+    second = _seed_inflight(session, prompt="second folded prompt")
+    _bind_ticket(first, transcript)
+    _bind_ticket(second, transcript)
+    _append_entry(
+        transcript,
+        {
+            "type": "user",
+            "message": {
+                "content": (
+                    "<fold>first folded prompt</fold>"
+                    "<fold>second folded prompt</fold>"
+                )
+            },
+        },
+    )
+    tailer = TmuxTranscriptTailer(
+        transcript,
+        lambda _response: None,
+        on_entry=session._on_transcript_entry,
+    )
+
+    await tailer.read_once()
+
+    assert first.turn.transport_accepted is True
+    assert second.turn.transport_accepted is True
+
+
+def test_complete_fold_row_remains_positive_at_scan_budget_boundary(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A fully read row stays usable even when the source scan is incomplete."""
+    session = _make_session()
+    transcript = tmp_path / "budget.jsonl"
+    transcript.write_text('{"type":"system"}\n', encoding="utf-8")
+    session._tailer = MagicMock()
+    session._tailer.transcript_path = transcript
+    prompt = "folded at the exact budget boundary"
+    entry = _seed_inflight(session, prompt=prompt)
+    _bind_ticket(entry, transcript)
+    _append_entry(
+        transcript,
+        {"type": "user", "message": {"content": f"<fold>{prompt}</fold>"}},
+    )
+    post_ticket_bytes = transcript.stat().st_size - entry.transcript_offset_at_paste
+    anchor_bytes = len(entry.transcript_anchor_at_paste or b"")
+    monkeypatch.setattr(
+        tmux_session,
+        "_PHANTOM_TRANSCRIPT_SCAN_BYTES",
+        anchor_bytes + post_ticket_bytes,
+    )
+
+    assert session._phantom_consumption_verdicts([entry]) == [True]
+
+
+def test_partial_fold_row_at_scan_budget_boundary_stays_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A budget-truncated row cannot become positive containment evidence."""
+    session = _make_session()
+    transcript = tmp_path / "partial-budget.jsonl"
+    transcript.write_text('{"type":"system"}\n', encoding="utf-8")
+    session._tailer = MagicMock()
+    session._tailer.transcript_path = transcript
+    prompt = "folded beyond the scan boundary"
+    entry = _seed_inflight(session, prompt=prompt)
+    _bind_ticket(entry, transcript)
+    _append_entry(
+        transcript,
+        {"type": "user", "message": {"content": f"<fold>{prompt}</fold>"}},
+    )
+    anchor_bytes = len(entry.transcript_anchor_at_paste or b"")
+    monkeypatch.setattr(
+        tmux_session,
+        "_PHANTOM_TRANSCRIPT_SCAN_BYTES",
+        anchor_bytes + 8,
+    )
+
+    assert session._phantom_consumption_verdicts([entry]) == [None]
+
+
+@pytest.mark.asyncio
+async def test_live_fold_after_ticket_survives_a_chunk_that_starts_before_ticket(
+    tmp_path: Path,
+) -> None:
+    """Use the row offset, not chunk start, when a read straddles the ticket."""
+    prompt = "folded after ticket in a chunk with older backlog"
+    transcript = tmp_path / "straddled.jsonl"
+    transcript.write_text(
+        json.dumps(
+            {
+                "type": "user",
+                "message": {"content": "unrelated row before the paste ticket"},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    session = _make_session()
+    seeded = _seed_inflight(session, prompt=prompt)
+    _bind_ticket(seeded, transcript)
+    _append_entry(
+        transcript,
+        {"type": "user", "message": {"content": f"<fold>{prompt}</fold>"}},
+    )
+    tailer = TmuxTranscriptTailer(
+        transcript,
+        lambda _response: None,
+        on_entry=session._on_transcript_entry,
+    )
+    assert tailer.offset == 0 < seeded.transcript_offset_at_paste
+
+    await tailer.read_once()
+
+    assert seeded.turn.transport_accepted is True
+
+
+@pytest.mark.asyncio
+async def test_delayed_live_callback_cannot_use_a_pre_ticket_fold_row(
+    tmp_path: Path,
+) -> None:
+    """A row already on disk before paste cannot prove the new occurrence.
+
+    The tailer reads a whole chunk before awaiting a turn callback.  A new paste
+    can start during that await, after later rows in the chunk are already on
+    disk but before their synchronous ``on_entry`` callbacks run.
+    """
+    prompt = "[telegram | dm | sender | chat | unique-message-id]\nrun once"
+    transcript = tmp_path / "delayed.jsonl"
+    rows = [
+        {
+            "type": "assistant",
+            "message": {
+                "content": [{"type": "text", "text": "prior response"}],
+                "usage": {"input_tokens": 1, "output_tokens": 1},
+            },
+        },
+        {
+            "type": "system",
+            "subtype": "stop_hook_summary",
+            "hookCount": 1,
+            "hasOutput": False,
+        },
+        {
+            "type": "user",
+            "message": {
+                "content": f"unrelated old row quoting <{prompt}> for diagnostics"
+            },
+        },
+    ]
+    transcript.write_text(
+        "".join(json.dumps(row) + "\n" for row in rows),
+        encoding="utf-8",
+    )
+    registry = MagicMock()
+    session = _make_session(registry=registry)
+    seeded = None
+
+    async def seed_during_prior_turn_callback(_response: object) -> None:
+        nonlocal seeded
+        seeded = _seed_inflight(
+            session,
+            prompt=prompt,
+            platform="telegram",
+            chat_id="chat",
+            message_id="unique-message-id",
+        )
+        _bind_ticket(seeded, transcript)
+
+    tailer = TmuxTranscriptTailer(
+        transcript,
+        seed_during_prior_turn_callback,
+        on_entry=session._on_transcript_entry,
+    )
+    await tailer.read_once()
+
+    assert seeded is not None
+    assert seeded.transcript_offset_at_paste == transcript.stat().st_size
+    assert seeded.turn.transport_accepted is False
+    registry.mark_turn_delivered.assert_not_called()

--- a/tests/test_tmux_fold_consumption_acceptance.py
+++ b/tests/test_tmux_fold_consumption_acceptance.py
@@ -228,7 +228,11 @@ async def test_fold_live_acceptance_persists_receipts_and_drains_without_requeue
     row = _folded_user_entry(prompt)
     _append_entry(transcript, row)
 
-    session._on_transcript_entry(row)
+    session._on_transcript_entry(
+        row,
+        entry_offset=folded.transcript_offset_at_paste,
+        source_identity=folded.transcript_file_identity_at_paste,
+    )
 
     assert folded.turn.transport_accepted is True
     assert scheduler_receipt.result() is True
@@ -253,7 +257,9 @@ async def test_fold_live_acceptance_persists_receipts_and_drains_without_requeue
 
 
 @pytest.mark.asyncio
-async def test_fold_acceptance_releases_scheduler_gate_before_idle_reconcile() -> None:
+async def test_fold_acceptance_releases_scheduler_gate_before_idle_reconcile(
+    tmp_path: Path,
+) -> None:
     """Fold evidence settles the receipt that makes the scheduler gate busy."""
     session = _make_session()
     session._config.live_status_fn = lambda: {
@@ -267,9 +273,20 @@ async def test_fold_acceptance_releases_scheduler_gate_before_idle_reconcile() -
         prompt=prompt,
         submission_receipt=receipt,
     )
+    transcript = tmp_path / "session.jsonl"
+    transcript.write_text('{"type":"system"}\n', encoding="utf-8")
+    session._tailer = MagicMock()
+    session._tailer.transcript_path = transcript
+    _bind_ticket(entry, transcript)
+    row = _folded_user_entry(prompt)
+    _append_entry(transcript, row)
 
     assert session._scheduler_pane_busy() is True
-    session._on_transcript_entry(_folded_user_entry(prompt))
+    session._on_transcript_entry(
+        row,
+        entry_offset=entry.transcript_offset_at_paste,
+        source_identity=entry.transcript_file_identity_at_paste,
+    )
 
     assert entry.turn.transport_accepted is True
     assert receipt.result() is True

--- a/tests/test_tmux_fold_consumption_acceptance.py
+++ b/tests/test_tmux_fold_consumption_acceptance.py
@@ -1,0 +1,561 @@
+"""Acceptance coverage for folded mid-turn tmux prompt consumption (#1163).
+
+Claude Code can fold one or more pane pastes into a framed ``user`` transcript
+row while another turn is running.  The full prompt bytes are still positive
+transport evidence, but the row is not byte-identical to any pasted prompt.
+
+Transport matrix: ``TmuxSession`` owns the Claude transcript evidence fixed in
+this file and writes ``delivered_turn`` rows after that evidence.  The separate
+``CodexSession`` transport has no delivered-turn acceptance path.
+``CodexTmuxSession`` inherits the ledger method from ``TmuxSession``, but Codex
+rollouts use an ``event_msg/user_message`` evidence shape and do not enter the
+Claude folded-row fallback; this change must not make that shape containment-
+aware or otherwise change Codex's empirically rowless behavior.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from pinky_daemon import tmux_session
+from pinky_daemon.codex_session import CodexSession
+from pinky_daemon.codex_tmux_session import CodexTmuxSession
+from pinky_daemon.streaming_session import StreamingSessionConfig
+from pinky_daemon.tmux_session import (
+    TmuxCommandResult,
+    TmuxSession,
+    _InflightMeta,
+    _QueuedTurn,
+    _TmuxControl,
+)
+from pinky_daemon.transport_state import SessionState
+
+
+def _ok() -> TmuxCommandResult:
+    return TmuxCommandResult(returncode=0, stdout="", stderr="")
+
+
+def _mock_tmux() -> MagicMock:
+    control = MagicMock(spec=_TmuxControl)
+    control.session_name = "pinky-fold-test"
+    control.tmux_binary = "tmux"
+    control.socket_name = ""
+    control.socket_path = None
+    control.has_session = AsyncMock(return_value=False)
+    control.new_session = AsyncMock(return_value=_ok())
+    control.kill_session = AsyncMock(return_value=_ok())
+    control.rename_session = AsyncMock(return_value=_ok())
+    control.send_keys = AsyncMock(return_value=_ok())
+    control.paste_text = AsyncMock(return_value=_ok())
+    control.capture_pane = AsyncMock(return_value=_ok())
+    control.resize_window = AsyncMock(return_value=_ok())
+    return control
+
+
+def _make_session(
+    *,
+    registry: object | None = None,
+    session_type: type[TmuxSession] = TmuxSession,
+) -> TmuxSession:
+    config = StreamingSessionConfig(
+        agent_name="dymok",
+        working_dir="/tmp/tmux-fold-consumption-test",
+    )
+    session = session_type(
+        config,
+        registry=registry,
+        tmux_control=_mock_tmux(),
+    )
+    session._skip_wake_prompt_for_tests = True
+    session._state_machine._state = SessionState.CONNECTED
+    return session
+
+
+def _seed_inflight(
+    session: TmuxSession,
+    *,
+    prompt: str,
+    transport_accepted: bool = False,
+    completion_event: asyncio.Event | None = None,
+    scheduler_delivery: asyncio.Future[bool] | None = None,
+    submission_receipt: asyncio.Future[bool] | None = None,
+    platform: str = "",
+    chat_id: str = "",
+    message_id: str = "",
+) -> _InflightMeta:
+    turn = _QueuedTurn(
+        prompt=prompt,
+        platform=platform,
+        chat_id=chat_id,
+        message_id=message_id,
+        completion_event=completion_event,
+        scheduler_delivery=scheduler_delivery,
+        submission_receipt=submission_receipt,
+        transport_accepted=transport_accepted,
+    )
+    turn.pane_delivery_started = True
+    entry = _InflightMeta(
+        meta={
+            "platform": platform,
+            "chat_id": chat_id,
+            "message_id": message_id,
+        },
+        completion_event=completion_event,
+        internal=False,
+        dispatched_at=time.time(),
+        turn=turn,
+    )
+    was_empty = not session._inflight_metas
+    session._inflight_metas.append(entry)
+    if was_empty:
+        session._head_started_at = time.time()
+    return entry
+
+
+def _bind_ticket(entry: _InflightMeta, transcript: Path) -> None:
+    stat = transcript.stat()
+    offset = stat.st_size
+    anchor_start = max(0, offset - 4096)
+    with transcript.open("rb") as handle:
+        handle.seek(anchor_start)
+        anchor = handle.read(offset - anchor_start)
+    entry.transcript_path_at_paste = transcript
+    entry.transcript_file_identity_at_paste = (stat.st_dev, stat.st_ino)
+    entry.transcript_offset_at_paste = offset
+    entry.transcript_anchor_start_at_paste = anchor_start
+    entry.transcript_anchor_at_paste = anchor
+    entry.transcript_ticket_captured_at_ns = time.time_ns()
+
+
+def _append_entry(transcript: Path, entry: dict) -> None:
+    with transcript.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(entry, ensure_ascii=False) + "\n")
+
+
+def _folded_user_entry(prompt: str) -> dict:
+    return {
+        "type": "user",
+        "message": {
+            "role": "user",
+            "content": [
+                {
+                    "type": "text",
+                    "text": "<system-reminder>queued alongside tool output\n",
+                },
+                {
+                    "type": "tool_result",
+                    "tool_use_id": "tool-1",
+                    "content": "adjacent result",
+                },
+                {"type": "text", "text": f"{prompt}\n</system-reminder>"},
+            ],
+        },
+    }
+
+
+def _enable_fast_idle_reconcile(
+    monkeypatch: pytest.MonkeyPatch,
+    session: TmuxSession,
+) -> None:
+    monkeypatch.setattr(tmux_session, "_TURN_DONE_TIMEOUT_SEC", 0.01)
+    monkeypatch.setattr(tmux_session, "_WATCHDOG_TICK_SEC", 0.01)
+    session._config.live_status_fn = lambda: {
+        "status": "idle",
+        "last_updated": time.time() + 1,
+    }
+    session._transcript_recently_grew = lambda *_args: False
+    session._head_started_at = time.time() - 1
+
+
+async def _run_idle_reconcile(session: TmuxSession) -> None:
+    task = asyncio.create_task(session._inflight_watchdog())
+    try:
+        for _ in range(200):
+            if not session._inflight_metas:
+                break
+            await asyncio.sleep(0.01)
+        else:
+            pytest.fail("watchdog did not reconcile the aged idle deque")
+    finally:
+        task.cancel()
+        await task
+
+
+@pytest.mark.asyncio
+async def test_fold_live_acceptance_persists_receipts_and_drains_without_requeue(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A framed fold is evidence now, and verified-consumed at idle later."""
+    decisions = MagicMock()
+    monkeypatch.setattr(tmux_session, "log_watchdog_decision", decisions)
+    registry = MagicMock()
+    registry.mark_turn_delivered.return_value = True
+    session = _make_session(registry=registry)
+    transcript = tmp_path / "session.jsonl"
+    transcript.write_text('{"type":"system"}\n', encoding="utf-8")
+    session._tailer = MagicMock()
+    session._tailer.transcript_path = transcript
+
+    running = _seed_inflight(
+        session,
+        prompt="turn A is already running",
+        transport_accepted=True,
+    )
+    _bind_ticket(running, transcript)
+    completion = asyncio.Event()
+    scheduler_receipt = asyncio.get_running_loop().create_future()
+    submission_receipt = asyncio.get_running_loop().create_future()
+    prompt = "[agent | sender | internal | 2026-08-27T06:00:00-07:00]\nrun B once"
+    folded = _seed_inflight(
+        session,
+        prompt=prompt,
+        completion_event=completion,
+        scheduler_delivery=scheduler_receipt,
+        submission_receipt=submission_receipt,
+        platform="telegram",
+        chat_id="chat-1",
+        message_id="message-1",
+    )
+    _bind_ticket(folded, transcript)
+    row = _folded_user_entry(prompt)
+    _append_entry(transcript, row)
+
+    session._on_transcript_entry(row)
+
+    assert folded.turn.transport_accepted is True
+    assert scheduler_receipt.result() is True
+    assert submission_receipt.result() is True
+    registry.mark_turn_delivered.assert_called_once_with(
+        "dymok",
+        "telegram",
+        "chat-1",
+        "message-1",
+        source="telegram",
+    )
+
+    _enable_fast_idle_reconcile(monkeypatch, session)
+    await _run_idle_reconcile(session)
+
+    assert completion.is_set()
+    assert session._message_queue.empty()
+    reasons = [call.kwargs.get("reason") for call in decisions.call_args_list]
+    assert "phantom_requeued_unconsumed" not in reasons
+    assert "verdict=verified_consumed" in capsys.readouterr().err
+    registry.mark_turn_delivered.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_fold_acceptance_releases_scheduler_gate_before_idle_reconcile() -> None:
+    """Fold evidence settles the receipt that makes the scheduler gate busy."""
+    session = _make_session()
+    session._config.live_status_fn = lambda: {
+        "status": "idle",
+        "last_updated": time.time() + 1,
+    }
+    receipt = asyncio.get_running_loop().create_future()
+    prompt = "folded wake holding the scheduler gate"
+    entry = _seed_inflight(
+        session,
+        prompt=prompt,
+        submission_receipt=receipt,
+    )
+
+    assert session._scheduler_pane_busy() is True
+    session._on_transcript_entry(_folded_user_entry(prompt))
+
+    assert entry.turn.transport_accepted is True
+    assert receipt.result() is True
+    assert len(session._inflight_metas) == 1, "no idle reconcile has run"
+    assert session._scheduler_pane_busy() is False
+
+
+@pytest.mark.asyncio
+async def test_ledgered_unconsumed_phantom_is_suppressed_with_negative_receipts(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A durable delivery row makes replay a known duplicate, so drop loudly."""
+    decisions = MagicMock()
+    monkeypatch.setattr(tmux_session, "log_watchdog_decision", decisions)
+    registry = MagicMock()
+    registry.is_turn_delivered.return_value = True
+    session = _make_session(registry=registry)
+    transcript = tmp_path / "session.jsonl"
+    transcript.write_text('{"type":"system"}\n', encoding="utf-8")
+    session._tailer = MagicMock()
+    session._tailer.transcript_path = transcript
+    completion = asyncio.Event()
+    scheduler_receipt = asyncio.get_running_loop().create_future()
+    submission_receipt = asyncio.get_running_loop().create_future()
+    entry = _seed_inflight(
+        session,
+        prompt="ledgered prompt absent from this transcript window",
+        completion_event=completion,
+        scheduler_delivery=scheduler_receipt,
+        submission_receipt=submission_receipt,
+        platform="telegram",
+        chat_id="chat-1",
+        message_id="message-1",
+    )
+    _bind_ticket(entry, transcript)
+    _enable_fast_idle_reconcile(monkeypatch, session)
+
+    await _run_idle_reconcile(session)
+
+    assert completion.is_set()
+    assert scheduler_receipt.result() is False
+    assert submission_receipt.result() is False
+    assert entry.turn.replay_count == 0
+    assert session._message_queue.empty()
+    registry.is_turn_delivered.assert_called_once_with(
+        "dymok", "telegram", "chat-1", "message-1"
+    )
+    reasons = [call.kwargs.get("reason") for call in decisions.call_args_list]
+    assert "phantom_suppressed_ledgered" in reasons
+    assert "phantom_requeued_unconsumed" not in reasons
+    logs = capsys.readouterr().err
+    assert "PHANTOM_SUPPRESSED_LEDGERED" in logs
+    assert "message-1" in logs
+    assert "scheduler_receipt=pending" in logs
+    assert "submission_receipt=pending" in logs
+    assert "PHANTOM_LEDGER_SUPPRESSION_SUMMARY suppressed=1" in logs
+
+
+@pytest.mark.asyncio
+async def test_ledger_read_error_fails_open_to_existing_requeue(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A broken backstop read never converts uncertainty into a silent drop."""
+    decisions = MagicMock()
+    monkeypatch.setattr(tmux_session, "log_watchdog_decision", decisions)
+    registry = MagicMock()
+    registry.is_turn_delivered.side_effect = RuntimeError("registry unavailable")
+    session = _make_session(registry=registry)
+    transcript = tmp_path / "session.jsonl"
+    transcript.write_text('{"type":"system"}\n', encoding="utf-8")
+    session._tailer = MagicMock()
+    session._tailer.transcript_path = transcript
+    completion = asyncio.Event()
+    entry = _seed_inflight(
+        session,
+        prompt="uncertain ledger prompt",
+        completion_event=completion,
+        platform="telegram",
+        chat_id="chat-2",
+        message_id="message-2",
+    )
+    _bind_ticket(entry, transcript)
+    _enable_fast_idle_reconcile(monkeypatch, session)
+
+    await _run_idle_reconcile(session)
+
+    assert not completion.is_set()
+    assert entry.turn.replay_count == 1
+    assert session._message_queue.get_nowait() is entry.turn
+    assert session._message_queue.empty()
+    reasons = [call.kwargs.get("reason") for call in decisions.call_args_list]
+    assert reasons.count("phantom_requeued_unconsumed") == 1
+    assert "phantom_suppressed_ledgered" not in reasons
+
+
+def test_repeated_fold_reserves_accepted_occurrence_without_second_mark() -> None:
+    """A replayed accepted candidate owns its fold; it cannot donate the row."""
+    registry = MagicMock()
+    session = _make_session(registry=registry)
+    prompt = "identical replayed prompt"
+    accepted = _seed_inflight(
+        session,
+        prompt=prompt,
+        transport_accepted=True,
+        platform="telegram",
+        chat_id="chat-3",
+        message_id="message-3",
+    )
+    later = _seed_inflight(session, prompt=prompt)
+
+    session._on_transcript_entry(_folded_user_entry(prompt))
+
+    assert accepted.turn.transport_accepted is True
+    assert later.turn.transport_accepted is False
+    registry.mark_turn_delivered.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("occurrences", "expected"),
+    [
+        (1, [True, False]),
+        (2, [True, True]),
+    ],
+)
+def test_idle_fold_allocates_identical_prompts_by_nonoverlapping_occurrence(
+    tmp_path: Path,
+    occurrences: int,
+    expected: list[bool],
+) -> None:
+    """One folded occurrence proves one oldest candidate; two prove both."""
+    session = _make_session()
+    transcript = tmp_path / "session.jsonl"
+    transcript.write_text('{"type":"system"}\n', encoding="utf-8")
+    session._tailer = MagicMock()
+    session._tailer.transcript_path = transcript
+    prompt = "same complete folded prompt"
+    first = _seed_inflight(session, prompt=prompt)
+    second = _seed_inflight(session, prompt=prompt)
+    _bind_ticket(first, transcript)
+    _bind_ticket(second, transcript)
+    content = "<fold>" + " | separator | ".join([prompt] * occurrences) + "</fold>"
+    _append_entry(
+        transcript,
+        {"type": "user", "message": {"role": "user", "content": content}},
+    )
+
+    assert session._phantom_consumption_verdicts([first, second]) == expected
+
+
+def test_idle_fold_allocates_exact_rows_before_containment(tmp_path: Path) -> None:
+    """A nested exact candidate takes its exact row before folded allocation."""
+    session = _make_session()
+    transcript = tmp_path / "session.jsonl"
+    transcript.write_text('{"type":"system"}\n', encoding="utf-8")
+    session._tailer = MagicMock()
+    session._tailer.transcript_path = transcript
+    short = _seed_inflight(session, prompt="alpha")
+    long = _seed_inflight(session, prompt="alpha beta")
+    _bind_ticket(short, transcript)
+    _bind_ticket(long, transcript)
+    _append_entry(
+        transcript,
+        {
+            "type": "user",
+            "message": {"role": "user", "content": "<fold>alpha beta</fold>"},
+        },
+    )
+    _append_entry(
+        transcript,
+        {"type": "user", "message": {"role": "user", "content": "alpha"}},
+    )
+
+    assert session._phantom_consumption_verdicts([short, long]) == [True, True]
+
+
+def test_idle_fold_uses_global_nonoverlapping_spans_oldest_first(tmp_path: Path) -> None:
+    """Overlapping distinct prompts under-accept safely instead of double-use."""
+    session = _make_session()
+    transcript = tmp_path / "session.jsonl"
+    transcript.write_text('{"type":"system"}\n', encoding="utf-8")
+    session._tailer = MagicMock()
+    session._tailer.transcript_path = transcript
+    short = _seed_inflight(session, prompt="alpha")
+    long = _seed_inflight(session, prompt="alpha beta")
+    _bind_ticket(short, transcript)
+    _bind_ticket(long, transcript)
+    _append_entry(
+        transcript,
+        {
+            "type": "user",
+            "message": {"role": "user", "content": "<fold>alpha beta</fold>"},
+        },
+    )
+
+    assert session._phantom_consumption_verdicts([short, long]) == [True, False]
+
+
+def test_live_fold_fallback_rejects_prefix_assistant_and_empty_prompt() -> None:
+    """Containment never promotes partial, assistant, or empty evidence."""
+    session = _make_session()
+    prefix = _seed_inflight(session, prompt="complete prompt bytes")
+    assistant = _seed_inflight(session, prompt="assistant-only complete prompt")
+    empty = _seed_inflight(session, prompt="")
+
+    session._on_transcript_entry(
+        {"type": "user", "message": {"content": "complete prompt"}}
+    )
+    session._on_transcript_entry(
+        {
+            "type": "assistant",
+            "message": {"content": "assistant-only complete prompt"},
+        }
+    )
+    session._on_transcript_entry(
+        {"type": "user", "message": {"content": "unrelated framed user row"}}
+    )
+
+    assert prefix.turn.transport_accepted is False
+    assert assistant.turn.transport_accepted is False
+    assert empty.turn.transport_accepted is False
+
+
+def test_idle_fold_preserves_ticket_window_empty_and_unavailable_verdicts(
+    tmp_path: Path,
+) -> None:
+    """Containment keeps the existing False/None provenance boundaries."""
+    session = _make_session()
+    transcript = tmp_path / "session.jsonl"
+    prompt = "full prompt must be post-ticket"
+    transcript.write_text(
+        json.dumps({"type": "user", "message": {"content": prompt}}) + "\n",
+        encoding="utf-8",
+    )
+    session._tailer = MagicMock()
+    session._tailer.transcript_path = transcript
+    bounded = _seed_inflight(session, prompt=prompt)
+    empty = _seed_inflight(session, prompt="")
+    _bind_ticket(bounded, transcript)
+    _bind_ticket(empty, transcript)
+    _append_entry(
+        transcript,
+        {"type": "user", "message": {"content": "full prompt must be post"}},
+    )
+    _append_entry(
+        transcript,
+        {"type": "assistant", "message": {"content": prompt}},
+    )
+
+    assert session._phantom_consumption_verdicts([bounded, empty]) == [False, False]
+
+    unavailable_session = _make_session()
+    unavailable = _seed_inflight(unavailable_session, prompt="unavailable prompt")
+    unavailable_session._tailer = None
+    assert unavailable_session._phantom_consumption_verdicts([unavailable]) == [None]
+
+
+def test_codex_transport_matrix_does_not_gain_claude_fold_evidence() -> None:
+    """Both Codex classes remain outside the Claude folded-row write path."""
+    assert not issubclass(CodexSession, TmuxSession)
+    assert not hasattr(CodexSession, "_mark_transport_accepted")
+    assert CodexTmuxSession._mark_transport_accepted is TmuxSession._mark_transport_accepted
+    assert CodexTmuxSession._on_transcript_entry is not TmuxSession._on_transcript_entry
+
+    registry = MagicMock()
+    session = _make_session(registry=registry, session_type=CodexTmuxSession)
+    prompt = "codex rollout prompt"
+    entry = _seed_inflight(
+        session,
+        prompt=prompt,
+        platform="telegram",
+        chat_id="chat-codex",
+        message_id="message-codex",
+    )
+
+    session._on_transcript_entry(
+        {
+            "type": "event_msg",
+            "payload": {
+                "type": "user_message",
+                "message": f"<fold>{prompt}</fold>",
+            },
+        }
+    )
+
+    assert entry.turn.transport_accepted is False
+    registry.mark_turn_delivered.assert_not_called()

--- a/tests/test_tmux_fold_consumption_provenance.py
+++ b/tests/test_tmux_fold_consumption_provenance.py
@@ -1,0 +1,267 @@
+"""Paste-boundary provenance pins for live folded acceptance (#1163)."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from pinky_daemon.codex_tmux_session import CodexTmuxSession
+from pinky_daemon.streaming_session import StreamingSessionConfig
+from pinky_daemon.tmux_session import (
+    TmuxCommandResult,
+    TmuxSession,
+    _InflightMeta,
+    _QueuedTurn,
+    _TmuxControl,
+)
+from pinky_daemon.tmux_transcript import TmuxTranscriptTailer
+from pinky_daemon.transport_state import SessionState
+
+
+def _ok() -> TmuxCommandResult:
+    return TmuxCommandResult(returncode=0, stdout="", stderr="")
+
+
+def _mock_tmux() -> MagicMock:
+    control = MagicMock(spec=_TmuxControl)
+    control.session_name = "pinky-fold-provenance"
+    control.tmux_binary = "tmux"
+    control.socket_name = ""
+    control.socket_path = None
+    control.has_session = AsyncMock(return_value=False)
+    control.new_session = AsyncMock(return_value=_ok())
+    control.kill_session = AsyncMock(return_value=_ok())
+    control.rename_session = AsyncMock(return_value=_ok())
+    control.send_keys = AsyncMock(return_value=_ok())
+    control.paste_text = AsyncMock(return_value=_ok())
+    control.capture_pane = AsyncMock(return_value=_ok())
+    control.resize_window = AsyncMock(return_value=_ok())
+    return control
+
+
+def _make_session(
+    *,
+    registry: object | None = None,
+    session_type: type[TmuxSession] = TmuxSession,
+) -> TmuxSession:
+    session = session_type(
+        StreamingSessionConfig(
+            agent_name="dymok",
+            working_dir="/tmp/tmux-fold-provenance",
+        ),
+        registry=registry,
+        tmux_control=_mock_tmux(),
+    )
+    session._skip_wake_prompt_for_tests = True
+    session._state_machine._state = SessionState.CONNECTED
+    return session
+
+
+def _seed_inflight(
+    session: TmuxSession,
+    *,
+    prompt: str,
+    scheduler_delivery: asyncio.Future[bool] | None = None,
+    submission_receipt: asyncio.Future[bool] | None = None,
+    platform: str = "telegram",
+    chat_id: str = "chat",
+    message_id: str = "message",
+) -> _InflightMeta:
+    turn = _QueuedTurn(
+        prompt=prompt,
+        scheduler_delivery=scheduler_delivery,
+        submission_receipt=submission_receipt,
+        platform=platform,
+        chat_id=chat_id,
+        message_id=message_id,
+    )
+    turn.pane_delivery_started = True
+    entry = _InflightMeta(
+        meta={
+            "platform": platform,
+            "chat_id": chat_id,
+            "message_id": message_id,
+        },
+        completion_event=None,
+        internal=False,
+        dispatched_at=time.time(),
+        turn=turn,
+    )
+    session._inflight_metas.append(entry)
+    return entry
+
+
+def _bind_ticket(entry: _InflightMeta, transcript: Path) -> None:
+    stat = transcript.stat()
+    offset = stat.st_size
+    anchor_start = max(0, offset - 4096)
+    anchor = transcript.read_bytes()[anchor_start:offset]
+    entry.transcript_path_at_paste = transcript
+    entry.transcript_file_identity_at_paste = (stat.st_dev, stat.st_ino)
+    entry.transcript_offset_at_paste = offset
+    entry.transcript_anchor_start_at_paste = anchor_start
+    entry.transcript_anchor_at_paste = anchor
+    entry.transcript_ticket_captured_at_ns = time.time_ns()
+
+
+def _folded_user_entry(prompt: str) -> dict:
+    return {
+        "type": "user",
+        "message": {"role": "user", "content": f"<fold>{prompt}</fold>"},
+    }
+
+
+def _append_entry(transcript: Path, entry: dict) -> None:
+    with transcript.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(entry) + "\n")
+
+
+async def _drive_tailer(
+    session: TmuxSession,
+    transcript: Path,
+) -> None:
+    tailer = TmuxTranscriptTailer(
+        transcript,
+        lambda _response: None,
+        on_entry=session._on_transcript_entry,
+    )
+    session._tailer = tailer
+    await tailer.read_once()
+
+
+@pytest.mark.asyncio
+async def test_live_fold_without_paste_ticket_fails_closed(
+    tmp_path: Path,
+) -> None:
+    """A live row cannot certify a candidate with no readable paste ticket."""
+    registry = MagicMock()
+    session = _make_session(registry=registry)
+    scheduler_receipt = asyncio.get_running_loop().create_future()
+    submission_receipt = asyncio.get_running_loop().create_future()
+    prompt = "ticketless folded prompt"
+    seeded = _seed_inflight(
+        session,
+        prompt=prompt,
+        scheduler_delivery=scheduler_receipt,
+        submission_receipt=submission_receipt,
+    )
+    transcript = tmp_path / "ticketless.jsonl"
+    _append_entry(transcript, _folded_user_entry(prompt))
+
+    await _drive_tailer(session, transcript)
+
+    assert seeded.turn.transport_accepted is False
+    assert scheduler_receipt.done() is False
+    assert submission_receipt.done() is False
+    registry.mark_turn_delivered.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_live_fold_from_mismatched_file_identity_fails_closed(
+    tmp_path: Path,
+) -> None:
+    """A replacement inode cannot spend a ticket captured on the old file."""
+    registry = MagicMock()
+    session = _make_session(registry=registry)
+    transcript = tmp_path / "replaced.jsonl"
+    transcript.write_text('{"type":"system"}\n', encoding="utf-8")
+    prompt = "folded prompt from replacement inode"
+    seeded = _seed_inflight(session, prompt=prompt)
+    _bind_ticket(seeded, transcript)
+    ticket_identity = seeded.transcript_file_identity_at_paste
+    replacement = tmp_path / "replacement.jsonl"
+    replacement.write_text('{"type":"system"}\n', encoding="utf-8")
+    replacement.replace(transcript)
+    assert (transcript.stat().st_dev, transcript.stat().st_ino) != ticket_identity
+    _append_entry(transcript, _folded_user_entry(prompt))
+
+    await _drive_tailer(session, transcript)
+
+    assert seeded.turn.transport_accepted is False
+    registry.mark_turn_delivered.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_live_fold_before_paste_offset_fails_closed(
+    tmp_path: Path,
+) -> None:
+    """A complete row whose start predates the ticket cannot certify it."""
+    registry = MagicMock()
+    session = _make_session(registry=registry)
+    prompt = "folded prompt already present before paste"
+    transcript = tmp_path / "pre-ticket.jsonl"
+    _append_entry(transcript, _folded_user_entry(prompt))
+    seeded = _seed_inflight(session, prompt=prompt)
+    _bind_ticket(seeded, transcript)
+    assert seeded.transcript_offset_at_paste == transcript.stat().st_size
+
+    await _drive_tailer(session, transcript)
+
+    assert seeded.turn.transport_accepted is False
+    registry.mark_turn_delivered.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_same_read_straddle_rejects_old_fold_then_accepts_new_fold(
+    tmp_path: Path,
+) -> None:
+    """Per-row offsets preserve a valid fold later in a pre-ticket chunk."""
+    registry = MagicMock()
+    session = _make_session(registry=registry)
+    prompt = "folded prompt straddling one transcript read"
+    transcript = tmp_path / "straddle.jsonl"
+    _append_entry(transcript, _folded_user_entry(prompt))
+    seeded = _seed_inflight(session, prompt=prompt)
+    _bind_ticket(seeded, transcript)
+    _append_entry(transcript, _folded_user_entry(prompt))
+    observed: list[bool] = []
+
+    def observe_entry(
+        entry: dict,
+        entry_offset: int | None = None,
+        source_identity: tuple[int, int] | None = None,
+    ) -> None:
+        session._on_transcript_entry(
+            entry,
+            entry_offset=entry_offset,
+            source_identity=source_identity,
+        )
+        observed.append(seeded.turn.transport_accepted)
+
+    tailer = TmuxTranscriptTailer(
+        transcript,
+        lambda _response: None,
+        on_entry=observe_entry,
+    )
+    session._tailer = tailer
+
+    await tailer.read_once()
+
+    assert observed == [False, True]
+    registry.mark_turn_delivered.assert_called_once()
+
+
+def test_codex_super_call_cannot_supply_claude_fold_provenance(
+    tmp_path: Path,
+) -> None:
+    """Codex's entry-only super call leaves Claude fold matching inert."""
+    registry = MagicMock()
+    session = _make_session(
+        registry=registry,
+        session_type=CodexTmuxSession,
+    )
+    prompt = "folded Claude-shaped row presented through Codex"
+    transcript = tmp_path / "codex.jsonl"
+    transcript.write_text('{"type":"system"}\n', encoding="utf-8")
+    seeded = _seed_inflight(session, prompt=prompt)
+    _bind_ticket(seeded, transcript)
+
+    session._on_transcript_entry(_folded_user_entry(prompt))
+
+    assert seeded.turn.transport_accepted is False
+    registry.mark_turn_delivered.assert_not_called()


### PR DESCRIPTION
## Summary

Mid-turn folded prompts never matched the existing exact-equality acceptance check. That left no delivery-ledger row, so idle or restart reconciliation could requeue and re-emit the prompt as a duplicate (#1163).

This change adds fold-aware containment acceptance backed by per-entry byte offsets and transcript file-identity provenance. Exact matches retain precedence, and containment fails closed whenever provenance is absent, mismatched, or predates the paste boundary. A durable-ledger check also prevents a negatively probed turn that is already rowed from being replayed.

Fixes #1163.

## COVERAGE MATRIX

| Scenario | RED classification | Coverage |
| --- | --- | --- |
| Folded live acceptance, receipts, ledger row, and idle drain | Fix scenario | A framed mid-turn prompt becomes transport-accepted, resolves receipts, writes one delivered-turn row, and drains as verified-consumed without requeue. |
| Scheduler gate release | Fix scenario | Positive fold evidence clears the unresolved-paste gate before idle reconciliation. |
| Durable-ledger replay backstop | Fix scenario plus preservation pin | An already-rowed negative probe is suppressed; a ledger-read error preserves the existing fail-open requeue behavior. |
| Repeated accepted fold | Preservation pin | An accepted candidate reserves its occurrence without a second ledger write or donating the occurrence to another candidate. |
| Identical, nested, and overlapping prompts | Fix scenarios plus preservation pins | Non-overlapping occurrences certify candidates oldest-first; exact rows allocate first; globally overlapping spans under-accept rather than double-certify. |
| False-accept boundaries | Preservation pins | Prefixes, empty prompts, assistant rows, pre-ticket rows, and unavailable transcript windows remain non-evidence. |
| Paste provenance | Fix scenarios | Missing tickets, mismatched file identities, and pre-paste offsets fail closed; same-read straddles reject the old row and accept only the post-paste row; delayed callbacks cannot claim pre-ticket folds. |
| Scan and chunk boundaries | Preservation pins | Chained overlap search, complete versus partial scan-budget rows, and chunks beginning before the ticket retain bounded, byte-accurate behavior. |
| Transport matrix | Preservation pins / no code change | `TmuxSession` gains the Claude folded-row evidence path. `CodexSession` and `CodexTmuxSession` have no code changes: the former has no such path, and the latter's entry-only evidence chain never supplies the keyword-only provenance parameters, so containment is structurally fail-closed. |

Initial RED classified as 7 fix failures / 5 preservation passes. The provenance RED classified as 8 fix failures / 15 preservation passes.

## Test notes

- Focused acceptance, provenance, review-probe, and unchanged transcript-tailer coverage: 81 passed.
- Expanded tmux/Codex coverage: 623 passed, 1 skipped.
- Full suite: 5600 passed, 4 skipped.
- Repository-wide ruff and diff checks passed.
- The fail-open ledger-read test lacks a called-assert for the read itself. Its coverage is coupled to the suppression test, which asserts the call on the same seam; this coupling was recorded at the RED gate.

## DECLARED READ-PATH DELTAS

- Transcript reads move from a text line iterator to a bounded binary loop using `split(b"\n")`. Terminators are retained for offsets, byte accounting is exact per line, and file identity comes from `fstat` on the open descriptor.
- An exists-to-open `FileNotFoundError` now returns zero entries without advancing the offset; the next poll retries instead of turning the race into a silent miss.

## RESIDUALS

A provenance-ineligible candidate can reserve the only fold span and starve a later eligible identical-prompt candidate; neither candidate is positively certified, idle reconciliation returns negative evidence, and recovery is replay, not positive certification. `_allocation_complete` early-stop remains exact-only, a conservative deviation whose scan extent is unchanged from before this fix. Ticketless accepted candidates no longer reserve fold spans, which is a fail-closed residue. Rejected-receipt candidates also do not reserve fold spans, mirroring the exact path.

## UI

Daemon-internal delivery pipeline only; there is no UI surface, so tests are the receipt.

🤖 Opened by Kuzya
